### PR TITLE
perf(qwen3-tts): QWEN3_TTS_CODEC_GPU env var for clean GPU codec path

### DIFF
--- a/docs/tts.md
+++ b/docs/tts.md
@@ -142,6 +142,7 @@ defaults reproduce the validated, end-to-end-tested code path.
 | `QWEN3_TTS_PROF` | unset | Per-op profiler (more granular than `BENCH`). |
 | `QWEN3_TTS_CP_BACKEND` | unset | Pin the code predictor to a chosen backend. `cpu`, `cpu-f16`, `cpu-f32` keep its weights on the CPU backend — useful when isolating bugs to the talker vs. code-predictor or when comparing CPU and Metal end-to-end. |
 | `QWEN3_TTS_DUMP_DIR` | unset | Write per-frame intermediate tensors into the named directory. Bulky; intended for diff-harness work (`tools/dump_reference.py --backend qwen3-tts`). |
+| `QWEN3_TTS_CODEC_GPU` | unset | Route the codec decode through the main GPU scheduler instead of the CPU-only `codec_sched`. The codec is pinned to CPU by default to dodge the M1 Metal hang; on CUDA / Vulkan / etc. the hang does not apply and CPU codec is dramatically slower. On Jetson Orin AGX, codec on CPU is ~50× slower than CUDA. Distinct from `QWEN3_TTS_CODEC_FORCE_METAL`, which also moves the codec to the main GPU sched but additionally enables a per-op `ggml_backend_synchronize` trace callback for reproducing the Metal hang — useful for debugging, not for production. |
 
 ## VibeVoice — realtime streaming TTS
 

--- a/src/qwen3_tts.cpp
+++ b/src/qwen3_tts.cpp
@@ -3579,13 +3579,22 @@ static bool load_codec(qwen3_tts_context* c, const char* path) {
     hp.rms_norm_eps = core_gguf::kv_f32(meta, "qwen3tts_codec.dec.rms_norm_eps", hp.rms_norm_eps);
     core_gguf::free_metadata(meta);
 
-    // Pass 2: weights — pinned to CPU backend (see codec_sched comment in
-    // qwen3_tts_context). Override with QWEN3_TTS_CODEC_FORCE_METAL=1 to
-    // reproduce the M1 Metal crash for instrumentation.
+    // Pass 2: weights — pinned to CPU backend by default to dodge the M1
+    // Metal hang. Two override env vars route weights onto the main GPU
+    // backend instead:
+    //   QWEN3_TTS_CODEC_FORCE_METAL=1 — reproduces the M1 hang with per-op
+    //                                   tracing for instrumentation.
+    //   QWEN3_TTS_CODEC_GPU=1         — clean GPU path with no trace.
+    //                                   Use on CUDA / Vulkan where the
+    //                                   Metal hang does not apply. On
+    //                                   Jetson Orin AGX, codec on CPU is
+    //                                   ~50x slower than CUDA.
     const bool force_metal = std::getenv("QWEN3_TTS_CODEC_FORCE_METAL") != nullptr;
-    ggml_backend_t weight_backend = force_metal ? c->backend : c->backend_cpu;
-    if (force_metal && c->params.verbosity >= 0) {
-        fprintf(stderr, "qwen3_tts: codec: QWEN3_TTS_CODEC_FORCE_METAL=1 — loading weights onto %s\n",
+    const bool codec_gpu = std::getenv("QWEN3_TTS_CODEC_GPU") != nullptr;
+    ggml_backend_t weight_backend = (force_metal || codec_gpu) ? c->backend : c->backend_cpu;
+    if ((force_metal || codec_gpu) && c->params.verbosity >= 0) {
+        fprintf(stderr, "qwen3_tts: codec: %s - loading weights onto %s\n",
+                force_metal ? "QWEN3_TTS_CODEC_FORCE_METAL=1" : "QWEN3_TTS_CODEC_GPU=1",
                 ggml_backend_name(weight_backend));
     }
     core_gguf::WeightLoad wl;
@@ -3746,10 +3755,14 @@ static bool codec_trace_eval_cb(struct ggml_tensor* t, bool ask, void* user_data
 }
 
 // Returns the codec scheduler to use for compute. Defaults to the CPU-only
-// codec_sched; QWEN3_TTS_CODEC_FORCE_METAL=1 routes through the main
-// Metal-capable c->sched to reproduce the M1 crash for instrumentation.
+// codec_sched. Two env vars route through the main GPU sched instead:
+//   QWEN3_TTS_CODEC_FORCE_METAL=1 — reproduces the M1 crash with tracing
+//                                   (see codec_decode_codes trace path).
+//   QWEN3_TTS_CODEC_GPU=1         — clean GPU codec path, no tracing.
+//                                   Use on CUDA / Vulkan where the Metal
+//                                   hang does not apply.
 static ggml_backend_sched_t codec_pick_sched(qwen3_tts_context* c) {
-    if (std::getenv("QWEN3_TTS_CODEC_FORCE_METAL")) {
+    if (std::getenv("QWEN3_TTS_CODEC_FORCE_METAL") || std::getenv("QWEN3_TTS_CODEC_GPU")) {
         return c->sched;
     }
     return c->codec_sched;


### PR DESCRIPTION
## Summary

Adds a new env var `QWEN3_TTS_CODEC_GPU=1` that routes the qwen3-tts codec decode through the main GPU scheduler **without** the per-op trace callback that `QWEN3_TTS_CODEC_FORCE_METAL=1` installs. On non-Mac GPU platforms (CUDA / Vulkan / etc.) the M1 Metal hang the default CPU pin is guarding against does not apply, and codec on CPU is dramatically slower than codec on GPU — but the only existing switch pulls in a debugging trace callback that serialises every kernel and tanks throughput, so users on those platforms have no clean fast path today.

## Why

Today the codec is pinned to a CPU-only `codec_sched` by default. The comment in `qwen3_tts_context` explains why: Metal hangs on the codec graph on M1, so falling back to CPU was the safe choice. `QWEN3_TTS_CODEC_FORCE_METAL=1` was added as an escape hatch to reproduce that hang on demand for instrumentation — and as a side effect, it also routes the codec to `c->sched`, which is the only way today to get codec compute on the GPU at all.

But `FORCE_METAL` also gates a per-op `ggml_backend_synchronize` callback in `codec_decode_codes` (the same condition: `QWEN3_TTS_CODEC_TRACE || QWEN3_TTS_CODEC_FORCE_METAL`). That callback synchronises after every node — necessary for reproducing the Metal hang, but it serialises kernel launches and roughly triples codec wall time on CUDA.

So the current state is:
- **Default (CPU codec):** safe everywhere, but ~50× slower than GPU on Jetson Orin AGX in my testing.
- **`FORCE_METAL=1` (GPU + trace):** still much slower than it should be because of the per-op sync.
- **No way to get codec-on-GPU without the trace overhead.**

## What this changes

A sibling env var `QWEN3_TTS_CODEC_GPU=1` that:

1. Loads the codec weights onto `c->backend` instead of `c->backend_cpu`.
2. Makes `codec_pick_sched` return `c->sched` (main GPU sched).
3. Does NOT enable the trace callback — that stays gated on `QWEN3_TTS_CODEC_TRACE` / `QWEN3_TTS_CODEC_FORCE_METAL`.

`FORCE_METAL` semantics are unchanged so the M1-debug workflow is preserved exactly. The new var is documented in `docs/tts.md` alongside the existing qwen3-tts env switches and explicitly contrasted with `FORCE_METAL`.

## Measured impact

On Jetson Orin AGX (compute capability 8.7, CUDA 12.8), Qwen3-TTS-1.7B-Base Q8_0 + the matching 12 Hz tokenizer, voice-clone synthesis through `qwen3_tts_synthesize_codes` + `qwen3_tts_decode_codes`:

| Mode | Codec wall time per request | Notes |
|---|---|---|
| Default (CPU codec) | ~60 s for 2 s of audio | RTF ≫ 1, dominated by CPU |
| `FORCE_METAL=1` (GPU + trace) | ~17 s for 2 s of audio | Trace callback serialises kernels |
| `CODEC_GPU=1` (GPU, no trace) | ~1.5 s for 2 s of audio | RTF ~0.75 for the codec stage |

End-to-end RTF on this hardware drops from ~9 → ~1.5 with this flag plus the public `synthesize_codes` + `decode_codes` two-call pattern.

## Testing

- Built with `-DGGML_CUDA=ON -DCMAKE_CUDA_ARCHITECTURES=87-real` on the Jetson and ran end-to-end voice clone synthesis through `qwen3-tts-1.7b-base`. Audio output is identical between `FORCE_METAL=1` and `CODEC_GPU=1` modulo the trace overhead.
- I have not exercised the Vulkan path. If the codec graph also runs cleanly on Vulkan, `CODEC_GPU=1` should help there too — happy to test if you can point me at a known-good config.

## Out of scope (future PRs)

Two related findings I hit while debugging this — happy to file as separate issues / PRs if useful:

1. The bundled `qwen3_tts_synthesize` concatenates `ref_codes ++ gen_codes` before codec decode and trims the ref portion off the output. With a 26 s reference WAV (334 codec frames) this added a roughly constant ~16 s of codec compute per request on Jetson regardless of how much new audio was generated. Calling `qwen3_tts_synthesize_codes` + `qwen3_tts_decode_codes` directly produces clean audio on this hardware and avoids the constant cost. There may be a clean way to expose a "skip ref" knob inside `synthesize` itself.
2. The May 2 commits flipped `QWEN3_TTS_O15` to default-on, which crashes on first call into `code_pred_generate_15` on CUDA — already filed as #56.

Thanks for the project — pure C++ + ggml on Jetson is a great fit and this change makes it practical.