### PR TITLE
feat(server,qwen3-tts): /v1/audio/speech + /v1/voices, per-request voice switch

### DIFF
--- a/examples/cli/cli.cpp
+++ b/examples/cli/cli.cpp
@@ -406,6 +406,11 @@ static bool whisper_params_parse(int argc, char** argv, whisper_params& params) 
             params.tts_ref_text = ARGV_NEXT;
         } else if (arg == "--instruct") {
             params.tts_instruct = ARGV_NEXT;
+        } else if (arg == "--voice-dir") {
+            // Server mode: directory of <name>.wav (+ <name>.txt) or
+            // <name>.gguf voice profiles. Used by POST /v1/audio/speech
+            // to resolve the request's "voice" field.
+            params.tts_voice_dir = ARGV_NEXT;
         } else if (arg == "--tts-trim-silence") {
             params.tts_trim_silence = true;
         } else if (arg == "--text") {
@@ -688,6 +693,8 @@ static void whisper_print_usage(int /*argc*/, char** argv, const whisper_params&
     fprintf(stderr, "             --instruct \"TEXT\"        natural-language voice description "
                     "(qwen3-tts VoiceDesign only; replaces --voice)\n");
     fprintf(stderr, "             --codec-model FNAME      qwen3-tts codec GGUF (defaults to sibling of -m)\n");
+    fprintf(stderr, "             --voice-dir PATH         server: dir of <name>.wav (+ <name>.txt) or "
+                    "<name>.gguf voice profiles for POST /v1/audio/speech\n");
     fprintf(stderr, "             --tts-steps N            [%-7d] DPM-Solver++ steps (10-20, vibevoice only)\n",
             params.tts_steps);
     fprintf(stderr, "             --tts-trim-silence       [%-7s] trim leading silence from TTS output\n",

--- a/examples/cli/crispasr_backend_qwen3_tts.cpp
+++ b/examples/cli/crispasr_backend_qwen3_tts.cpp
@@ -109,14 +109,28 @@ public:
         if (!ctx_ || text.empty())
             return {};
 
-        // Voice prompt: load once on first synthesise call. Four paths:
+        // Voice prompt: re-load only when the requested identity changes.
+        // Four mutually-exclusive paths (gated by the loaded model variant):
         //   --voice <name>       → CustomVoice fixed-speaker selection
         //                          (only when the loaded model is CustomVoice)
         //   --voice X.gguf       → baked voice pack (Base)
         //   --voice X.wav --ref-text "..." → runtime ECAPA + codec encoder (Base)
         //   --instruct "..."     → VoiceDesign natural-language description
         //                          (only when the loaded model is VoiceDesign)
-        if (!voice_loaded_) {
+        //
+        // Cache the composite identity in `last_voice_key_` so the CLI's
+        // single-shot use case still pays the load cost only once, while
+        // server-mode callers can switch voice per request just by changing
+        // `params.tts_voice` (or `params.tts_ref_text` / `params.tts_instruct`).
+        std::string voice_key;
+        if (qwen3_tts_is_voice_design(ctx_)) {
+            voice_key = "vd:" + params.tts_instruct;
+        } else if (qwen3_tts_is_custom_voice(ctx_)) {
+            voice_key = "cv:" + params.tts_voice;
+        } else {
+            voice_key = "base:" + params.tts_voice + "\x01" + params.tts_ref_text;
+        }
+        if (voice_key != last_voice_key_) {
             if (qwen3_tts_is_voice_design(ctx_)) {
                 // VoiceDesign: --instruct is required, --voice has no role.
                 if (!params.tts_voice.empty() && !params.no_prints) {
@@ -183,7 +197,7 @@ public:
                     }
                 }
             }
-            voice_loaded_ = true;
+            last_voice_key_ = voice_key;
         }
 
         int n = 0;
@@ -200,12 +214,12 @@ public:
             qwen3_tts_free(ctx_);
             ctx_ = nullptr;
         }
-        voice_loaded_ = false;
+        last_voice_key_.clear();
     }
 
 private:
     qwen3_tts_context* ctx_ = nullptr;
-    bool voice_loaded_ = false;
+    std::string last_voice_key_;
 };
 
 } // namespace

--- a/examples/cli/crispasr_server.cpp
+++ b/examples/cli/crispasr_server.cpp
@@ -26,7 +26,7 @@
 
 #include "common-crispasr.h" // read_audio_data
 #include "../server/httplib.h"
-#include "../server/json.hpp"
+#include "../json.hpp"
 
 #include <atomic>
 #include <cerrno>

--- a/examples/cli/crispasr_server.cpp
+++ b/examples/cli/crispasr_server.cpp
@@ -9,10 +9,12 @@
 // Endpoints:
 //   POST /inference                   — transcribe (native JSON)
 //   POST /v1/audio/transcriptions     — OpenAI-compatible endpoint
+//   POST /v1/audio/speech             — TTS (OpenAI-compatible; CAP_TTS only)
 //   POST /load                        — hot-swap model
 //   GET  /health                      — server status
 //   GET  /backends                    — list available backends
 //   GET  /v1/models                   — OpenAI-compatible model list
+//   GET  /v1/voices                   — list voices in --voice-dir (CAP_TTS only)
 //
 // Adapted from examples/server/server.cpp for multi-backend support.
 
@@ -24,13 +26,17 @@
 
 #include "common-crispasr.h" // read_audio_data
 #include "../server/httplib.h"
+#include "../server/json.hpp"
 
 #include <atomic>
 #include <cerrno>
 #include <chrono>
+#include <cmath>
+#include <cstdint>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <filesystem>
 #include <fstream>
 #include <memory>
 #include <mutex>
@@ -276,6 +282,100 @@ static transcription_result do_transcribe(const httplib::MultipartFormData& audi
 
     result.ok = true;
     return result;
+}
+
+// ---------------------------------------------------------------------------
+// TTS helpers
+// ---------------------------------------------------------------------------
+
+// Read a whole file into a string. Returns empty string on failure.
+static std::string read_text_file(const std::string& path) {
+    std::ifstream f(path);
+    if (!f.good())
+        return "";
+    std::stringstream ss;
+    ss << f.rdbuf();
+    return ss.str();
+}
+
+// Resolve a voice request name to an absolute path (and optional ref-text)
+// from the configured voice-dir. Looks for <name>.wav (paired with
+// <name>.txt for the reference transcription used by Qwen3-TTS ICL
+// prefill) or <name>.gguf (baked voice pack). Returns true on hit;
+// sets out_path and out_ref_text.
+static bool resolve_voice(const std::string& voice_dir, const std::string& name, std::string& out_path,
+                          std::string& out_ref_text) {
+    if (voice_dir.empty() || name.empty())
+        return false;
+    const std::string wav = voice_dir + "/" + name + ".wav";
+    const std::string txt = voice_dir + "/" + name + ".txt";
+    const std::string gguf = voice_dir + "/" + name + ".gguf";
+    {
+        std::ifstream f(wav);
+        if (f.good()) {
+            out_path = wav;
+            out_ref_text = read_text_file(txt);
+            return true;
+        }
+    }
+    {
+        std::ifstream f(gguf);
+        if (f.good()) {
+            out_path = gguf;
+            out_ref_text.clear();
+            return true;
+        }
+    }
+    return false;
+}
+
+// Build a 16-bit PCM RIFF WAV from float32 samples in [-1, 1].
+// Mono, sample_rate Hz. Header is the standard 44-byte PCM-fmt RIFF.
+// Returned buffer is contiguous and safe to pass to res.set_content().
+static std::string make_wav_int16(const float* pcm, int n_samples, int sample_rate) {
+    const uint16_t num_channels = 1;
+    const uint16_t bits_per_sample = 16;
+    const uint32_t byte_rate = sample_rate * num_channels * (bits_per_sample / 8);
+    const uint16_t block_align = num_channels * (bits_per_sample / 8);
+    const uint32_t data_size = (uint32_t)n_samples * block_align;
+    const uint32_t riff_size = 36 + data_size;
+
+    std::string out;
+    out.reserve(44 + (size_t)data_size);
+    auto put_u32 = [&](uint32_t v) {
+        out.push_back((char)(v & 0xff));
+        out.push_back((char)((v >> 8) & 0xff));
+        out.push_back((char)((v >> 16) & 0xff));
+        out.push_back((char)((v >> 24) & 0xff));
+    };
+    auto put_u16 = [&](uint16_t v) {
+        out.push_back((char)(v & 0xff));
+        out.push_back((char)((v >> 8) & 0xff));
+    };
+    out.append("RIFF", 4);
+    put_u32(riff_size);
+    out.append("WAVE", 4);
+    out.append("fmt ", 4);
+    put_u32(16); // PCM fmt chunk size
+    put_u16(1);  // PCM format
+    put_u16(num_channels);
+    put_u32(sample_rate);
+    put_u32(byte_rate);
+    put_u16(block_align);
+    put_u16(bits_per_sample);
+    out.append("data", 4);
+    put_u32(data_size);
+    out.resize(out.size() + (size_t)data_size);
+    int16_t* dst = reinterpret_cast<int16_t*>(&out[out.size() - data_size]);
+    for (int i = 0; i < n_samples; i++) {
+        float s = pcm[i];
+        if (s > 1.0f)
+            s = 1.0f;
+        if (s < -1.0f)
+            s = -1.0f;
+        dst[i] = (int16_t)std::lround(s * 32767.0f);
+    }
+    return out;
 }
 
 // ---------------------------------------------------------------------------
@@ -564,6 +664,149 @@ int crispasr_run_server(whisper_params& params, const std::string& host, int por
     });
 
     // -----------------------------------------------------------------------
+    // POST /v1/audio/speech — OpenAI-compatible TTS endpoint
+    //
+    // Body: application/json
+    //   {
+    //     "input":           "TEXT to synthesize",       (required)
+    //     "voice":           "<name in --voice-dir>",    (optional)
+    //     "response_format": "wav" | "pcm"               (optional, default "wav")
+    //   }
+    //
+    // Returns:
+    //   200 audio/wav   — 16-bit PCM int16, 24 kHz mono
+    //   200 application/octet-stream — raw float32 PCM (response_format=pcm)
+    //
+    //   400 — backend lacks CAP_TTS, missing input, malformed body
+    //   422 — voice name not found in --voice-dir
+    //   500 — backend->synthesize returned empty
+    //   503 — model still loading
+    //
+    // Voice resolution: <voice-dir>/<name>.wav (paired with <name>.txt
+    // for ref-text) or <voice-dir>/<name>.gguf (baked pack). When
+    // "voice" is omitted the request inherits whatever was set at server
+    // startup via --voice / --instruct.
+    // -----------------------------------------------------------------------
+    svr.Post("/v1/audio/speech", [&](const Request& req, Response& res) {
+        if (!require_auth(req, res))
+            return;
+        if (!ready.load()) {
+            json_error(res, 503, "model is still loading");
+            return;
+        }
+        if (!(backend->capabilities() & CAP_TTS)) {
+            json_error(res, 400,
+                       "loaded backend '" + backend_name +
+                           "' does not support TTS (no CAP_TTS); load a TTS backend "
+                           "(e.g. qwen3-tts, kokoro, vibevoice, orpheus) via POST /load");
+            return;
+        }
+
+        nlohmann::json body;
+        try {
+            body = nlohmann::json::parse(req.body);
+        } catch (...) {
+            json_error(res, 400, "invalid JSON body");
+            return;
+        }
+
+        std::string text = body.value("input", "");
+        if (text.empty()) {
+            json_error(res, 400, "missing or empty 'input' field");
+            return;
+        }
+
+        std::string voice_name = body.value("voice", "");
+        std::string response_format = body.value("response_format", std::string("wav"));
+        if (response_format != "wav" && response_format != "pcm") {
+            json_error(res, 400, "response_format must be 'wav' or 'pcm'");
+            return;
+        }
+
+        // Per-request param overrides — copy then mutate.
+        whisper_params rp = params;
+        if (!voice_name.empty()) {
+            if (rp.tts_voice_dir.empty()) {
+                json_error(res, 400,
+                           "server has no --voice-dir configured; "
+                           "cannot resolve voice '" + voice_name + "'");
+                return;
+            }
+            std::string voice_path, ref_text;
+            if (!resolve_voice(rp.tts_voice_dir, voice_name, voice_path, ref_text)) {
+                json_error(res, 422, "voice '" + voice_name + "' not found in --voice-dir");
+                return;
+            }
+            rp.tts_voice = voice_path;
+            if (!ref_text.empty())
+                rp.tts_ref_text = ref_text;
+        }
+
+        auto t0 = std::chrono::steady_clock::now();
+        std::vector<float> pcm;
+        {
+            std::lock_guard<std::mutex> lock(model_mutex);
+            pcm = backend->synthesize(text, rp);
+        }
+        auto t1 = std::chrono::steady_clock::now();
+
+        if (pcm.empty()) {
+            json_error(res, 500, "synthesis failed (backend returned empty audio)");
+            return;
+        }
+
+        const double elapsed_s = std::chrono::duration<double>(t1 - t0).count();
+        const double audio_s = (double)pcm.size() / 24000.0;
+        fprintf(stderr,
+                "crispasr-server: synthesized %.1fs audio in %.2fs (RTF=%.2f) "
+                "voice='%s' format=%s\n",
+                audio_s, elapsed_s, elapsed_s > 0 ? elapsed_s / audio_s : 0.0,
+                voice_name.empty() ? "<startup>" : voice_name.c_str(), response_format.c_str());
+
+        if (response_format == "pcm") {
+            std::string buf((const char*)pcm.data(), pcm.size() * sizeof(float));
+            res.set_content(std::move(buf), "application/octet-stream");
+        } else {
+            std::string wav = make_wav_int16(pcm.data(), (int)pcm.size(), 24000);
+            res.set_content(std::move(wav), "audio/wav");
+        }
+    });
+
+    // -----------------------------------------------------------------------
+    // GET /v1/voices — list voices in --voice-dir (CAP_TTS only)
+    // Returns: {"voices": [{"name": "<stem>", "format": "wav"|"gguf"}, ...]}
+    // -----------------------------------------------------------------------
+    svr.Get("/v1/voices", [&](const Request& req, Response& res) {
+        if (!require_auth(req, res))
+            return;
+
+        std::ostringstream js;
+        js << "{\"voices\": [";
+        bool first = true;
+        if (!params.tts_voice_dir.empty()) {
+            std::error_code ec;
+            for (const auto& entry : std::filesystem::directory_iterator(params.tts_voice_dir, ec)) {
+                if (ec)
+                    break;
+                if (!entry.is_regular_file())
+                    continue;
+                const auto& path = entry.path();
+                const std::string ext = path.extension().string();
+                if (ext != ".wav" && ext != ".gguf")
+                    continue;
+                const std::string stem = path.stem().string();
+                const char* fmt = (ext == ".wav") ? "wav" : "gguf";
+                if (!first)
+                    js << ", ";
+                js << "{\"name\": \"" << crispasr_json_escape(stem) << "\", \"format\": \"" << fmt << "\"}";
+                first = false;
+            }
+        }
+        js << "]}";
+        res.set_content(js.str(), "application/json");
+    });
+
+    // -----------------------------------------------------------------------
     // Log unmatched requests (helps debug wrong endpoints like /audio/transcriptions)
     svr.set_error_handler([&](const Request& req, Response& res) {
         fprintf(stderr, "crispasr-server: %s %s → 404 (no matching route)\n", req.method.c_str(), req.path.c_str());
@@ -572,13 +815,25 @@ int crispasr_run_server(whisper_params& params, const std::string& host, int por
 
     // Start
     // -----------------------------------------------------------------------
+    const bool tts = (backend->capabilities() & CAP_TTS) != 0;
     fprintf(stderr, "\ncrispasr-server: listening on %s:%d\n", host.c_str(), port);
     fprintf(stderr, "  POST /inference                  — upload audio (native JSON)\n");
     fprintf(stderr, "  POST /v1/audio/transcriptions    — OpenAI-compatible API\n");
+    if (tts) {
+        fprintf(stderr, "  POST /v1/audio/speech            — TTS (OpenAI-compatible)\n");
+    }
     fprintf(stderr, "  POST /load                       — hot-swap model\n");
     fprintf(stderr, "  GET  /health                     — server status\n");
     fprintf(stderr, "  GET  /backends                   — list backends\n");
-    fprintf(stderr, "  GET  /v1/models                  — model info\n\n");
+    fprintf(stderr, "  GET  /v1/models                  — model info\n");
+    if (tts) {
+        fprintf(stderr, "  GET  /v1/voices                  — list voices in --voice-dir\n");
+        if (params.tts_voice_dir.empty()) {
+            fprintf(stderr, "crispasr-server: warning: --voice-dir not set; /v1/voices will return empty "
+                            "and /v1/audio/speech will reject requests with a 'voice' field\n");
+        }
+    }
+    fprintf(stderr, "\n");
     if (!api_keys.empty())
         fprintf(stderr, "crispasr-server: API key authentication enabled\n");
 

--- a/examples/cli/whisper_params.h
+++ b/examples/cli/whisper_params.h
@@ -144,6 +144,13 @@ struct whisper_params {
     std::string tts_instruct; // VoiceDesign: natural-language voice description
     bool tts_trim_silence = false;
 
+    // Server mode: directory containing voice profiles for /v1/audio/speech.
+    // Each profile is a sibling pair: <name>.wav + <name>.txt (the WAV is
+    // the reference audio, the TXT is its transcription used by Qwen3-TTS
+    // ICL prefill), or a baked voice pack <name>.gguf. The server's
+    // POST /v1/audio/speech `voice` field maps to a stem in this directory.
+    std::string tts_voice_dir;
+
     // Text-to-text translation input (m2m100 + future translate-only
     // backends). When `--text` is set on a backend that declares
     // CAP_TRANSLATE and has no input audio, crispasr_run dispatches to


### PR DESCRIPTION
Closes #58.

Adds the OpenAI-compatible TTS endpoint to the persistent `crispasr-server`, following the design we converged on in #58. Hands the request through the existing `CrispasrBackend::synthesize()` abstraction so kokoro / qwen3-tts / vibevoice / orpheus all get the routes for free as soon as the user loads them.

## Routes

```
POST /v1/audio/speech
  Body: application/json
    {
      "input":           "<text to synthesize>",       (required)
      "voice":           "<name in --voice-dir>",      (optional)
      "response_format": "wav" | "pcm"                 (optional, default "wav")
    }
  Returns:
    200 audio/wav                  16-bit PCM int16 WAV at 24 kHz mono
    200 application/octet-stream   raw float32 PCM (response_format=pcm)
    400  loaded backend lacks CAP_TTS, missing/empty input, malformed body,
         or `voice` provided but server has no --voice-dir configured
    422  voice name not found in --voice-dir
    500  backend->synthesize returned empty audio
    503  model still loading

GET /v1/voices
  Returns: { "voices": [ { "name": "<stem>", "format": "wav"|"gguf" }, ... ] }
  Source: directory listing of --voice-dir for *.{wav,gguf} files
```

## Design choices (per #58 thread)

- **Single binary, capability-gated.** Routes register on every backend; the TTS handlers reject with 400 when `backend->capabilities() & CAP_TTS` is unset. No backend-name string match — kokoro/qwen3-tts/vibevoice/orpheus get the routes automatically once they advertise `CAP_TTS`.
- **Generic via the abstraction.** Calls `backend->synthesize(text, params)` and writes `vector<float>` 24 kHz mono PCM to either a WAV (int16 RIFF) or raw float32. No backend-specific code in the route handler — the server doesn't include `qwen3_tts.h`.
- **Voice management is filesystem.** `<voice-dir>/<name>.wav` paired with `<name>.txt` (Qwen3-TTS ICL ref-text), or `<voice-dir>/<name>.gguf` (baked voice pack). Maps the request's `voice` field directly to `whisper_params::tts_voice`. Upload endpoint and inline `ref_audio_b64` deferred per #58.
- **WAV + PCM only.** `pcm` is free since the backend already returns `vector<float>`. `mp3` / `opus` deferred.
- **No streaming.** Deferred per #58.
- **No auth changes.** Reuses the existing `is_authorized` / `require_auth` shape from the file. `CRISPASR_API_KEYS` already covers the new routes since they go through `require_auth`.

## Per-request voice switching

The qwen3-tts adapter (`crispasr_backend_qwen3_tts.cpp`) previously cached voice-load behind a single boolean (`voice_loaded_`) that ignored later changes to `params.tts_voice` / `params.tts_ref_text` / `params.tts_instruct`. The CLI's single-shot use case never noticed because each invocation creates a fresh process; the server caller hits it the first time it tries to switch voice.

Replaced with a composite voice-key cache (`last_voice_key_`):
```cpp
// VoiceDesign:    "vd:" + tts_instruct
// CustomVoice:    "cv:" + tts_voice
// Base (WAV/pack): "base:" + tts_voice + "\x01" + tts_ref_text
```
Re-runs `qwen3_tts_set_voice_prompt_with_text` / `qwen3_tts_set_speaker_by_name` / `qwen3_tts_set_instruct` only when the key actually changes. CLI single-shot behaviour is unchanged (first call still loads once).

## CMake

Added `json_cpp` (the existing `examples/CMakeLists.txt` INTERFACE library that exposes `examples/json.hpp`) to `crispasr-cli`'s link list — needed for `nlohmann::json::parse(req.body)`. No new dependencies.

## Smoke test (Jetson Orin AGX)

```
$ crispasr --server --backend qwen3-tts-1.7b-base \
    -m ~/.cache/crispasr/qwen3-tts-12hz-1.7b-base-q8_0.gguf \
    --codec-model ~/.cache/crispasr/qwen3-tts-tokenizer-12hz.gguf \
    --voice-dir ~/voice-ref --host 0.0.0.0 --port 11441
crispasr-server: backend 'qwen3-tts-1.7b-base' loaded, model '...12hz-1.7b-base-q8_0.gguf'
crispasr-server: listening on 0.0.0.0:11441
  POST /inference                  — upload audio (native JSON)
  POST /v1/audio/transcriptions    — OpenAI-compatible API
  POST /v1/audio/speech            — TTS (OpenAI-compatible)
  POST /load                       — hot-swap model
  GET  /health                     — server status
  GET  /backends                   — list backends
  GET  /v1/models                  — model info
  GET  /v1/voices                  — list voices in --voice-dir

$ curl -s http://nova:11441/v1/voices
{"voices": [{"name": "vik", "format": "wav"}, ...]}

$ curl -s -X POST http://nova:11441/v1/audio/speech \
    -H "Content-Type: application/json" \
    -d '{"input": "Hello there.", "voice": "vik"}' \
    -o /tmp/out.wav -w "%{http_code}\n"
200
crispasr-server: synthesized 3.8s audio in 25.50s (RTF=6.78) voice='vik' format=wav
```

Output is a valid 16-bit PCM 24 kHz mono WAV that plays back the input cloned in the reference voice.

The 6.78 RTF in this trace is from `qwen3_tts_synthesize` re-decoding the ref codes through the codec on every call (~16s of constant cost on Orin AGX from the 26-second reference). That's worth fixing internally as a `skip_ref_decode` knob on `qwen3_tts_synthesize` — I'll file a separate issue for it as agreed in #58.

## Out of scope (deferred per #58, happy to pick up in follow-ups)

- `POST /v1/voices` (multipart upload) and inline `ref_audio_b64` for runtime voice provisioning
- mp3 / opus encoding
- Streaming response (chunked transfer)
- `CRISPASR_API_KEYS` audit across `/inference` + new TTS routes (already wired via `require_auth`, but worth a follow-up review)
- `skip_ref_decode` knob on `qwen3_tts_synthesize` to drop the constant ref-decode cost (#58 thread)

Thanks for the design feedback on #58 — converging on the abstraction-friendly shape made the implementation clean.