### PR TITLE
feat(vibevoice-tts): voice-dir bare-name resolution + per-request voice switch

### DIFF
--- a/examples/cli/crispasr_backend_vibevoice.cpp
+++ b/examples/cli/crispasr_backend_vibevoice.cpp
@@ -10,10 +10,30 @@
 
 #include "vibevoice.h"
 
+#include <cctype>
 #include <cstdio>
+#include <string>
+#include <sys/stat.h>
 #include <vector>
 
 namespace {
+
+static bool ends_with_ci(const std::string& s, const std::string& suffix) {
+    if (s.size() < suffix.size())
+        return false;
+    for (size_t i = 0; i < suffix.size(); i++) {
+        char a = (char)std::tolower((unsigned char)s[s.size() - suffix.size() + i]);
+        char b = (char)std::tolower((unsigned char)suffix[i]);
+        if (a != b)
+            return false;
+    }
+    return true;
+}
+
+static bool file_exists(const std::string& path) {
+    struct stat st;
+    return stat(path.c_str(), &st) == 0;
+}
 
 static std::vector<float> resample_16k_to_24k(const float* in, int n_in) {
     std::vector<float> out;
@@ -85,22 +105,45 @@ public:
 
     std::vector<float> synthesize(const std::string& text, const whisper_params& params) override {
         // Voice resolution order:
-        //   1. Explicit --voice <path>
-        //   2. Per-language sibling pick (vibevoice-voice-<lang>-Spk1_woman.gguf
-        //      → vibevoice-voice-<lang>-Spk0_man.gguf), if -l <lang> is set
-        //   3. Sibling kokoro-voice-emma.gguf as English default (matches the
-        //      auto-download companion)
+        //   1. Bare-name in --voice-dir: <voice-dir>/<name>.gguf
+        //      (matches qwen3-tts post-d35940b — server-mode callers can
+        //       pass the same {"voice": "<name>"} request shape across all
+        //       TTS backends; the adapter does the filesystem lookup
+        //       against `params.tts_voice_dir`.)
+        //   2. Explicit --voice <path>: literal path to a voice GGUF.
+        //   3. Per-language sibling pick (vibevoice-voice-<lang>-Spk1_woman.gguf
+        //      → vibevoice-voice-<lang>-Spk0_man.gguf), if -l <lang> is set.
+        //   4. Sibling vibevoice-voice-emma.gguf as English default (matches
+        //      the auto-download companion).
         std::string voice_path = params.tts_voice;
+
+        // (1) Bare name → voice-dir lookup. A "bare name" is a token with
+        // no path separators and no `.gguf`/`.wav` extension — e.g.
+        // `voice: "vik"` from a /v1/audio/speech request. Path-traversal
+        // sanitization (reject `..` and NUL) mirrors the qwen3-tts adapter.
+        if (!voice_path.empty() && !params.tts_voice_dir.empty() && voice_path.find('/') == std::string::npos &&
+            voice_path.find('\\') == std::string::npos && !ends_with_ci(voice_path, ".gguf") &&
+            !ends_with_ci(voice_path, ".wav")) {
+            if (voice_path.find("..") != std::string::npos || voice_path.find('\0') != std::string::npos) {
+                fprintf(stderr, "crispasr[vibevoice-tts]: voice name '%s' contains illegal characters (.. or NUL)\n",
+                        voice_path.c_str());
+                return {};
+            }
+            const std::string gguf_path = params.tts_voice_dir + "/" + voice_path + ".gguf";
+            if (file_exists(gguf_path)) {
+                voice_path = gguf_path;
+            }
+            // else: leave bare name; vibevoice_load_voice will fail with a
+            // clearer "could not be loaded" path below.
+        }
+
         if (voice_path.empty()) {
             auto slash = params.model.find_last_of("/\\");
             std::string dir = (slash == std::string::npos) ? "." : params.model.substr(0, slash);
             auto try_sibling = [&](const std::string& fname) -> std::string {
                 std::string p = dir + "/" + fname;
-                FILE* f = fopen(p.c_str(), "rb");
-                if (f) {
-                    fclose(f);
+                if (file_exists(p))
                     return p;
-                }
                 return {};
             };
             const std::string& lang = params.language;
@@ -113,11 +156,17 @@ public:
             if (voice_path.empty())
                 voice_path = try_sibling("vibevoice-voice-emma.gguf");
         }
-        if (!voice_loaded_ && !voice_path.empty()) {
+
+        // Per-call voice-key cache. Replaces the previous `voice_loaded_`
+        // boolean so server callers can switch voice per request just by
+        // changing params.tts_voice. CLI single-shot behaviour is unchanged
+        // (first call still pays one load); vibevoice_load_voice() replaces
+        // the active voice when re-called.
+        if (!voice_path.empty() && voice_path != last_voice_key_) {
             if (vibevoice_load_voice(ctx_, voice_path.c_str()) == 0) {
-                voice_loaded_ = true;
-                if (params.tts_voice.empty())
-                    fprintf(stderr, "crispasr[vibevoice-tts]: auto-picked voice '%s'\n", voice_path.c_str());
+                last_voice_key_ = voice_path;
+                if (params.tts_voice.empty() || params.tts_voice != voice_path)
+                    fprintf(stderr, "crispasr[vibevoice-tts]: voice loaded '%s'\n", voice_path.c_str());
             } else {
                 fprintf(stderr,
                         "crispasr[vibevoice-tts]: voice '%s' could not be loaded; "
@@ -126,9 +175,10 @@ public:
                 return {};
             }
         }
-        if (!voice_loaded_) {
-            fprintf(stderr, "crispasr[vibevoice-tts]: no voice prompt resolved (pass --voice <path> "
-                            "or place a vibevoice-voice-*.gguf next to the model).\n");
+        if (last_voice_key_.empty()) {
+            fprintf(stderr, "crispasr[vibevoice-tts]: no voice prompt resolved (pass --voice <path>, "
+                            "drop a <name>.gguf into --voice-dir, or place a vibevoice-voice-*.gguf "
+                            "next to the model).\n");
             return {};
         }
         if (!ctx_ || text.empty())
@@ -147,11 +197,12 @@ public:
             vibevoice_free(ctx_);
             ctx_ = nullptr;
         }
+        last_voice_key_.clear();
     }
 
 private:
     vibevoice_context* ctx_ = nullptr;
-    bool voice_loaded_ = false;
+    std::string last_voice_key_;
 };
 
 } // namespace


### PR DESCRIPTION
Brings the vibevoice-tts adapter in line with the qwen3-tts adapter's `d35940b` voice-dir refactor so server callers can hit `POST /v1/audio/speech` with the same `{"voice": "<name>"}` request shape regardless of which TTS backend is loaded. The route handler stays thin (passes `params.tts_voice` through unchanged) and the adapter does the filesystem lookup against `params.tts_voice_dir`.

## Two changes

**1. Bare-name → voice-dir resolution.** When `params.tts_voice` is a token with no path separators and no `.gguf`/`.wav` extension (e.g. `"vik"` from a JSON request body), the adapter probes `<voice-dir>/<name>.gguf` and uses it if present. Path-traversal sanitization (reject `..` and NUL) is the same shape as qwen3-tts. When the bare name doesn't resolve, the original token is left in place and `vibevoice_load_voice()` surfaces the standard "could not be loaded" error — same fall-through pattern as qwen3-tts post-d35940b.

**2. `voice_loaded_` boolean → `last_voice_key_` string cache.** Per-call re-load when `params.tts_voice` resolves to a different path between requests, otherwise skip. CLI single-shot behaviour is unchanged (first call still pays one load); server callers can now switch voice per request without restart. `vibevoice_load_voice()` is re-callable so this is a straight swap.

Existing fallback chain (per-language sibling pick → `vibevoice-voice-emma.gguf` default) stays in place for the no-voice auto-download path, untouched.

## Smoke test (Jetson Orin AGX)

```
$ curl -s -X POST nova:11442/v1/audio/speech \
    -d '{"input":"test","voice":"vik"}'
crispasr[vibevoice-tts]: voice 'vik' could not be loaded; refusing to
    synthesise without a voice prompt.
HTTP/1.1 500

$ curl -s -X POST nova:11442/v1/audio/speech \
    -d '{"input":"test","voice":"../../etc/passwd"}'
# Has path separators → not treated as a bare name → falls through to
# the loader, which rejects with "invalid magic characters" via the
# GGUF magic-bytes check. Defense-in-depth, same shape as qwen3-tts.
HTTP/1.1 500
```

The first failure mode is the expected one — vibevoice voice clones still require a baked GGUF that doesn't exist for arbitrary user voices yet. The second is the path-traversal trade-off we accept by mirroring qwen3-tts: bare names get sanitized, but anything WITH separators is treated as a literal path the loader has to validate (it does, via the GGUF magic-bytes check).

## Voice-cloning gap (separate work)

VibeVoice voice packs are baked GGUFs produced by an out-of-tree pipeline (Microsoft's `voices_pt/*.pt` → upstream `models/convert-vibevoice-voice-to-gguf.py`). End users can't yet bake from a custom WAV — that's tracked in #72. Once bake-from-WAV lands, the user-visible workflow becomes: drop the WAV in `<voice-dir>/`, run the baker, and per-request `{"voice": "<name>"}` works against the same vibevoice-tts server with no other changes.

This PR is the half that's purely an adapter refactor — no new dependencies, no new files, ~68 LOC. Lands cleanly without #72.

## Related
- #58 — TTS server design discussion (closed by #63); this completes the "uniform server API across TTS backends" half for vibevoice.
- #63 — TTS server endpoint PR (merged); same bare-name pattern as qwen3-tts after maintainer's `d35940b` refactor.
- #72 — bake-vibevoice-voice-from-wav design discussion (open) — the prerequisite for end users to actually exercise this code path with their own voices.