### PR TITLE
Skip finalized stream VAD slices before decode

### DIFF
--- a/examples/cli/crispasr_run.cpp
+++ b/examples/cli/crispasr_run.cpp
@@ -1424,15 +1424,20 @@ int crispasr_run_backend(const whisper_params& params_in) {
                 // machine *after* this loop runs, so it reflects the
                 // upper bound of all utterances finalized before this step.
                 const int64_t window_start_sample_now = cumulative_samples - (int64_t)pcm_window.size();
+                constexpr int kStraddleMinSamples = 32000; // 2 s @ 16 kHz; backend-safe tail decode floor.
                 for (const auto& sl : slices) {
-                    auto slice_segs =
-                        backend->transcribe(pcm_window.data() + sl.start, sl.end - sl.start, sl.t0_cs, params);
+                    const int64_t s_start_abs = window_start_sample_now + (int64_t)sl.start;
+                    const int64_t s_end_abs = window_start_sample_now + (int64_t)sl.end;
+                    if (params.stream_json && s_end_abs <= finalized_until_sample)
+                        continue;
+
+                    std::vector<crispasr_segment> slice_segs;
                     if (params.stream_json) {
                         // Apply punc/strip on a copy so the per-slice text
                         // is in its final form before we hand it to the
-                        // utterance state machine. The aggregate gets the
-                        // same treatment after the loop, so plain-text
-                        // mode behavior is unchanged.
+                        // utterance state machine. JSON mode can filter or
+                        // trim finalized rolling-window slices before decode;
+                        // plain-text mode below still decodes full slices.
                         std::vector<crispasr_segment> sl_for_text;
 
                         // Round 3 (CKwasd #1 corner): if the VAD slice
@@ -1441,14 +1446,9 @@ int crispasr_run_backend(const whisper_params& params_in) {
                         // full-slice decode covers audio that belongs to
                         // the prior utterance — emitting it as a partial
                         // for the new utterance_id leaks prior text into
-                        // the live stream. Re-decode just the post-
-                        // finalized subrange so partial.text describes
-                        // only the new utterance's interval. This costs
-                        // one extra encoder pass per straddling slice
-                        // (bounded to ~window_length / stream_step steps
-                        // after a finalize, until the rolling window
-                        // evicts the old audio).
-                        const int64_t s_start_abs = window_start_sample_now + (int64_t)sl.start;
+                        // the live stream. Decode just the post-finalized
+                        // subrange so partial.text describes only the new
+                        // utterance's interval.
                         // Some backends (moonshine's stacked conv1d
                         // encoder, for example) abort on inputs shorter
                         // than a few hundred ms — `OW > 0` from
@@ -1459,7 +1459,6 @@ int crispasr_run_backend(const whisper_params& params_in) {
                         // 32000 samples = 2 s @ 16 kHz, comfortably
                         // above every supported backend's encoder
                         // minimum.
-                        constexpr int kStraddleMinSamples = 32000;
                         if (s_start_abs < finalized_until_sample) {
                             const int sub_start = (int)(finalized_until_sample - window_start_sample_now);
                             const int sub_end = (int)sl.end;
@@ -1470,6 +1469,7 @@ int crispasr_run_backend(const whisper_params& params_in) {
                                 decode_params.vad_model.clear();
                                 sl_for_text =
                                     backend->transcribe(pcm_window.data() + sub_start, sub_len, 0, decode_params);
+                                slice_segs = sl_for_text;
                             }
                             // else: sl_for_text stays empty → empty
                             // partial text for this slice, which
@@ -1479,6 +1479,8 @@ int crispasr_run_backend(const whisper_params& params_in) {
                             // new audio will be picked up on a later
                             // step once the subrange exceeds the min.
                         } else {
+                            slice_segs =
+                                backend->transcribe(pcm_window.data() + sl.start, sl.end - sl.start, sl.t0_cs, params);
                             sl_for_text = slice_segs;
                         }
                         apply_punc_model(punc_ctx.get(), sl_for_text);
@@ -1494,6 +1496,9 @@ int crispasr_run_backend(const whisper_params& params_in) {
                         for (const auto& s : sl_for_text)
                             sl_text += s.text;
                         step_slice_text.emplace_back(sl, std::move(sl_text));
+                    } else {
+                        slice_segs =
+                            backend->transcribe(pcm_window.data() + sl.start, sl.end - sl.start, sl.t0_cs, params);
                     }
                     segs.insert(segs.end(), std::make_move_iterator(slice_segs.begin()),
                                 std::make_move_iterator(slice_segs.end()));


### PR DESCRIPTION
## Summary

Move finalized/straddling VAD slice filtering ahead of `backend->transcribe()` in JSON streaming mode.

Previously, the stream loop decoded each VAD slice first, then the JSON state machine skipped fully finalized slices or re-decoded the post-finalized tail for straddling slices. With small `--stream-step` values, rolling-window audio could repeatedly decode already-finalized speech until it aged out of `--stream-length`.

This change avoids that wasted backend work by deciding whether a VAD slice is old, straddling, or new before calling `backend->transcribe()`.

## Details

- Skip fully finalized VAD slices before backend decode.
- Decode only the post-finalized tail for straddling slices.
- Preserve the existing 2s minimum tail gate.
- Leave non-JSON streaming behavior unchanged.

## Manual Test Notes

Tested JSON streaming with:

```text
--backend cohere
-l ja
--stream-json
--stream-final-mode redecode
--stream-final-on-silence-ms 300
--stream-length 8000
--stream-step 500
--vad
-vt 0.65
-vspd 200
-vsd 300
-vp 100
```

`dbg_lag_sec` includes an initial wall-clock offset from stream setup, so the useful signal is whether it keeps increasing over time.

In this A/B run, normalized peak backlog growth dropped from about `+13.03s` to `+4.34s`, a reduction of roughly `67%`.

```text
1 - 4.34 / 13.03 = 0.667 ~= 67%
```

Before this change, lag grew substantially during the run before later silence allowed the stream to catch up:

| Point | dbg_lag_sec | Growth from baseline |
|---|---:|---:|
| first post-track event, t=1.0s | ~9.75s | 0.00s |
| t=14.98s | ~14.25s | +4.50s |
| t=29.98s | ~15.95s | +6.20s |
| t=45.0s | ~19.72s | +9.97s |
| t=57-58s | ~22.78s | +13.03s |
| t=75.5s, after catch-up silence | ~16.36s | +6.61s |

After this change, lag stayed roughly bounded around the initial offset:

| Point | dbg_lag_sec | Growth from baseline |
|---|---:|---:|
| first post-track event, t=1.0s | ~24.46s | 0.00s |
| t=15.5s | ~25.04s | +0.58s |
| t=29.5s | ~26.30s | +1.85s |
| t=45.5s | ~26.53s | +2.07s |
| t=53-54s peak | ~28.80s | +4.34s |
| t=61.5s, after catch-up silence | ~26.17s | +1.72s |

Normalized backlog growth:

```text
Before:
t≈1s    0.0s   █
t≈15s  +4.5s   █████
t≈30s  +6.2s   ██████
t≈45s +10.0s   ██████████
t≈58s +13.0s   █████████████
t≈75s  +6.6s   ███████

After:
t≈1s    0.0s   █
t≈16s  +0.6s   █
t≈30s  +1.9s   ██
t≈46s  +2.1s   ██
t≈54s  +4.3s   ████
t≈62s  +1.7s   ██
```

Short utterances also emitted partial/final events promptly in the post-change run, including sub-second reactions such as `うん?`, `えっ!?`, `うわ!`, and `でも`.
