### PR TITLE
Rewrite streaming JSON VAD merge policy

### DIFF
--- a/docs/streaming.md
+++ b/docs/streaming.md
@@ -18,6 +18,7 @@ overlap. Tune via `--stream-step`, `--stream-length`, `--stream-keep`.
 Quality-control flags supported in streaming mode:
 
 - `--vad`, `--vad-model`, `--vad-threshold`, `--vad-min-speech-duration-ms`, `--vad-min-silence-duration-ms`, `--vad-speech-pad-ms`
+- `--stream-vad-merge-gap-ms` for JSON streaming VAD close-gap tuning
 - `--punc-model` and `--no-punctuation`
 
 Notes:
@@ -56,6 +57,7 @@ Stream-contract guarantees:
 - Once an `utterance_id` finalizes, its audio is bookmarked and never re-opens a later `utterance_id`. Earlier text will not reappear in later utterances' partials.
 - Finalization fires as soon as `now - last_speech_end_sample ≥ --stream-final-on-silence-ms`, independent of the rolling-window length. A 260 ms silence threshold with `--stream-length 18000` finalizes ~260 ms after the speaker stops, not ~18 s later.
 - `final.t1 = last_speech_end_sample / 16 kHz` and the redecode buffer is trimmed to `[utterance_start_sample, last_speech_end_sample]`, so `final.text` describes exactly the `[t0..t1]` interval (trailing silence past `t1` is not part of the decoded region).
+- With `--stream-json --vad`, VAD post-merge only joins very close detector jitter gaps. `--stream-vad-merge-gap-ms` defaults to `250` and is clamped below `--stream-final-on-silence-ms`, so VAD merging cannot hide a gap that should finalize an utterance. The offline VAD short-slice merge policy is not used on this JSON streaming path.
 
 Sample stream:
 
@@ -174,6 +176,12 @@ block.
 | `--stream-step N` | `3000` ms | Step between consecutive windows. Smaller = more frequent partial transcripts. |
 | `--stream-length N` | `10000` ms | Rolling context window cap. The decode buffer accumulates audio up to this many ms, then drops the oldest samples from the front. Larger = better accuracy on long-form content but higher per-step cost. |
 | `--stream-keep N` | `200` ms | Legacy — kept for compatibility, currently a no-op. The rolling buffer above subsumes it (see issue #84). |
+
+`--stream-vad-merge-gap-ms` defaults to `250` ms and applies only to
+`--stream-json --vad`. It merges adjacent VAD slices only across gaps smaller
+than that value. When `--stream-final-on-silence-ms` is enabled, the effective
+merge gap is clamped below the finalization threshold. Set it to `0` to disable
+this close-gap merge.
 
 > **Note (issue #84).** Before May 2026, `--stream-length` was a
 > *ceiling* on `keep + step` rather than a true rolling cap, so

--- a/examples/cli/cli.cpp
+++ b/examples/cli/cli.cpp
@@ -520,6 +520,12 @@ static bool whisper_params_parse_arg_streaming_tts(int argc, char** argv, int& i
         params.stream_json = true;
     } else if (arg == "--stream-final-on-silence-ms") {
         params.stream_final_silence_ms = std::stoi(ARGV_NEXT);
+    } else if (arg == "--stream-vad-merge-gap-ms") {
+        params.stream_vad_merge_gap_ms = std::stoi(ARGV_NEXT);
+        if (params.stream_vad_merge_gap_ms < 0) {
+            fprintf(stderr, "crispasr: --stream-vad-merge-gap-ms must be >= 0\n");
+            exit(2);
+        }
     } else if (arg == "--stream-final-mode") {
         std::string mode = ARGV_NEXT;
         if (mode != "redecode" && mode != "prefix") {
@@ -848,6 +854,9 @@ static void whisper_print_usage(int /*argc*/, char** argv, const whisper_params&
     fprintf(stderr,
             "  --stream-final-on-silence-ms N    [%-7d] trailing silence (ms) that promotes a partial to final\n",
             params.stream_final_silence_ms);
+    fprintf(stderr,
+            "  --stream-vad-merge-gap-ms N       [%-7d] JSON+VAD close-gap merge in ms; clamped below final silence\n",
+            params.stream_vad_merge_gap_ms);
     fprintf(stderr,
             "  --stream-final-mode MODE          [%-7s] final.text source: 'redecode' (re-runs on the utterance "
             "PCM, best quality) or 'prefix' (LCP-accumulated, no extra encoder pass)\n",

--- a/examples/cli/crispasr_run.cpp
+++ b/examples/cli/crispasr_run.cpp
@@ -1288,6 +1288,11 @@ int crispasr_run_backend(const whisper_params& params_in) {
         // Streaming windows are already bounded by --stream-length.
         stream_vad_opts.chunk_seconds = 0;
         stream_vad_opts.n_threads = params.n_threads;
+        if (params.stream_json) {
+            stream_vad_opts.post_merge_policy = crispasr_vad_post_merge_policy::streaming_json;
+            stream_vad_opts.stream_close_gap_ms = params.stream_vad_merge_gap_ms;
+            stream_vad_opts.stream_final_silence_ms = params.stream_final_silence_ms;
+        }
 
         // If --mic, spawn a subprocess to capture audio from the default mic
         FILE* mic_pipe = nullptr;

--- a/examples/cli/whisper_params.h
+++ b/examples/cli/whisper_params.h
@@ -174,6 +174,10 @@ struct whisper_params {
     // pause length for live captions / translation handoff and matches
     // the example in the issue. Only relevant with --stream-json.
     int32_t stream_final_silence_ms = 800;
+    // JSON streaming + VAD only: merge adjacent VAD slices across tiny
+    // detector jitter gaps, but never across --stream-final-on-silence-ms.
+    // 0 disables streaming-specific post-merge.
+    int32_t stream_vad_merge_gap_ms = 250;
     // Issue #84 round 2 (CKwasd retest): how to compute `final.text`
     // when an utterance closes. The round-1 design just echoed the
     // last rolling-window partial — wrong because the rolling window

--- a/src/crispasr_vad.cpp
+++ b/src/crispasr_vad.cpp
@@ -180,28 +180,10 @@ std::vector<crispasr_audio_slice> crispasr_compute_vad_slices(const float* sampl
         whisper_vad_free(vctx);
     }
 
-    // Post-merge: combine adjacent VAD segments that are too short
-    // or too close together. ASR models need at least a few seconds
-    // of audio context to produce reliable output; tiny VAD segments
-    // (< 2s) and short inter-segment gaps (< 1s) degrade quality.
-    if (slices.size() > 1) {
-        const int min_dur_samples = 3 * sample_rate;   // 3 s minimum
-        const int merge_gap_samples = 1 * sample_rate; // merge if gap < 1 s
-        std::vector<crispasr_audio_slice> merged;
-        merged.push_back(slices[0]);
-        for (size_t i = 1; i < slices.size(); i++) {
-            auto& prev = merged.back();
-            const int gap = slices[i].start - prev.end;
-            const int prev_dur = prev.end - prev.start;
-            if (gap < merge_gap_samples || prev_dur < min_dur_samples) {
-                prev.end = slices[i].end;
-                prev.t1_cs = slices[i].t1_cs;
-            } else {
-                merged.push_back(slices[i]);
-            }
-        }
-        slices = std::move(merged);
-    }
+    // Post-merge: offline/file callers keep the historical short/close merge.
+    // JSON streaming can request a narrower close-gap-only policy so VAD never
+    // hides a silence gap that should finalize an utterance.
+    slices = crispasr_post_merge_vad_slices(slices, sample_rate, opts);
 
     // Post-split: break any VAD segment that exceeds chunk_seconds into
     // sub-segments. Prevents OOM on very long continuous speech (10+ min

--- a/src/crispasr_vad.h
+++ b/src/crispasr_vad.h
@@ -20,6 +20,7 @@
 
 #pragma once
 
+#include <cstddef>
 #include <cstdint>
 #include <vector>
 
@@ -43,9 +44,13 @@ struct crispasr_stitched_audio {
     int64_t total_duration_cs = 0;             // total duration in centiseconds
 };
 
-// Plain options struct — no CLI dependency. Mirrors the crispasr
-// VAD tunables plus the chunk fallback used by long-audio encoders.
-// Zero-initialising yields a sensible default configuration.
+enum class crispasr_vad_post_merge_policy {
+    offline = 0,
+    streaming_json = 1,
+};
+
+// Plain options struct: no CLI dependency. Mirrors the VAD tunables plus the
+// chunk fallback used by long-audio encoders.
 struct crispasr_vad_options {
     // whisper_vad_params
     float threshold = 0.5f;
@@ -55,6 +60,9 @@ struct crispasr_vad_options {
     // Post-VAD clean-up
     int chunk_seconds = 30; // split any merged slice longer than this; 0 = no split
     int n_threads = 4;      // VAD inference threads
+    crispasr_vad_post_merge_policy post_merge_policy = crispasr_vad_post_merge_policy::offline;
+    int stream_close_gap_ms = 250;
+    int stream_final_silence_ms = 0;
     // Issue #83 follow-up: distinguish "user passed -vt explicitly" from
     // "default 0.5 was inherited." VAD models with non-Silero probability
     // calibration (currently whisper-vad-encdec) use this to auto-lower
@@ -64,6 +72,60 @@ struct crispasr_vad_options {
     // to opt into per-model auto-tuning.
     bool threshold_explicit = false;
 };
+
+inline int crispasr_stream_vad_effective_merge_gap_ms(int configured_gap_ms, int final_silence_ms) {
+    if (configured_gap_ms <= 0)
+        return 0;
+    if (final_silence_ms <= 0)
+        return configured_gap_ms;
+    const int hard_max = final_silence_ms - 1;
+    if (hard_max <= 0)
+        return 0;
+    return configured_gap_ms < hard_max ? configured_gap_ms : hard_max;
+}
+
+inline std::vector<crispasr_audio_slice> crispasr_post_merge_vad_slices(const std::vector<crispasr_audio_slice>& slices,
+                                                                        int sample_rate,
+                                                                        const crispasr_vad_options& opts) {
+    if (slices.size() <= 1 || sample_rate <= 0)
+        return slices;
+
+    std::vector<crispasr_audio_slice> merged;
+    merged.push_back(slices[0]);
+
+    if (opts.post_merge_policy == crispasr_vad_post_merge_policy::streaming_json) {
+        const int effective_gap_ms =
+            crispasr_stream_vad_effective_merge_gap_ms(opts.stream_close_gap_ms, opts.stream_final_silence_ms);
+        if (effective_gap_ms <= 0)
+            return slices;
+        for (std::size_t i = 1; i < slices.size(); i++) {
+            auto& prev = merged.back();
+            const int gap = slices[i].start - prev.end;
+            if ((int64_t)gap * 1000 < (int64_t)effective_gap_ms * sample_rate) {
+                prev.end = slices[i].end;
+                prev.t1_cs = slices[i].t1_cs;
+            } else {
+                merged.push_back(slices[i]);
+            }
+        }
+        return merged;
+    }
+
+    const int min_dur_samples = 3 * sample_rate;
+    const int merge_gap_samples = 1 * sample_rate;
+    for (std::size_t i = 1; i < slices.size(); i++) {
+        auto& prev = merged.back();
+        const int gap = slices[i].start - prev.end;
+        const int prev_dur = prev.end - prev.start;
+        if (gap < merge_gap_samples || prev_dur < min_dur_samples) {
+            prev.end = slices[i].end;
+            prev.t1_cs = slices[i].t1_cs;
+        } else {
+            merged.push_back(slices[i]);
+        }
+    }
+    return merged;
+}
 
 // Load Silero VAD, emit one slice per speech segment, then merge
 // short/adjacent slices and split overlong ones. Returns an empty

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -220,6 +220,21 @@ catch_discover_tests(test-stream-vad-skip
     PROPERTIES LABELS "unit;stream-json"
 )
 
+# JSON streaming VAD post-merge policy. Pure arithmetic, no model load.
+add_executable(test-stream-vad-merge-policy
+    test-stream-vad-merge-policy.cpp
+)
+target_include_directories(test-stream-vad-merge-policy PRIVATE
+    ${PROJECT_SOURCE_DIR}/src
+)
+target_link_libraries(test-stream-vad-merge-policy PRIVATE
+    Catch2::Catch2WithMain
+)
+catch_discover_tests(test-stream-vad-merge-policy
+    TEST_SPEC "[unit]"
+    PROPERTIES LABELS "unit;stream-json"
+)
+
 # ─── test - punctuation - policy — Catch2 unit tests for punctuation auto - enable
 #policy.Pure logic, no model load.
 add_executable(test-punctuation-policy

--- a/tests/test-stream-vad-merge-policy.cpp
+++ b/tests/test-stream-vad-merge-policy.cpp
@@ -1,0 +1,96 @@
+// test-stream-vad-merge-policy.cpp -- pure unit tests for the JSON streaming
+// VAD post-merge policy. No VAD model or audio I/O is required.
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "../src/crispasr_vad.h"
+
+#include <vector>
+
+static crispasr_audio_slice slice(int start, int end) {
+    return crispasr_audio_slice{start, end, start / 160, end / 160};
+}
+
+static crispasr_vad_options stream_opts(int merge_gap_ms, int final_silence_ms = 800) {
+    crispasr_vad_options opts;
+    opts.post_merge_policy = crispasr_vad_post_merge_policy::streaming_json;
+    opts.stream_close_gap_ms = merge_gap_ms;
+    opts.stream_final_silence_ms = final_silence_ms;
+    return opts;
+}
+
+TEST_CASE("stream-vad-merge-policy: effective gap clamps below final silence", "[unit][stream-json]") {
+    REQUIRE(crispasr_stream_vad_effective_merge_gap_ms(250, 800) == 250);
+    REQUIRE(crispasr_stream_vad_effective_merge_gap_ms(500, 300) == 299);
+    REQUIRE(crispasr_stream_vad_effective_merge_gap_ms(250, 1) == 0);
+    REQUIRE(crispasr_stream_vad_effective_merge_gap_ms(250, 0) == 250);
+    REQUIRE(crispasr_stream_vad_effective_merge_gap_ms(0, 800) == 0);
+}
+
+TEST_CASE("stream-vad-merge-policy: close jitter gap merges below threshold", "[unit][stream-json]") {
+    const std::vector<crispasr_audio_slice> in = {
+        slice(0, 16000),
+        slice(16000 + 3999, 32000),
+    };
+    const auto out = crispasr_post_merge_vad_slices(in, 16000, stream_opts(250));
+
+    REQUIRE(out.size() == 1);
+    REQUIRE(out[0].start == 0);
+    REQUIRE(out[0].end == 32000);
+}
+
+TEST_CASE("stream-vad-merge-policy: gap equal to threshold does not merge", "[unit][stream-json]") {
+    const std::vector<crispasr_audio_slice> in = {
+        slice(0, 16000),
+        slice(16000 + 4000, 32000),
+    };
+    const auto out = crispasr_post_merge_vad_slices(in, 16000, stream_opts(250));
+
+    REQUIRE(out.size() == 2);
+    REQUIRE(out[0].end == 16000);
+    REQUIRE(out[1].start == 20000);
+}
+
+TEST_CASE("stream-vad-merge-policy: hard final silence boundary is not hidden", "[unit][stream-json]") {
+    const std::vector<crispasr_audio_slice> in = {
+        slice(0, 16000),
+        slice(16000 + 4800, 32000),
+    };
+    const auto out = crispasr_post_merge_vad_slices(in, 16000, stream_opts(500, 300));
+
+    REQUIRE(crispasr_stream_vad_effective_merge_gap_ms(500, 300) == 299);
+    REQUIRE(out.size() == 2);
+}
+
+TEST_CASE("stream-vad-merge-policy: no duration-based short-slice merge", "[unit][stream-json]") {
+    const std::vector<crispasr_audio_slice> in = {
+        slice(0, 8000),
+        slice(8000 + 20000, 44000),
+    };
+    const auto out = crispasr_post_merge_vad_slices(in, 16000, stream_opts(250));
+
+    REQUIRE(out.size() == 2);
+}
+
+TEST_CASE("stream-vad-merge-policy: offline policy still merges short previous slice", "[unit][stream-json]") {
+    const std::vector<crispasr_audio_slice> in = {
+        slice(0, 8000),
+        slice(8000 + 20000, 44000),
+    };
+    crispasr_vad_options opts;
+    const auto out = crispasr_post_merge_vad_slices(in, 16000, opts);
+
+    REQUIRE(out.size() == 1);
+    REQUIRE(out[0].start == 0);
+    REQUIRE(out[0].end == 44000);
+}
+
+TEST_CASE("stream-vad-merge-policy: final silence disabled uses configured gap", "[unit][stream-json]") {
+    const std::vector<crispasr_audio_slice> in = {
+        slice(0, 16000),
+        slice(16000 + 7999, 40000),
+    };
+    const auto out = crispasr_post_merge_vad_slices(in, 16000, stream_opts(500, 0));
+
+    REQUIRE(out.size() == 1);
+}


### PR DESCRIPTION
# Summary

Rewrite the VAD post-merge policy used by `--stream-json --vad`.

The old shared VAD post-merge behavior was tuned for offline/file transcription:

- merge adjacent slices with gaps below 1 second;
- merge when the previous slice is shorter than 3 seconds.

That improves ASR context, but in structured streaming it can hide a silence gap that should finalize the current utterance. When that happens, finalized text can straddle into the next rolling-window partial, delaying short replies or making old text reappear after a boundary.

This change keeps offline/file VAD behavior unchanged and switches only the JSON streaming VAD path to a narrower close-gap-only policy.

# What Changed

- Added a VAD post-merge policy selector:
  - `offline`
  - `streaming_json`
- Kept the historical short/close merge as the default offline policy.
- Added streaming JSON VAD merge logic:
  - merge adjacent VAD slices only when the gap is below the effective close-gap
    threshold;
  - do not merge based on previous slice duration;
  - never allow the merge threshold to cross
    `--stream-final-on-silence-ms`.
- Added CLI option:

```text
--stream-vad-merge-gap-ms N
```

Default:

```text
250
```

Effective value:

```text
if --stream-final-on-silence-ms > 0:
    effective_gap_ms = min(stream_vad_merge_gap_ms,
                           stream_final_on_silence_ms - 1)
else:
    effective_gap_ms = stream_vad_merge_gap_ms
```

- Plumbed the streaming policy only when `params.stream_json` and VAD are active.
- Added pure unit tests for the policy helper.
- Documented the new option in `docs/streaming.md`.

# Files

- `src/crispasr_vad.h`
- `src/crispasr_vad.cpp`
- `examples/cli/whisper_params.h`
- `examples/cli/cli.cpp`
- `examples/cli/crispasr_run.cpp`
- `tests/test-stream-vad-merge-policy.cpp`
- `tests/CMakeLists.txt`
- `docs/streaming.md`

# Tests

Unit tests:

```text
.\build-vulkan\bin\test-stream-vad-merge-policy.exe
```

Result:

```text
All tests passed (18 assertions in 7 test cases)
```

Existing related test:

```text
.\build-vulkan\bin\test-stream-vad-skip.exe
```

Result:

```text
All tests passed (20 assertions in 7 test cases)
```

# Manual A/B

Sample:

```text
C:\tmp\3Znnk9UD8Fo.16k.s16le
```

Common streaming settings:

```text
--backend cohere -l ja
--stream --stream-json --monitor --no-prints
--stream-final-mode redecode
--stream-utterance-max-sec 60
--stream-final-on-silence-ms 300
--stream-length 8000
--stream-step 500
--vad -vt 0.65 -vspd 180 -vmsd 10 -vp 110
```

Per-variant overrides:

```text
-vsd 300 or -vsd 100
--stream-vad-merge-gap-ms 0, 250, or 300
```

## A/B Results

| Variant | Finals | Avg final | Median final | Finals < 1.2s | Finals < 0.7s | Time |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| old `@998e22f`, `-vsd 300` | 49 | 2.464s | 2.580s | 10 | 7 | 150.146s |
| new, `-vsd 300`, gap `0` | 61 | 1.645s | 1.520s | 23 | 12 | 169.136s |
| new, `-vsd 300`, gap `300` | 61 | 1.645s | 1.520s | 23 | 12 | 142.464s |
| old `@998e22f`, `-vsd 100` | 47 | 2.472s | 2.600s | 11 | 8 | 160.954s |
| new, `-vsd 100`, gap `0` | 65 | 1.472s | 1.410s | 27 | 15 | 162.389s |
| new, `-vsd 100`, gap `250` | 65 | 1.467s | 1.410s | 28 | 15 | 181.595s |

The `Time` column is a single-run wall-clock smoke measurement. It is included only to show that the commands completed successfully; it is not used as an efficiency benchmark and this PR does not claim a runtime improvement or regression.

Notes:

- All tested JSONL outputs were valid JSON.
- No tested variant produced adjacent `final` events with exactly identical
  final text.
- With `--stream-final-on-silence-ms 300`, gap `300` is clamped to an
  effective `299ms`; gap `250` is not clamped and remains `250ms`.
- Under `-vsd 300`, gap `0` and gap `300` produced byte-identical JSONL output.
  This is expected because the clamped `299ms` gap gives the post-merge policy
  little or no close-gap work to do under `-vsd 300`.
- Under `-vsd 100`, gap `0` and gap `250` differed, but aggregate behavior was
  almost unchanged.

## Embedded Visual Summary

Final count:

```text
old -vsd 300              49 | #######################
old -vsd 100              47 | ######################
new -vsd 300 gap 0        61 | #############################
new -vsd 300 gap 300      61 | #############################
new -vsd 100 gap 0        65 | ###############################
new -vsd 100 gap 250      65 | ###############################
```

Finals shorter than 1.2s:

```text
old -vsd 300              10 | ###########
old -vsd 100              11 | ############
new -vsd 300 gap 0        23 | #########################
new -vsd 300 gap 300      23 | #########################
new -vsd 100 gap 0        27 | #############################
new -vsd 100 gap 250      28 | ##############################
```

Average final duration:

```text
old -vsd 300             2.464s | ##############################
old -vsd 100             2.472s | ##############################
new -vsd 300 gap 0       1.645s | ####################
new -vsd 300 gap 300     1.645s | ####################
new -vsd 100 gap 0       1.472s | ##################
new -vsd 100 gap 250     1.467s | ##################
```

Same-parameter deltas:

Runtime deltas below are single-run smoke context only. Treat them as non-deterministic wall-clock observations, not performance conclusions.

| Comparison | Final delta | Avg final delta | `< 1.2s` delta | `< 0.7s` delta | Runtime delta |
| --- | ---: | ---: | ---: | ---: | ---: |
| new `-vsd 300`, gap `0` vs old `-vsd 300` | +12 | -0.819s | +13 | +5 | +18.990s |
| new `-vsd 300`, gap `300` vs old `-vsd 300` | +12 | -0.819s | +13 | +5 | -7.682s |
| new `-vsd 100`, gap `0` vs old `-vsd 100` | +18 | -1.000s | +16 | +7 | +1.435s |
| new `-vsd 100`, gap `250` vs old `-vsd 100` | +18 | -1.005s | +17 | +7 | +20.641s |

# Interpretation

The patch is a boundary-correctness change, not a speed improvement.

It removes the offline short-slice merge from the JSON streaming VAD path. That exposes finalization boundaries instead of hiding them behind wide VAD merges.

The tradeoff is higher fragmentation:

- old `-vsd 300`: 49 finals;
- new `-vsd 300`: 61 finals;
- old `-vsd 100`: 47 finals;
- new `-vsd 100`: 65 finals.

This matches the intended product tradeoff for this phase: prefer correct boundaries and short-reaction finalization over preserving offline-style ASR context.

# Runtime Notes

Runtime is not a claimed improvement or regression in this PR. The wall-clock timings above are single-run measurements and are included only as smoke-test context.

The streaming JSON output metrics are the meaningful A/B signal here. Runtime should be evaluated separately with repeated runs and median/p95 reporting if a future PR makes an explicit performance claim.

Follow-up reruns of `new -vsd 100 gap 250` produced byte-identical JSONL output with the same aggregate metrics, but substantially different wall-clock times:

| Run | Time | JSONL hash prefix | Events | Partials | Finals | Avg final |
| --- | ---: | --- | ---: | ---: | ---: | ---: |
| rerun 1 | 127.073s | `b42233d4c49a` | 316 | 206 | 65 | 1.467s |
| rerun 2 | 99.218s | `b42233d4c49a` | 316 | 206 | 65 | 1.467s |
| rerun 3 | 122.809s | `b42233d4c49a` | 316 | 206 | 65 | 1.467s |

This makes the original `181.595s` single-run timing look like a wall-clock outlier, not evidence that gap `250` changed the amount of JSON streaming work.

# Example Live Streaming ASR Settings

One tested live streaming ASR configuration:

```text
--stream-final-on-silence-ms 300
--stream-vad-merge-gap-ms 250
--stream-step 750
--stream-length 8000
-vt 0.65
-vspd 180
-vsd 300
-vmsd 10
-vp 110
```

In this sample, `-vsd 100` produced substantially more fragmentation than `-vsd 300`.

# Risk

- More short finals and choppier captions.
- Some short utterances may have less ASR context.
- Users who prefer fewer, longer finals may need to raise VAD/finalization
  thresholds.

This PR intentionally does not solve short-final quality or stream-loop performance; those should be handled separately without restoring the offline short-slice merge.
