### PR TITLE
Fix Whisper-VAD-EncDec GGUF decoder input

### DIFF
--- a/include/crispasr.h
+++ b/include/crispasr.h
@@ -745,6 +745,42 @@ extern "C" {
     CRISPASR_API void whisper_vad_free_segments(struct whisper_vad_segments * segments);
     CRISPASR_API void whisper_vad_free         (struct whisper_vad_context  * ctx);
 
+    // CrispASR C-ABI VAD helpers.
+    //
+    // crispasr_vad_segments is the legacy Silero/whisper_vad path and returns
+    // malloc-owned [start_cs, end_cs] float pairs in centiseconds.
+    CRISPASR_API int crispasr_vad_segments(
+            const char * vad_model_path,
+            const float * pcm,
+                    int   n_samples,
+                    int   sample_rate,
+                  float   threshold,
+                    int   min_speech_ms,
+                    int   min_silence_ms,
+                    int   n_threads,
+                   bool   use_gpu,
+                  float ** out_spans);
+
+    // crispasr_vad_slices routes through CrispASR's shared VAD dispatcher and
+    // can use Silero, FireRedVAD, MarbleNet, or Whisper-VAD-EncDec depending
+    // on the concrete model path. It returns malloc-owned [start_s, end_s]
+    // float pairs in seconds. Passing threshold <= 0 leaves per-model default
+    // threshold behavior intact, including Whisper-VAD-EncDec auto-tuning.
+    CRISPASR_API int crispasr_vad_slices(
+            const char * vad_model_path,
+            const float * pcm,
+                    int   n_samples,
+                    int   sample_rate,
+                  float   threshold,
+                    int   min_speech_ms,
+                    int   min_silence_ms,
+                    int   speech_pad_ms,
+                  float   max_chunk_duration_s,
+                    int   n_threads,
+                  float ** out_spans);
+
+    CRISPASR_API void crispasr_vad_free(float * spans);
+
     ////////////////////////////////////////////////////////////////////////////
 
     // Temporary helpers needed for exposing ggml interface

--- a/src/crispasr_c_api.cpp
+++ b/src/crispasr_c_api.cpp
@@ -16,6 +16,8 @@
 #include <cstdio>
 #include <cstring>
 #include <cstdlib>
+#include <cmath>
+#include <algorithm>
 #include <string>
 #include <vector>
 
@@ -382,20 +384,20 @@ CA_EXPORT float crispasr_detect_language(whisper_context* ctx, const float* pcm,
 }
 
 // =========================================================================
-// VAD — run Silero on PCM, return [start_s, end_s] pairs
+// VAD — run Silero on PCM, return [start_cs, end_cs] pairs
 // =========================================================================
 //
-// `out_spans` is a malloc'd array of floats (2 per span). The caller must
-// pass the pointer back to `crispasr_vad_free` when done. Returns the number
-// of speech segments detected (>= 0), or a negative error.
+// `out_spans` is a malloc'd array of centisecond floats (2 per span). The
+// caller must pass the pointer back to `crispasr_vad_free` when done. Returns
+// the number of speech segments detected (>= 0), or a negative error.
 //
 //   -1  bad arguments
 //   -2  model init failed
 //   -3  VAD inference failed
 
 CA_EXPORT int crispasr_vad_segments(const char* vad_model_path, const float* pcm, int n_samples, int sample_rate,
-                                    float threshold, int min_speech_ms, int min_silence_ms, int n_threads, bool use_gpu,
-                                    float** out_spans) {
+                                     float threshold, int min_speech_ms, int min_silence_ms, int n_threads, bool use_gpu,
+                                     float** out_spans) {
     if (!vad_model_path || !pcm || n_samples <= 0 || !out_spans)
         return -1;
     *out_spans = nullptr;
@@ -444,6 +446,68 @@ CA_EXPORT int crispasr_vad_segments(const char* vad_model_path, const float* pcm
     // Silero VAD internally assumes 16 kHz — if we later add automatic
     // resampling here, callers don't have to change.
     (void)sample_rate;
+    return n;
+}
+
+// Dispatcher-backed VAD slicing. Unlike crispasr_vad_segments above, this
+// routes through crispasr_compute_vad_slices so GGUF VAD backends such as
+// Whisper-VAD-EncDec, FireRedVAD, and MarbleNet use the same path as the CLI.
+//
+// `out_spans` is a malloc'd array of [start_s, end_s] float pairs. The caller
+// must pass it to crispasr_vad_free. Returns the number of slices (>= 0), or a
+// negative error.
+//
+//   -1  bad arguments
+//   -2  allocation failed
+CA_EXPORT int crispasr_vad_slices(const char* vad_model_path, const float* pcm, int n_samples, int sample_rate,
+                                  float threshold, int min_speech_ms, int min_silence_ms, int speech_pad_ms,
+                                  float max_chunk_duration_s, int n_threads, float** out_spans) {
+    if (!vad_model_path || !*vad_model_path || !pcm || n_samples <= 0 || sample_rate <= 0 || !out_spans)
+        return -1;
+    *out_spans = nullptr;
+
+    crispasr_vad_options opts;
+    if (threshold > 0.0f) {
+        opts.threshold = threshold;
+        opts.threshold_explicit = true;
+    }
+    if (min_speech_ms > 0)
+        opts.min_speech_duration_ms = min_speech_ms;
+    if (min_silence_ms > 0)
+        opts.min_silence_duration_ms = min_silence_ms;
+    const int pad_ms = speech_pad_ms > 0 ? speech_pad_ms : 0;
+    // Apply padding below for all dispatcher backends. Some implementations
+    // (for example Whisper-VAD-EncDec) ignore opts.speech_pad_ms internally.
+    opts.speech_pad_ms = 0;
+    if (max_chunk_duration_s > 0.0f)
+        opts.chunk_seconds = (int)std::ceil(max_chunk_duration_s);
+    else
+        opts.chunk_seconds = 0;
+    if (n_threads > 0)
+        opts.n_threads = n_threads;
+
+    std::vector<crispasr_audio_slice> slices = crispasr_compute_vad_slices(pcm, n_samples, sample_rate, vad_model_path, opts);
+    const int n = (int)slices.size();
+    if (n == 0)
+        return 0;
+
+    float* buf = (float*)std::malloc(sizeof(float) * 2 * n);
+    if (!buf)
+        return -2;
+
+    const float duration_s = (float)n_samples / (float)sample_rate;
+    const float pad_s = (float)pad_ms / 1000.0f;
+    for (int i = 0; i < n; ++i) {
+        float start_s = (float)slices[i].t0_cs / 100.0f;
+        float end_s = (float)slices[i].t1_cs / 100.0f;
+        if (pad_s > 0.0f) {
+            start_s = std::max(0.0f, start_s - pad_s);
+            end_s = std::min(duration_s, end_s + pad_s);
+        }
+        buf[2 * i + 0] = start_s;
+        buf[2 * i + 1] = end_s;
+    }
+    *out_spans = buf;
     return n;
 }
 

--- a/src/crispasr_vad_encdec.cpp
+++ b/src/crispasr_vad_encdec.cpp
@@ -409,7 +409,7 @@ static wvad_result wvad_forward(whisper_vad_encdec_context* ctx, const float* me
         h = ggml_add(ctx0, h, f32(m.conv1_b));
         h = ggml_cont(ctx0, ggml_transpose(ctx0, h));
     }
-    h = ggml_gelu(ctx0, h);
+    h = ggml_gelu_erf(ctx0, h);
     ggml_tensor* conv2_w_f16 = ggml_cast(ctx0, m.conv2_w, GGML_TYPE_F16);
     h = ggml_conv_1d_ph(ctx0, conv2_w_f16, h, 2, 1); // stride=2: 3000->1500
     if (m.conv2_b) {
@@ -417,7 +417,7 @@ static wvad_result wvad_forward(whisper_vad_encdec_context* ctx, const float* me
         h = ggml_add(ctx0, h, f32(m.conv2_b));
         h = ggml_cont(ctx0, ggml_transpose(ctx0, h));
     }
-    h = ggml_gelu(ctx0, h);
+    h = ggml_gelu_erf(ctx0, h);
 
     // h after conv2+bias is [T, d] from transpose back. It was already transposed in bias add.
     // After conv2 bias: h = [T, C] → transposed back from [C, T].
@@ -476,7 +476,7 @@ static wvad_result wvad_forward(whisper_vad_encdec_context* ctx, const float* me
         h = ggml_mul_mat(ctx0, L.fc1_w, h);
         if (f32(L.fc1_b))
             h = ggml_add(ctx0, h, f32(L.fc1_b));
-        h = ggml_gelu(ctx0, h);
+        h = ggml_gelu_erf(ctx0, h);
         h = ggml_mul_mat(ctx0, L.fc2_w, h);
         if (f32(L.fc2_b))
             h = ggml_add(ctx0, h, f32(L.fc2_b));
@@ -493,10 +493,13 @@ static wvad_result wvad_forward(whisper_vad_encdec_context* ctx, const float* me
     ggml_set_output(enc_out);
 
     // ── Decoder (2 layers with self-attn + cross-attn) ──
-    // Input: position queries [d, T, 1] → squeeze to [d, T]
+    // ONNX/PyTorch initializes the decoder stream with encoder states plus
+    // learned position queries: `decoder_input = encoder_output + queries`.
+    // Using queries alone severely de-calibrates the frame classifier.
     ggml_tensor* tgt = m.dec_pos_queries;
     if (ggml_n_dims(tgt) > 2)
         tgt = ggml_cont(ctx0, ggml_reshape_2d(ctx0, tgt, d, T));
+    tgt = ggml_add(ctx0, enc_out, tgt);
 
     for (int il = 0; il < m.n_dec_layers; il++) {
         auto& L = m.dec[il];


### PR DESCRIPTION
## Summary

- Add a dispatcher-backed `crispasr_vad_slices` C ABI for wrapper-owned VAD slicing in seconds.
- Fix Whisper-VAD-EncDec GGUF inference to match ONNX decoder semantics by initializing decoder input as `encoder_output + position_queries`.
- Keep existing VAD defaults and threshold auto-tuning behavior intact.

## Why

Whisper-VAD-EncDec GGUF output quality was much worse than the ONNX reference. Quantization was not the root cause: F32 GGUF diverged from ONNX before the runtime fix, while Q4 and F32 GGUF tracked each other. The actual mismatch was in the decoder input path. ONNX adds encoder output to learned decoder position queries before the decoder; the GGUF runtime used only the position queries.

The new `crispasr_vad_slices` export is needed because we are integrating CrispASR into a downstream project that needs raw VAD speech segments directly from the shared library. That project owns its own chunking and ASR scheduling, so it cannot rely on CrispASR's internal chunking path or stitched-transcription flow.

## Validation

- Rebuilt `crispasr` successfully with CMake.
- Patched F32 GGUF vs ONNX raw probabilities: `corr=1.0000`, `mae=0.0000`, `rmse=0.0001`.
- Patched Q4 GGUF vs ONNX raw probabilities: `corr=0.9880`, `mae=0.0339`, `rmse=0.0629`.
- VAD-only placeholder SRT on the target ASMR sample: 64 cues, 0 bad intervals.