### PR TITLE
fix(pyannote): keep segmentation weights on CPU

### DIFF
--- a/src/pyannote_seg.cpp
+++ b/src/pyannote_seg.cpp
@@ -75,9 +75,9 @@ struct pyannote_seg_context {
 // ===========================================================================
 
 static bool pyannote_load(pyannote_model& m, const char* path) {
-    ggml_backend_t backend = ggml_backend_init_best();
-    if (!backend)
-        backend = ggml_backend_cpu_init();
+    // pyannote_seg_run() is a manual CPU F32 implementation that directly
+    // dereferences tensor->data, so weights must live in host memory.
+    ggml_backend_t backend = ggml_backend_cpu_init();
     core_gguf::WeightLoad wl;
     if (!core_gguf::load_weights(path, backend, "pyannote_seg", wl)) {
         ggml_backend_free(backend);


### PR DESCRIPTION
## Summary

Fixes native pyannote segmentation on GPU-enabled builds by loading the pyannote GGUF weights on the CPU backend.

## How this fixes it

`pyannote_seg_run()` is a manual CPU F32 implementation and directly dereferences `ggml_tensor->data` for SincNet, Conv, LSTM, and Linear weights. When `ggml_backend_init_best()` selects CUDA/Metal/Vulkan, those tensor data pointers may point to device memory and cannot safely be read by host code.

This PR restores CPU-resident weights for this runtime by using `ggml_backend_cpu_init()` in the pyannote loader, while preserving the existing backend lifetime management.

## Generality / compatibility

This is a general correctness fix for the current native pyannote runtime, not a workaround for one input file. The runtime already executes on CPU; keeping weights on CPU aligns storage with the execution path. A future GPU implementation should move the whole pyannote forward pass to ggml/backend graph execution rather than just placing weights on a device backend.

Resolves #98
