### PR TITLE
fix(cohere): keep generic diarize out of decode prompt

### DIFF
--- a/examples/cli/crispasr_backend_cohere.cpp
+++ b/examples/cli/crispasr_backend_cohere.cpp
@@ -5,9 +5,10 @@
 // grouping, so we emit one segment per transcribe() call with tokens
 // attached.
 //
-// Cohere's punctuation and diarization toggles are set on the context
-// params at init() time, not per call, so this backend reads them from
-// whisper_params once during init.
+// Cohere's punctuation toggle is set on the context params at init() time,
+// not per call, so this backend reads it from whisper_params once during init.
+// CLI --diarize is a generic post-processing pass; do not map it to Cohere's
+// experimental <|diarize|> decode prompt because that changes ASR text.
 
 #include "crispasr_backend.h"
 #include "crispasr_backend_utils.h"
@@ -38,7 +39,7 @@ public:
         cp.use_flash = p.flash_attn;
         cp.use_gpu = crispasr_backend_should_use_gpu(p);
         cp.no_punctuation = !p.punctuation;
-        cp.diarize = p.diarize;
+        cp.diarize = false;
         cp.verbosity = p.no_prints ? 0 : 1;
         if (getenv("CRISPASR_VERBOSE") || getenv("COHERE_BENCH"))
             cp.verbosity = 2;


### PR DESCRIPTION
## Summary

Prevents the generic CLI `--diarize` post-processing flag from changing Cohere's ASR decode prompt to the experimental `<|diarize|>` mode.

## How this fixes it

The CLI diarization path labels speakers after ASR, but the Cohere adapter also mapped `params.diarize` into `cohere_context_params::diarize`. That changed the model prompt from `<|nodiarize|>` to `<|diarize|>`, which can change transcript text before any post-processing method such as `vad-turns` runs.

This PR keeps Cohere transcription in `<|nodiarize|>` mode for the generic CLI diarization surface, so `--diarize --diarize-method vad-turns` only adds speaker labels after normal ASR.

## Generality / compatibility

This is a CLI semantics fix: framework-level `--diarize` should not alter backend decode behavior unless explicitly requested. The only behavior removed is the implicit coupling to Cohere's experimental native diarization prompt. If that prompt should be exposed, it should use a separate Cohere-specific option.

Resolves #100
