### PR TITLE
fix(audio): average stereo downmix for diarize path

### DIFF
--- a/examples/common-crispasr.cpp
+++ b/examples/common-crispasr.cpp
@@ -164,7 +164,7 @@ bool read_audio_data(const std::string & fname, std::vector<float>& pcmf32, std:
         pcmf32.resize(frame_count);
 
         for (uint64_t i = 0; i < frame_count; i++) {
-            pcmf32[i] = (stereo_data[2*i] + stereo_data[2*i + 1]);
+            pcmf32[i] = 0.5f * (stereo_data[2*i] + stereo_data[2*i + 1]);
         }
 
         pcmf32s.resize(2);


### PR DESCRIPTION
## Summary

Fixes the shared stereo-to-mono downmix path so enabling `--diarize` does not double the ASR input amplitude for normal stereo files.

## How this fixes it

The CLI requests stereo decoding when `--diarize` is enabled so stereo diarizers can inspect left/right channels. The ASR backend still receives a mono buffer reconstructed from the decoded stereo data.

The current downmix uses `L + R`, which gives a +6 dB boost for centered/correlated stereo content and can change ASR/VAD behavior simply because diarization was enabled. This PR changes the downmix to the conventional average, `0.5f * (L + R)`, while preserving the separate channel buffers for stereo diarization methods.

## Generality / compatibility

This is a shared audio-loader correctness fix across backends using `read_audio_data(..., stereo=true)`. Mono input is unaffected. Stereo golden outputs may change because the previous path fed boosted audio into ASR; this PR makes the diarize path match normal downmix semantics.

Resolves #101
