### PR TITLE
fix(pyannote): use ONNX LSTM gate order

### DIFF
--- a/src/pyannote_seg.cpp
+++ b/src/pyannote_seg.cpp
@@ -172,13 +172,14 @@ static void bilstm_forward(const float* input, int T, int C_in, const pyannote_l
                 gates[g] = sum;
             }
 
-            // i=sigmoid, f=sigmoid, g=tanh, o=sigmoid
+            // ONNX LSTM gate order is i, o, f, c (cell candidate), not
+            // PyTorch's common i, f, g, o ordering.
             for (int j = 0; j < H; j++) {
                 float i_g = sigmoid(gates[0 * H + j]);
-                float f_g = sigmoid(gates[1 * H + j]);
-                float g_g = tanhf(gates[2 * H + j]);
-                float o_g = sigmoid(gates[3 * H + j]);
-                c[j] = f_g * c[j] + i_g * g_g;
+                float o_g = sigmoid(gates[1 * H + j]);
+                float f_g = sigmoid(gates[2 * H + j]);
+                float c_g = tanhf(gates[3 * H + j]);
+                c[j] = f_g * c[j] + i_g * c_g;
                 h[j] = o_g * tanhf(c[j]);
             }
 


### PR DESCRIPTION
## Summary

Fixes the manual native pyannote LSTM implementation to use ONNX gate order (`i, o, f, c`) instead of PyTorch-style gate order (`i, f, g, o`).

## How this fixes it

The pyannote GGUF weights are converted from ONNX LSTM initializers. ONNX stores the four LSTM gates as input, output, forget, and cell candidate. The native runtime previously interpreted them as input, forget, candidate, and output, corrupting the recurrent state update and causing speaker assignments to collapse on tested multi-speaker audio.

This PR updates the gate interpretation in `bilstm_forward()` and documents the ONNX order in the code.

## Generality / compatibility

This is a correctness fix for GGUFs generated directly from ONNX initializers, including the included pyannote converter path. Native pyannote diarization outputs will change. A nonstandard GGUF with manually pre-reordered gates would need to be regenerated or handled separately, but that is not the format produced by the current converter.

Resolves #102
