### PR TITLE
Fix sherpa pyannote segmentation flag

### DIFF
--- a/examples/cli/crispasr_diarize_cli.cpp
+++ b/examples/cli/crispasr_diarize_cli.cpp
@@ -220,7 +220,7 @@ bool apply_sherpa(const std::vector<float>& mono, int64_t slice_t0_cs, std::vect
     // clang-format off
     cmd << bin
         << " --clustering.num-clusters=" << params.sherpa_num_clusters
-        << " --segmentation.pyannote.model='" << params.sherpa_segment_model << "'"
+        << " --segmentation.pyannote-model='" << params.sherpa_segment_model << "'"
         << " --embedding.model='" << params.sherpa_embedding_model << "'"
         << " '" << wav_path << "'";
     // clang-format on


### PR DESCRIPTION
## Summary

Fixes the sherpa/ecapa diarization subprocess invocation by using the pyannote segmentation flag name supported by current sherpa-onnx releases:

```text
--segmentation.pyannote-model=...
```

instead of the unsupported dotted spelling:

```text
--segmentation.pyannote.model=...
```

Without this change, sherpa-onnx rejects the command-line option and CrispASR reports that the subprocess produced no parseable segments, even when the binary and both model paths are valid.

## Validation

- `cmake --build build -j$(nproc)`
- Smoke-tested `--diarize --diarize-method ecapa` with sherpa-onnx v1.13.2, pyannote segmentation ONNX, and a 3D-Speaker embedding ONNX; CrispASR now logs parsed speaker regions instead of `no parseable segments`.

Resolves #108
