### PR TITLE
Add streaming punctuation policy

### DIFF
--- a/docs/streaming.md
+++ b/docs/streaming.md
@@ -135,6 +135,21 @@ seen in `partial` events, never an empty string blanking a
 previously-emitted partial. The fallback is internal; no flag, no
 event change.
 
+### Streaming punctuation (`--stream-punc`)
+
+When `--stream-json --vad` is used with `--punc-model`, FireRedPunc can be
+placed on different parts of the streaming path:
+
+| Mode | Effect |
+|---|---|
+| `off` | Do not run FireRedPunc on streaming partials or finals. |
+| `final` | Run FireRedPunc only when emitting `final` text. This is the default and the recommended realtime mode. |
+| `partial` | Run FireRedPunc on partials and finals. This preserves the older behavior but can add substantial latency when partials are frequent. |
+
+`final` keeps live partials cheap while still restoring punctuation on finalized
+utterances. Use `partial` only when punctuation on every partial is worth the
+extra compute.
+
 ## Microphone (`--mic`)
 
 ```bash

--- a/examples/cli/cli.cpp
+++ b/examples/cli/cli.cpp
@@ -528,6 +528,14 @@ static bool whisper_params_parse_arg_streaming_tts(int argc, char** argv, int& i
             fprintf(stderr, "crispasr: --stream-vad-merge-gap-ms must be >= 0\n");
             exit(2);
         }
+    } else if (arg == "--stream-punc") {
+        std::string mode = ARGV_NEXT;
+        if (mode != "off" && mode != "final" && mode != "partial") {
+            fprintf(stderr, "crispasr: --stream-punc must be 'off', 'final', or 'partial' (got '%s')\n",
+                    mode.c_str());
+            exit(2);
+        }
+        params.stream_punc = mode;
     } else if (arg == "--stream-final-mode") {
         std::string mode = ARGV_NEXT;
         if (mode != "redecode" && mode != "prefix") {
@@ -861,6 +869,9 @@ static void whisper_print_usage(int /*argc*/, char** argv, const whisper_params&
     fprintf(stderr,
             "  --stream-vad-merge-gap-ms N       [%-7d] JSON+VAD close-gap merge in ms; clamped below final silence\n",
             params.stream_vad_merge_gap_ms);
+    fprintf(stderr,
+            "  --stream-punc MODE                [%-7s] JSON+VAD FireRedPunc mode: off, final, or partial\n",
+            params.stream_punc.c_str());
     fprintf(stderr,
             "  --stream-final-mode MODE          [%-7s] final.text source: 'redecode' (re-runs on the utterance "
             "PCM, best quality) or 'prefix' (LCP-accumulated, no extra encoder pass)\n",

--- a/examples/cli/crispasr_run.cpp
+++ b/examples/cli/crispasr_run.cpp
@@ -64,6 +64,25 @@ static void apply_punc_model(fireredpunc_context* punc_ctx, std::vector<crispasr
     }
 }
 
+static std::string apply_punc_text(fireredpunc_context* punc_ctx, const std::string& text) {
+    if (!punc_ctx || text.empty())
+        return text;
+    char* result = fireredpunc_process(punc_ctx, text.c_str());
+    if (!result)
+        return text;
+    std::string out = result;
+    free(result);
+    return out;
+}
+
+static bool stream_punc_partials_enabled(const whisper_params& params) {
+    return params.stream_punc == "partial";
+}
+
+static bool stream_punc_finals_enabled(const whisper_params& params) {
+    return params.stream_punc == "final" || params.stream_punc == "partial";
+}
+
 // Apply PCS (punctuation + capitalization + segmentation) to all segments.
 static void apply_pcs_model(pcs_context* pcs_ctx, std::vector<crispasr_segment>& segs) {
     if (!pcs_ctx)
@@ -1501,7 +1520,8 @@ int crispasr_run_backend(const whisper_params& params_in) {
                         }
                         if (!sl_for_text.empty())
                             decoded_segments_this_step = true;
-                        apply_punc_model(punc_ctx.get(), sl_for_text);
+                        if (stream_punc_partials_enabled(params))
+                            apply_punc_model(punc_ctx.get(), sl_for_text);
                         apply_truecase_model(tc_ctx.get(), sl_for_text);
                         apply_truecase_crf_model(tc_crf_ctx.get(), sl_for_text);
                         apply_truecase_lstm_model(tc_lstm_ctx.get(), sl_for_text);
@@ -1605,6 +1625,7 @@ int crispasr_run_backend(const whisper_params& params_in) {
                     // replaced by an empty final. (Round 4 of #84: CKwasd
                     // report 2026-05-11 "empty finals on sub-2-s utterances".)
                     std::string final_text;
+                    bool final_text_from_redecode = false;
                     if (params.stream_final_mode == "redecode") {
                         if ((int)utterance_pcm.size() >= crispasr::kStreamRedecodeMinSamples) {
                             // Disable nested VAD: utterance_pcm is already
@@ -1616,7 +1637,8 @@ int crispasr_run_backend(const whisper_params& params_in) {
                             decode_params.vad_model.clear();
                             auto utt_segs =
                                 backend->transcribe(utterance_pcm.data(), (int)utterance_pcm.size(), 0, decode_params);
-                            apply_punc_model(punc_ctx.get(), utt_segs);
+                            if (stream_punc_finals_enabled(params))
+                                apply_punc_model(punc_ctx.get(), utt_segs);
                             apply_truecase_model(tc_ctx.get(), utt_segs);
                             apply_truecase_crf_model(tc_crf_ctx.get(), utt_segs);
                             apply_truecase_lstm_model(tc_lstm_ctx.get(), utt_segs);
@@ -1627,6 +1649,7 @@ int crispasr_run_backend(const whisper_params& params_in) {
                             }
                             for (const auto& s : utt_segs)
                                 final_text += s.text;
+                            final_text_from_redecode = !final_text.empty();
                         }
                         if (final_text.empty())
                             final_text = crispasr::stitch_partial_accumulator(prefix_committed, last_partial_text);
@@ -1634,6 +1657,8 @@ int crispasr_run_backend(const whisper_params& params_in) {
                         // prefix mode: stitch committed prefix + last partial tail
                         final_text = crispasr::stitch_partial_accumulator(prefix_committed, last_partial_text);
                     }
+                    if (stream_punc_finals_enabled(params) && !final_text_from_redecode)
+                        final_text = apply_punc_text(punc_ctx.get(), final_text);
                     const double t0 = (double)utterance_start_sample / (double)SR;
                     const double t1 = (double)last_speech_end_sample / (double)SR;
                     fprintf(stdout,
@@ -1903,6 +1928,7 @@ int crispasr_run_backend(const whisper_params& params_in) {
             // EOF path: identical redecode→stitch-fallback contract to the
             // in-loop finalize_utterance. See crispasr_stream_finalize.h.
             std::string final_text;
+            bool final_text_from_redecode = false;
             if (params.stream_final_mode == "redecode") {
                 if ((int)utterance_pcm.size() >= crispasr::kStreamRedecodeMinSamples) {
                     whisper_params decode_params = params;
@@ -1910,7 +1936,8 @@ int crispasr_run_backend(const whisper_params& params_in) {
                     decode_params.vad_model.clear();
                     auto utt_segs =
                         backend->transcribe(utterance_pcm.data(), (int)utterance_pcm.size(), 0, decode_params);
-                    apply_punc_model(punc_ctx.get(), utt_segs);
+                    if (stream_punc_finals_enabled(params))
+                        apply_punc_model(punc_ctx.get(), utt_segs);
                     apply_truecase_model(tc_ctx.get(), utt_segs);
                     apply_truecase_crf_model(tc_crf_ctx.get(), utt_segs);
                     apply_truecase_lstm_model(tc_lstm_ctx.get(), utt_segs);
@@ -1921,12 +1948,15 @@ int crispasr_run_backend(const whisper_params& params_in) {
                     }
                     for (const auto& s : utt_segs)
                         final_text += s.text;
+                    final_text_from_redecode = !final_text.empty();
                 }
                 if (final_text.empty())
                     final_text = crispasr::stitch_partial_accumulator(prefix_committed, last_partial_text);
             } else {
                 final_text = crispasr::stitch_partial_accumulator(prefix_committed, last_partial_text);
             }
+            if (stream_punc_finals_enabled(params) && !final_text_from_redecode)
+                final_text = apply_punc_text(punc_ctx.get(), final_text);
             const double t0 = (double)utterance_start_sample / (double)SR;
             const double t1 = last_speech_end_sample > 0 ? (double)last_speech_end_sample / (double)SR
                                                          : (double)cumulative_samples / (double)SR;

--- a/examples/cli/whisper_params.h
+++ b/examples/cli/whisper_params.h
@@ -179,6 +179,10 @@ struct whisper_params {
     // detector jitter gaps, but never across --stream-final-on-silence-ms.
     // 0 disables streaming-specific post-merge.
     int32_t stream_vad_merge_gap_ms = 250;
+    // JSON streaming + VAD only: control FireRedPunc placement when
+    // --punc-model is loaded. "final" avoids the high-frequency partial
+    // punc path; "partial" preserves the older partial+final behavior.
+    std::string stream_punc = "final"; // off|final|partial
     // Issue #84 round 2 (CKwasd retest): how to compute `final.text`
     // when an utterance closes. The round-1 design just echoed the
     // last rolling-window partial — wrong because the rolling window


### PR DESCRIPTION
## Summary

Add `--stream-punc off|final|partial` for `--stream-json --vad` when `--punc-model` is loaded. Default is `--stream-punc final`, so FireRedPunc runs on final text only and stays off the high-frequency partial path.

## Why

Recent Cohere JA streaming tests showed FireRedPunc on every partial is a major lag amplifier, especially with `--stream-step 500`. Final-only punctuation preserves finalized punctuation without paying the per-partial cost.

## CLI Behavior

```text
--stream-punc off      # no FireRedPunc on streaming partials/finals
--stream-punc final    # FireRedPunc on final text only; default
--stream-punc partial  # FireRedPunc on partials and finals; old behavior
```

`--stream-punc` only has an effect when `--punc-model` is provided.

## Implementation

Changed files: `examples/cli/whisper_params.h`, `examples/cli/cli.cpp`, `examples/cli/crispasr_run.cpp`, `docs/streaming.md`

Behavior: partial slice text only runs FireRedPunc with `--stream-punc partial`; final redecode / prefix fallback / EOF final runs FireRedPunc with `--stream-punc final|partial`.

## Smoke Test

Script: `Y:\ASR\test_stream_punc_modes_30s.ps1`

Command shape: `--stream --stream-json --stream-final-mode redecode --stream-final-on-silence-ms 330 --stream-vad-merge-gap-ms 280 --stream-length 8000 --stream-step 500 --vad --punc-model fireredpunc-q4_k.gguf --stream-punc <mode>`

| mode | seconds | step | events | partials | finals | silences | wall_sec | exit |
|---|---:|---:|---:|---:|---:|---:|---:|---:|
| final | 30 | 500 | 61 | 36 | 11 | 14 | 44.320 | 0 |
| off | 30 | 500 | 61 | 36 | 11 | 14 | 35.540 | 0 |
| partial | 30 | 500 | 61 | 36 | 11 | 14 | 45.893 | 0 |

Help output confirms: `--stream-punc MODE [final] JSON+VAD FireRedPunc mode: off, final, or partial`

## Build / Validation

`git diff --check` passed. User rebuilt successfully: `[SUCCESS] Build complete. Binary is at build-vulkan\bin\crispasr.exe`

## Risk

Default JSON+VAD streaming punctuation changes from partial+final to final-only.
Users can restore old behavior with `--stream-punc partial` or disable streaming punctuation with `--stream-punc off`.
