### PR TITLE
Fix VAD chunk-context handling and zero-duration subtitle timestamps

### DIFF
--- a/examples/cli/crispasr_backend_granite.cpp
+++ b/examples/cli/crispasr_backend_granite.cpp
@@ -335,11 +335,22 @@ public:
                 free(text);
 
             crispasr_segment seg;
+            seg.t0 = t_offset_cs;
+            seg.t1 = t_offset_cs + (int64_t)((double)n_samples / 16000.0 * 100.0);
             // Strip leading space
             size_t start = 0;
             while (start < transcript.size() && transcript[start] == ' ')
                 start++;
             seg.text = transcript.substr(start);
+            seg.tokens.reserve(gen_ids.size());
+            for (size_t i = 0; i < gen_ids.size(); i++) {
+                if (gen_ids[i] == eos_tok)
+                    break;
+                crispasr_token ct;
+                ct.id = gen_ids[i];
+                ct.confidence = (i < probs.size()) ? probs[i] : -1.0f;
+                seg.tokens.push_back(std::move(ct));
+            }
             if (!params.punctuation) {
                 crispasr_strip_ascii_punctuation(seg.text);
                 crispasr_lowercase_ascii(seg.text);

--- a/examples/cli/crispasr_chunk_context_gate.h
+++ b/examples/cli/crispasr_chunk_context_gate.h
@@ -15,8 +15,9 @@
 // on parakeet-tdt-0.6b-ja was kanji collapsing to bare hiragana plus
 // entire short slices being dropped.
 //
-// The fix is to gate overlap-save on `effective_chunk_seconds > 0`:
-// it's a chunking-only mitigation, and VAD slicing is not chunking.
+// The fix is to gate overlap-save on the actual slice source:
+// it's a chunking-only mitigation, and VAD slicing is not chunking even
+// when the CLI's fallback chunk_seconds value is non-zero.
 
 #pragma once
 
@@ -29,12 +30,15 @@ namespace crispasr_chunk_context {
 // sl.size + 2*ctx, ...)`), then trimmed back via word-level filtering.
 //
 // Returns false (no context, transcribe the bare slice) when:
+//   - the slices came from VAD. VAD-derived slices are already speech
+//     boundaries and must not pull neighbouring utterances into context.
 //   - chunking is not in effect (effective_chunk_seconds == 0). The
-//     CAP_UNBOUNDED_INPUT default; covers VAD-derived multi-slice runs.
+//     CAP_UNBOUNDED_INPUT default for non-VAD runs.
 //   - there is only one slice (no boundary to mitigate).
 //   - the user has set --chunk-overlap 0 explicitly.
-inline bool should_use_chunk_context(int effective_chunk_seconds, std::size_t n_slices, float chunk_overlap_seconds) {
-    return effective_chunk_seconds > 0 && n_slices > 1 && chunk_overlap_seconds > 0.0f;
+inline bool should_use_chunk_context(int effective_chunk_seconds, std::size_t n_slices, float chunk_overlap_seconds,
+                                     bool vad_slicing) {
+    return !vad_slicing && effective_chunk_seconds > 0 && n_slices > 1 && chunk_overlap_seconds > 0.0f;
 }
 
 } // namespace crispasr_chunk_context

--- a/examples/cli/crispasr_run.cpp
+++ b/examples/cli/crispasr_run.cpp
@@ -194,6 +194,10 @@ std::vector<crispasr_segment> merge_segments(std::vector<std::vector<crispasr_se
     return out;
 }
 
+bool crispasr_words_have_positive_span(const std::vector<crispasr_word>& words) {
+    return !words.empty() && words.back().t1 > words.front().t0;
+}
+
 // Stdout serialization mutex. Used by the parallel-processors path to
 // keep stdout transcript lines from interleaving across worker threads.
 // The single-threaded path acquires it too — no measurable cost since
@@ -512,7 +516,7 @@ int process_one_input(CrispasrBackend& backend, const std::string& fname_inp, co
                 if (e > s) {
                     auto words = crispasr_ctc_align(params.aligner_model, seg.text, samples.data() + s, e - s, seg.t0,
                                                     params.n_threads);
-                    if (!words.empty()) {
+                    if (crispasr_words_have_positive_span(words)) {
                         seg.t0 = words.front().t0;
                         seg.t1 = words.back().t1;
                         seg.words = std::move(words);
@@ -627,7 +631,8 @@ int process_one_input(CrispasrBackend& backend, const std::string& fname_inp, co
     // unit test in tests/test-issue-114-chunk-context-gate.cpp can pin
     // it without spinning up a model. See the header for the rationale.
     const bool use_chunk_context =
-        crispasr_chunk_context::should_use_chunk_context(effective_chunk_seconds, slices.size(), kChunkContextS);
+        crispasr_chunk_context::should_use_chunk_context(effective_chunk_seconds, slices.size(), kChunkContextS,
+                                                         wants_vad);
 
     auto process_slice = [&](size_t i, CrispasrBackend& be) {
         const auto& sl = slices[i];
@@ -751,7 +756,7 @@ int process_one_input(CrispasrBackend& backend, const std::string& fname_inp, co
                     continue;
                 auto words = crispasr_ctc_align(params.aligner_model, seg.text, samples.data() + sl.start,
                                                 sl.end - sl.start, sl.t0_cs, params.n_threads);
-                if (!words.empty()) {
+                if (crispasr_words_have_positive_span(words)) {
                     seg.t0 = words.front().t0;
                     seg.t1 = words.back().t1;
                     seg.words = std::move(words);
@@ -2468,7 +2473,7 @@ int crispasr_run_backend(const whisper_params& params_in) {
                         sl.end - sl.start,
                         sl.t0_cs,
                         params.n_threads);
-                    if (!words.empty()) {
+                    if (crispasr_words_have_positive_span(words)) {
                         seg.t0 = words.front().t0;
                         seg.t1 = words.back().t1;
                         seg.words = std::move(words);

--- a/tests/test-issue-114-chunk-context-gate.cpp
+++ b/tests/test-issue-114-chunk-context-gate.cpp
@@ -1,23 +1,20 @@
-// test-issue-114-chunk-context-gate.cpp — unit tests for the overlap-save
+// test-issue-114-chunk-context-gate.cpp - unit tests for the overlap-save
 // gating logic (issue #114).
 //
 // The cad4c28a "feat(#89): overlap-save chunking with --chunk-overlap flag"
-// change extended each transcribe() slice by ±chunk_overlap_seconds on
+// change extended each transcribe() slice by +/-chunk_overlap_seconds on
 // each side whenever slices.size() > 1. That gate was correct for
 // explicit `--chunk-seconds N` runs (where the chunks are arbitrary cuts
 // through continuous speech and the encoder genuinely needs left/right
-// context to span boundaries), but WRONG for VAD-derived multi-slice
-// runs: VAD slices are separated by silence, so there is no boundary
-// signal to recover. Adding 3 s of neighbour audio pulled the next
-// utterance into the current encoder's context window, shifted the
-// FastConformer features, and caused the TDT decoder to pick a worse
-// token path. The user-visible symptom on parakeet-tdt-0.6b-ja was kanji
-// collapsing to bare hiragana plus entire short slices being dropped
-// (issue #114).
+// context to span boundaries), but wrong for VAD-derived multi-slice runs:
+// VAD slices are separated by silence, so there is no boundary signal to
+// recover. Adding 3 s of neighbour audio pulled the next utterance into the
+// current encoder context window, shifted features, and caused short slices
+// to be dropped.
 //
-// The fix gates use_chunk_context on `effective_chunk_seconds > 0` so
-// the extension is applied only when chunking is the actual reason for
-// having multiple slices. These tests pin that invariant.
+// The fix gates use_chunk_context on both effective_chunk_seconds > 0 and
+// whether the slices came from VAD, so the extension is applied only when
+// chunking is the actual reason for having multiple slices.
 
 #include <catch2/catch_test_macros.hpp>
 
@@ -26,56 +23,49 @@
 using crispasr_chunk_context::should_use_chunk_context;
 
 TEST_CASE("issue #114: VAD-derived multi-slice run does NOT extend with context", "[unit][chunk-context][issue-114]") {
-    // CAP_UNBOUNDED_INPUT backends (parakeet, canary, ...) set
-    // effective_chunk_seconds = 0 unconditionally in crispasr_run.cpp.
-    // With 56 VAD slices and the default chunk_overlap_seconds = 3.0,
-    // the pre-fix gate evaluated to true (slices.size() > 1 && 3.0 > 0)
-    // and produced the kanji → hiragana regression.
     constexpr int effective_chunk_seconds = 0;
     constexpr std::size_t n_slices = 56;
     constexpr float chunk_overlap_seconds = 3.0f;
-    REQUIRE_FALSE(should_use_chunk_context(effective_chunk_seconds, n_slices, chunk_overlap_seconds));
+    REQUIRE_FALSE(should_use_chunk_context(effective_chunk_seconds, n_slices, chunk_overlap_seconds, true));
 }
 
-TEST_CASE("explicit --chunk-seconds with multiple slices uses overlap-save", "[unit][chunk-context][issue-114]") {
-    // The original intended use case of cad4c28a: the user (or the
-    // default fallback for non-CAP_UNBOUNDED backends) requested
-    // chunk_seconds=30 to cut long audio into 30 s slices. Here the
-    // overlap is genuinely useful — adjacent slices are continuous
-    // speech, so the encoder needs the ±3 s context to span the cut.
+TEST_CASE("issue #114: VAD with default fallback chunk_seconds still gets no context",
+          "[unit][chunk-context][issue-114]") {
+    // Non-CAP_UNBOUNDED backends such as Cohere keep the CLI default
+    // effective_chunk_seconds=30 even when VAD produced the slices. That
+    // value is only a later overlong-slice split limit; it must not make
+    // VAD slices look like fixed chunks.
+    REQUIRE_FALSE(should_use_chunk_context(30, 33, 3.0f, true));
+}
+
+TEST_CASE("explicit --chunk-seconds with multiple non-VAD slices uses overlap-save",
+          "[unit][chunk-context][issue-114]") {
     constexpr int effective_chunk_seconds = 30;
     constexpr std::size_t n_slices = 10;
     constexpr float chunk_overlap_seconds = 3.0f;
-    REQUIRE(should_use_chunk_context(effective_chunk_seconds, n_slices, chunk_overlap_seconds));
+    REQUIRE(should_use_chunk_context(effective_chunk_seconds, n_slices, chunk_overlap_seconds, false));
 }
 
-TEST_CASE("single slice never gets context (no boundary to mitigate)", "[unit][chunk-context][issue-114]") {
-    // Even with explicit chunking + positive overlap, one slice means
-    // there is no chunk boundary at all. Adding context would just be
-    // expanding the slice to cover audio that isn't there.
-    REQUIRE_FALSE(should_use_chunk_context(30, 1, 3.0f));
-    REQUIRE_FALSE(should_use_chunk_context(0, 1, 3.0f));
+TEST_CASE("single slice never gets context", "[unit][chunk-context][issue-114]") {
+    REQUIRE_FALSE(should_use_chunk_context(30, 1, 3.0f, false));
+    REQUIRE_FALSE(should_use_chunk_context(0, 1, 3.0f, false));
 }
 
 TEST_CASE("--chunk-overlap 0 disables overlap-save", "[unit][chunk-context][issue-114]") {
-    // The CLI gives the user an explicit knob to turn off the context
-    // extension even when chunking is active. Useful as an escape hatch
-    // if overlap-save itself proves problematic on a particular model.
-    REQUIRE_FALSE(should_use_chunk_context(30, 10, 0.0f));
-    // Negative values must also disable (defensive — should never happen).
-    REQUIRE_FALSE(should_use_chunk_context(30, 10, -1.0f));
+    REQUIRE_FALSE(should_use_chunk_context(30, 10, 0.0f, false));
+    REQUIRE_FALSE(should_use_chunk_context(30, 10, -1.0f, false));
 }
 
-TEST_CASE("gate is purely a function of its three inputs", "[unit][chunk-context][issue-114]") {
-    // The gate must remain stateless / referentially transparent so the
-    // unit test stays trustworthy. Same inputs → same output, every time.
+TEST_CASE("gate is purely a function of its four inputs", "[unit][chunk-context][issue-114]") {
     for (int chunk_s : {0, 1, 5, 30, 120}) {
         for (std::size_t n : {std::size_t{0}, std::size_t{1}, std::size_t{2}, std::size_t{56}}) {
             for (float overlap : {-1.0f, 0.0f, 0.1f, 3.0f, 10.0f}) {
-                const bool a = should_use_chunk_context(chunk_s, n, overlap);
-                const bool b = should_use_chunk_context(chunk_s, n, overlap);
+                const bool a = should_use_chunk_context(chunk_s, n, overlap, false);
+                const bool b = should_use_chunk_context(chunk_s, n, overlap, false);
+                const bool vad = should_use_chunk_context(chunk_s, n, overlap, true);
                 REQUIRE(a == b);
-                // Cross-check against the closed-form gate.
+                REQUIRE_FALSE(vad);
+
                 const bool expected = (chunk_s > 0) && (n > 1) && (overlap > 0.0f);
                 REQUIRE(a == expected);
             }


### PR DESCRIPTION
## Summary

This PR fixes two subtitle regressions in the non-Whisper ASR dispatcher:

- VAD-derived slices could still enter the chunk-context/LCS trimming path, causing valid Japanese utterances to be merged or dropped.
- Granite beam-search results did not initialize segment timestamps, which could produce zero-duration SRT entries after downstream alignment/output processing.

The fix restores stable Japanese SRT output for Cohere, Granite Speech 4.1, Parakeet, FunASR, and SenseVoice test runs.

## Root Cause

### VAD slices were misclassified as chunked audio

The overlap-save chunk-context path is useful for fixed `--chunk-seconds` slicing because those slices are arbitrary cuts through continuous audio. It is not appropriate for VAD-derived slices, which already represent speech boundaries.

The existing gate only checked `effective_chunk_seconds > 0`. That was insufficient for backends such as Cohere, where the CLI fallback chunk size remains non-zero even when VAD produced the actual slices. As a result, VAD segments could still be extended with neighboring audio and then trimmed/deduplicated by LCS, collapsing valid subtitle segments.

### Granite beam-search segments had no timestamps

Granite's greedy path initialized segment start/end times from the input slice, but the beam-search path did not. When Granite ran through beam search, downstream subtitle and aligner logic could receive zero-initialized segment timing.

### Forced alignment accepted unusable spans

The dispatcher accepted any non-empty CTC alignment result. Some aligner outputs can contain words without a positive time span. Those results should not replace valid segment-level timing.

## Changes

- Add an explicit `vad_slicing` input to `should_use_chunk_context()`.
- Disable chunk-context/LCS overlap handling whenever slices came from VAD.
- Pass the dispatcher `wants_vad` state into the chunk-context gate.
- Initialize Granite beam-search segment `t0/t1` from the input audio slice.
- Preserve Granite beam-search token confidence metadata.
- Only apply forced-alignment timestamps when the returned words have a positive time span.
- Update chunk-context gate coverage for the case where VAD slicing is active but `effective_chunk_seconds` is still non-zero.

## Compatibility with #89 and #114

This does not revert the #89 chunk-overlap work. Overlap-save context and LCS stitching still run for real fixed-chunk processing, including explicit `--chunk-seconds` and the long-audio fallback path used when VAD is off.

The change only prevents VAD-derived slices from entering that path. That matches the #114 invariant: VAD slices are already speech-bounded segments, not arbitrary chunk boundaries, so they should not pull neighboring utterances into the decoder context or be LCS-deduplicated as if they were overlapping chunks.

In short:

- `--vad`: no chunk-context overlap, no chunk-boundary LCS dedup.
- `--chunk-seconds` / long-audio fallback without VAD: chunk-context overlap remains enabled.
- Valid CTC forced-alignment spans are still used; only non-positive alignment spans are ignored.

## Verification

Built successfully with:

```powershell
Y:\AI\ASR\CrispASR\build-vulkan.bat
```

Regression audio:

```text
Y:\AI\ASR\1-RJXXXXXX.mp3
```

### Before

On current `main`, the same Cohere Japanese + VAD regression case collapsed valid VAD-derived subtitle segments into a much smaller merged output:

```text
cohere-transcribe-ja-v0.1 + VAD
segments: 8
```

Granite Speech 4.1 with VAD and the Qwen3 forced aligner also produced repeated zero-duration subtitle timestamps:

```text
granite-speech-4.1-2b + VAD + Qwen3 forced aligner
zero-duration subtitle lines: 25
```

### After

With this patch and the rebuilt Vulkan CLI:

| Model | Exit | Segments | Zero-duration subtitle lines |
|---|---:|---:|---:|
| cohere-transcribe-ja-v0.1 + VAD | 0 | 33 | 0 |
| granite-speech-4.1-2b + VAD | 0 | 33 | 0 |
| granite-speech-4.1-2b + VAD + Qwen3 forced aligner | 0 | 36 | 0 |

### Broader Retest

Also retested the Japanese model set; all completed successfully with zero zero-duration subtitle lines:

| Model | Exit | Segments | Zero-duration subtitle lines |
|---|---:|---:|---:|
| cohere-transcribe-original + VAD | 0 | 33 | 0 |
| parakeet-tdt-0.6b-ja + VAD | 0 | 36 | 0 |
| funasr-nano + VAD | 0 | 91 | 0 |
| funasr-mlt-nano + VAD | 0 | 80 | 0 |
| sensevoice-small + VAD | 0 | 66 | 0 |

The Cohere Japanese VAD regression no longer collapses the file to a small number of merged segments, and Granite no longer emits zero-duration SRT timestamps in the tested paths.
