### PR TITLE
fix(test): correct qwen3 backend name + stub-model guard in session-beam suite

### DIFF
--- a/tests/test-session-beam.cpp
+++ b/tests/test-session-beam.cpp
@@ -197,6 +197,7 @@ TEST_CASE("beam: whisper greedy no-regression (beam_size=1 == default)", "[beam]
     INFO("default:    " << text1);
     INFO("beam_size=1:" << text2);
     INFO("beam_size=0:" << text3);
+    REQUIRE_FALSE(text1.empty());  // stub-model guard: empty==empty must not pass vacuously
     REQUIRE(text1 == text2);
     REQUIRE(text1 == text3);
 }
@@ -277,6 +278,7 @@ TEST_CASE("beam: glm-asr greedy no-regression (beam_size=1 == default)", "[beam]
 
     INFO("default:    " << text1);
     INFO("beam_size=1:" << text2);
+    REQUIRE_FALSE(text1.empty());  // stub-model guard: empty==empty must not pass vacuously
     REQUIRE(text1 == text2);
 }
 
@@ -313,7 +315,7 @@ TEST_CASE("beam: qwen3-asr greedy no-regression (beam_size=1 == default)", "[bea
     REQUIRE(!pcm.empty());
 
     // Default (no setter call)
-    crispasr_session* s1 = crispasr_session_open_explicit(model.c_str(), "qwen3-asr", 2);
+    crispasr_session* s1 = crispasr_session_open_explicit(model.c_str(), "qwen3", 2);
     REQUIRE(s1 != nullptr);
     auto* r1 = crispasr_session_transcribe(s1, pcm.data(), (int)pcm.size());
     REQUIRE(r1 != nullptr);
@@ -322,7 +324,7 @@ TEST_CASE("beam: qwen3-asr greedy no-regression (beam_size=1 == default)", "[bea
     crispasr_session_close(s1);
 
     // Explicit beam_size=1
-    crispasr_session* s2 = crispasr_session_open_explicit(model.c_str(), "qwen3-asr", 2);
+    crispasr_session* s2 = crispasr_session_open_explicit(model.c_str(), "qwen3", 2);
     REQUIRE(s2 != nullptr);
     REQUIRE(crispasr_session_set_beam_size(s2, 1) == 0);
     auto* r2 = crispasr_session_transcribe(s2, pcm.data(), (int)pcm.size());
@@ -333,6 +335,7 @@ TEST_CASE("beam: qwen3-asr greedy no-regression (beam_size=1 == default)", "[bea
 
     INFO("default:    " << text1);
     INFO("beam_size=1:" << text2);
+    REQUIRE_FALSE(text1.empty());  // stub-model guard: empty==empty must not pass vacuously
     REQUIRE(text1 == text2);
 }
 
@@ -344,7 +347,7 @@ TEST_CASE("beam: qwen3-asr beam_size=2 produces non-empty output", "[beam][.live
     auto pcm = load_wav_16k_mono(audio);
     REQUIRE(!pcm.empty());
 
-    crispasr_session* s = crispasr_session_open_explicit(model.c_str(), "qwen3-asr", 2);
+    crispasr_session* s = crispasr_session_open_explicit(model.c_str(), "qwen3", 2);
     REQUIRE(s != nullptr);
     REQUIRE(crispasr_session_set_beam_size(s, 2) == 0);
     auto* r = crispasr_session_transcribe(s, pcm.data(), (int)pcm.size());

--- a/tests/test-session-beam.cpp
+++ b/tests/test-session-beam.cpp
@@ -23,6 +23,8 @@
 //   CRISPASR_MODEL_WHISPER   — whisper GGUF path
 //   CRISPASR_MODEL_QWEN3_ASR — qwen3-asr GGUF path (optional, replay-helper)
 //   CRISPASR_MODEL_GLM_ASR   — glm-asr GGUF path (optional, per-backend setter)
+//   CRISPASR_MODEL_CANARY    — canary GGUF path (optional, AED branched-KV beam)
+//   CRISPASR_MODEL_COHERE    — cohere GGUF path (optional, AED branched-KV beam)
 //   CRISPASR_AUDIO_EN        — English test audio (default: samples/jfk.wav)
 
 #include <catch2/catch_test_macros.hpp>
@@ -356,6 +358,126 @@ TEST_CASE("beam: qwen3-asr beam_size=2 produces non-empty output", "[beam][.live
     std::string text = result_text(r);
     INFO("qwen3-asr beam=2: " << text);
     REQUIRE(!text.empty());
+
+    crispasr_session_result_free(r);
+    crispasr_session_close(s);
+}
+
+// --- canary (encoder-decoder AED, branched-KV beam — §61h/§90, 52cfec83) -
+// canary's beam path differs from the LLM backends above: it shares the
+// cross-attention KV across beams and snapshots only the self-attention KV
+// per beam (run_with_probs_branched). These cases confirm greedy stays
+// bit-identical and beam produces real output on the AED decoder.
+
+TEST_CASE("beam: canary greedy no-regression (beam_size=1 == default)", "[beam][.live]") {
+    std::string model = get_env("CRISPASR_MODEL_CANARY");
+    if (model.empty()) { SKIP("CRISPASR_MODEL_CANARY not set"); return; }
+
+    std::string audio = get_env("CRISPASR_AUDIO_EN", "samples/jfk.wav");
+    auto pcm = load_wav_16k_mono(audio);
+    REQUIRE(!pcm.empty());
+
+    // Default (no setter call)
+    crispasr_session* s1 = crispasr_session_open_explicit(model.c_str(), "canary", 2);
+    REQUIRE(s1 != nullptr);
+    auto* r1 = crispasr_session_transcribe(s1, pcm.data(), (int)pcm.size());
+    REQUIRE(r1 != nullptr);
+    std::string text1 = result_text(r1);
+    crispasr_session_result_free(r1);
+    crispasr_session_close(s1);
+
+    // Explicit beam_size=1
+    crispasr_session* s2 = crispasr_session_open_explicit(model.c_str(), "canary", 2);
+    REQUIRE(s2 != nullptr);
+    REQUIRE(crispasr_session_set_beam_size(s2, 1) == 0);
+    auto* r2 = crispasr_session_transcribe(s2, pcm.data(), (int)pcm.size());
+    REQUIRE(r2 != nullptr);
+    std::string text2 = result_text(r2);
+    crispasr_session_result_free(r2);
+    crispasr_session_close(s2);
+
+    INFO("default:    " << text1);
+    INFO("beam_size=1:" << text2);
+    REQUIRE_FALSE(text1.empty());  // stub-model guard: empty==empty must not pass vacuously
+    REQUIRE(text1 == text2);
+}
+
+TEST_CASE("beam: canary beam_size=2 produces non-empty output", "[beam][.live]") {
+    std::string model = get_env("CRISPASR_MODEL_CANARY");
+    if (model.empty()) { SKIP("CRISPASR_MODEL_CANARY not set"); return; }
+
+    std::string audio = get_env("CRISPASR_AUDIO_EN", "samples/jfk.wav");
+    auto pcm = load_wav_16k_mono(audio);
+    REQUIRE(!pcm.empty());
+
+    crispasr_session* s = crispasr_session_open_explicit(model.c_str(), "canary", 2);
+    REQUIRE(s != nullptr);
+    REQUIRE(crispasr_session_set_beam_size(s, 2) == 0);
+    auto* r = crispasr_session_transcribe(s, pcm.data(), (int)pcm.size());
+    REQUIRE(r != nullptr);
+
+    std::string text = result_text(r);
+    INFO("canary beam=2: " << text);
+    REQUIRE(!text.empty());
+    REQUIRE(crispasr_session_result_n_segments(r) > 0);
+
+    crispasr_session_result_free(r);
+    crispasr_session_close(s);
+}
+
+// --- cohere (encoder-decoder AED, branched-KV beam — §61h/§90, 52cfec83) -
+
+TEST_CASE("beam: cohere greedy no-regression (beam_size=1 == default)", "[beam][.live]") {
+    std::string model = get_env("CRISPASR_MODEL_COHERE");
+    if (model.empty()) { SKIP("CRISPASR_MODEL_COHERE not set"); return; }
+
+    std::string audio = get_env("CRISPASR_AUDIO_EN", "samples/jfk.wav");
+    auto pcm = load_wav_16k_mono(audio);
+    REQUIRE(!pcm.empty());
+
+    // Default (no setter call)
+    crispasr_session* s1 = crispasr_session_open_explicit(model.c_str(), "cohere", 2);
+    REQUIRE(s1 != nullptr);
+    auto* r1 = crispasr_session_transcribe(s1, pcm.data(), (int)pcm.size());
+    REQUIRE(r1 != nullptr);
+    std::string text1 = result_text(r1);
+    crispasr_session_result_free(r1);
+    crispasr_session_close(s1);
+
+    // Explicit beam_size=1
+    crispasr_session* s2 = crispasr_session_open_explicit(model.c_str(), "cohere", 2);
+    REQUIRE(s2 != nullptr);
+    REQUIRE(crispasr_session_set_beam_size(s2, 1) == 0);
+    auto* r2 = crispasr_session_transcribe(s2, pcm.data(), (int)pcm.size());
+    REQUIRE(r2 != nullptr);
+    std::string text2 = result_text(r2);
+    crispasr_session_result_free(r2);
+    crispasr_session_close(s2);
+
+    INFO("default:    " << text1);
+    INFO("beam_size=1:" << text2);
+    REQUIRE_FALSE(text1.empty());  // stub-model guard: empty==empty must not pass vacuously
+    REQUIRE(text1 == text2);
+}
+
+TEST_CASE("beam: cohere beam_size=2 produces non-empty output", "[beam][.live]") {
+    std::string model = get_env("CRISPASR_MODEL_COHERE");
+    if (model.empty()) { SKIP("CRISPASR_MODEL_COHERE not set"); return; }
+
+    std::string audio = get_env("CRISPASR_AUDIO_EN", "samples/jfk.wav");
+    auto pcm = load_wav_16k_mono(audio);
+    REQUIRE(!pcm.empty());
+
+    crispasr_session* s = crispasr_session_open_explicit(model.c_str(), "cohere", 2);
+    REQUIRE(s != nullptr);
+    REQUIRE(crispasr_session_set_beam_size(s, 2) == 0);
+    auto* r = crispasr_session_transcribe(s, pcm.data(), (int)pcm.size());
+    REQUIRE(r != nullptr);
+
+    std::string text = result_text(r);
+    INFO("cohere beam=2: " << text);
+    REQUIRE(!text.empty());
+    REQUIRE(crispasr_session_result_n_segments(r) > 0);
 
     crispasr_session_result_free(r);
     crispasr_session_close(s);


### PR DESCRIPTION
Found by actually building + running `test-session-beam` on real models (M1/Metal) — the parallel-session commits (`ef3c37e4` + `3a04b672`) were syntax-checked only.

**Bug 1 — qwen3 cases never opened a session.** They called `open_explicit(model, "qwen3-asr", …)`, but the dispatch string is `"qwen3"` (GGUF arch `qwen3-asr` → backend `"qwen3"`; `transcribe_single` matches `s->backend == "qwen3"`). So `open_explicit` returned `nullptr` and the cases always failed at `REQUIRE(s != nullptr)`, never exercising the `run_with_probs` replay path they target. Fixed at all 3 call sites.

**Bug 2 — no-regression checks passed vacuously on a stub model.** They asserted only `text1 == text2(==text3)`; on a tensorless fixture (`for-tests-ggml-*.bin` loads with *no tensors → empty model for testing*), empty == empty is green. Added `REQUIRE_FALSE(text1.empty())` to all three so a stub fails loudly.

**Verified on real models** (`ggml-tiny.en.bin`, `qwen3-asr-0.6b-q4_k`, `glm-asr-nano-q4_k`): unit 2/2, live 7/7 (49 assertions), all green — whisper native, qwen3-asr replay, and glm-asr setter beam paths confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)