### PR TITLE
Add Windows + AMD ROCm HIP build support & non utf-8 locale support for crispasr.exe

### DIFF
--- a/examples/cli/cli.cpp
+++ b/examples/cli/cli.cpp
@@ -1819,6 +1819,30 @@ int main(int argc, char** argv) {
     // are still encoded in the system's code page. In this way, we can print
     // non-ASCII characters to the console, and access files with non-ASCII paths.
     SetConsoleOutputCP(CP_UTF8);
+    // Convert argv from ANSI code page (e.g. GBK) to UTF-8
+    std::vector<std::string> _argv_utf8;
+    std::vector<char*> _argv_ptr;
+    _argv_utf8.reserve((size_t)argc); 
+    _argv_ptr.reserve((size_t)argc); 
+    for (int ai = 0; ai < argc; ai++) {
+        int wlen = MultiByteToWideChar(CP_ACP, 0, argv[ai], -1, nullptr, 0);
+        if (wlen > 1) {
+            std::wstring wbuf;
+            wbuf.resize((size_t)wlen);
+            MultiByteToWideChar(CP_ACP, 0, argv[ai], -1, &wbuf[0], wlen);
+            int ulen = WideCharToMultiByte(CP_UTF8, 0, wbuf.c_str(), -1, nullptr, 0, nullptr, nullptr);
+            if (ulen > 1) {
+                _argv_utf8.emplace_back((size_t)(ulen - 1), '\0');
+                WideCharToMultiByte(CP_UTF8, 0, wbuf.c_str(), -1, &_argv_utf8.back()[0], ulen, nullptr, nullptr);
+            } else {
+                _argv_utf8.push_back(argv[ai]);
+            }
+        } else {
+            _argv_utf8.push_back(argv[ai]);
+        }
+        _argv_ptr.push_back(&_argv_utf8.back()[0]);
+    }
+    argv = _argv_ptr.data();
 #endif
 
     whisper_params params;

--- a/ggml/src/ggml-cuda/vendors/hip.h
+++ b/ggml/src/ggml-cuda/vendors/hip.h
@@ -247,7 +247,11 @@ typedef __hip_bfloat162 nv_bfloat162;
 
 #if HIP_VERSION >= 60200000
 #include <hip/hip_fp8.h>
+#ifdef _WIN32
+typedef __hip_fp8_e4m3_fnuz __nv_fp8_e4m3; // Windows ROCm hip_fp8.h missing e4m3
+#else
 typedef __hip_fp8_e4m3 __nv_fp8_e4m3;
+#endif
 #define FP8_AVAILABLE
 #endif // HIP_VERSION >= 60200000
 

--- a/tests/test-issue-79.cpp
+++ b/tests/test-issue-79.cpp
@@ -2,7 +2,7 @@
 //
 // Reproduces #79: VibeVoice ASR crashes when transcribing a short buffer
 // followed by a longer buffer because the KV cache wasn't reallocated.
-
+#define _USE_MATH_DEFINES 
 #include "vibevoice.h"
 #include <vector>
 #include <iostream>


### PR DESCRIPTION
- Fix M_PI undefined: add _USE_MATH_DEFINES for MSVC compatibility
- Fix FP8 type: use fnuz for Windows ROCm hip_fp8.h
- Fix CLI: convert argv from ANSI code page to UTF-8 on Windows