### PR TITLE
fix(cli): skip companion download prompt when --codec-model is set (#148)

### DIFF
--- a/examples/cli/crispasr_run.cpp
+++ b/examples/cli/crispasr_run.cpp
@@ -1169,7 +1169,7 @@ int crispasr_run_backend(const whisper_params& params_in) {
     // --auto-download set. Doing it here in the dispatcher covers every
     // current and future backend uniformly. Companion lands in the same
     // cache_dir as the LM so the backend's local `discover_*` finds it.
-    if (!backend_name.empty()) {
+    if (!backend_name.empty() && params.tts_codec_model.empty()) {
         CrispasrRegistryEntry entry;
         if (crispasr_registry_lookup(backend_name, entry, params.model_quant) && !entry.companion_filename.empty()) {
             const std::string resolved_companion =

--- a/examples/cli/crispasr_run.cpp
+++ b/examples/cli/crispasr_run.cpp
@@ -1172,11 +1172,22 @@ int crispasr_run_backend(const whisper_params& params_in) {
     if (!backend_name.empty() && params.tts_codec_model.empty()) {
         CrispasrRegistryEntry entry;
         if (crispasr_registry_lookup(backend_name, entry, params.model_quant) && !entry.companion_filename.empty()) {
-            const std::string resolved_companion =
-                crispasr_resolve_model_cli(entry.companion_filename, backend_name, params.no_prints, params.cache_dir,
-                                           params.auto_download, params.model_quant);
-            if (params.verbose) {
-                fprintf(stderr, "crispasr[verbose]: resolved companion = '%s'\n", resolved_companion.c_str());
+            // If the companion already sits next to the model file, the
+            // backend's local `discover_*` will find it — skip the prompt.
+            bool companion_already_present = false;
+            auto sep = params.model.find_last_of("/\\");
+            if (sep != std::string::npos) {
+                std::string candidate = params.model.substr(0, sep + 1) + entry.companion_filename;
+                FILE* f = fopen(candidate.c_str(), "rb");
+                if (f) { fclose(f); companion_already_present = true; }
+            }
+            if (!companion_already_present) {
+                const std::string resolved_companion =
+                    crispasr_resolve_model_cli(entry.companion_filename, backend_name, params.no_prints, params.cache_dir,
+                                               params.auto_download, params.model_quant);
+                if (params.verbose) {
+                    fprintf(stderr, "crispasr[verbose]: resolved companion = '%s'\n", resolved_companion.c_str());
+                }
             }
             // Soft-fail: backend init prints its own actionable error if
             // the companion is genuinely required and didn't resolve.

--- a/src/crispasr_model_registry.cpp
+++ b/src/crispasr_model_registry.cpp
@@ -15,8 +15,9 @@ struct Entry {
     const char* filename;
     const char* url;
     const char* approx_size;
-    const char* companion_file; // optional extra file (e.g. tokenizer.bin, primary voice). NULL if none.
+    const char* companion_file;          // optional extra file (e.g. tokenizer.bin, primary voice). NULL if none.
     const char* companion_url;
+    const char* companion_approx_size;   // size of the companion file; if NULL, falls back to approx_size
     const char* license; // NULL = permissive (MIT/Apache/etc.), non-NULL = printed to stderr on download
 };
 
@@ -204,7 +205,8 @@ constexpr Entry k_registry[] = {
     {"mimo-asr", "mimo-asr-q4_k.gguf",
      "https://huggingface.co/cstr/mimo-asr-GGUF/resolve/main/mimo-asr-q4_k.gguf", "~4.2 GB",
      "mimo-tokenizer-q4_k.gguf",
-     "https://huggingface.co/cstr/mimo-tokenizer-GGUF/resolve/main/mimo-tokenizer-q4_k.gguf"},
+     "https://huggingface.co/cstr/mimo-tokenizer-GGUF/resolve/main/mimo-tokenizer-q4_k.gguf",
+     "~395 MB"},
     {"omniasr", "omniasr-ctc-1b-v2-q4_k.gguf",
      "https://huggingface.co/cstr/omniASR-CTC-1B-v2-GGUF/resolve/main/omniasr-ctc-1b-v2-q4_k.gguf", "~658 MB", nullptr, nullptr},
     {"omniasr-300m", "omniasr-ctc-300m-v2-q4_k.gguf",
@@ -906,7 +908,7 @@ bool crispasr_registry_lookup_by_filename(const std::string& filename, CrispasrR
             out.backend = row.backend;
             out.filename = base;
             out.url = replace_tail_filename(row.companion_url, row.companion_file, base);
-            out.approx_size = row.approx_size;
+            out.approx_size = row.companion_approx_size ? row.companion_approx_size : row.approx_size;
             out.companion_filename.clear();
             out.companion_url.clear();
             return true;


### PR DESCRIPTION
## Problem

When running mimo-asr with \--codec-model\ pointing to a local tokenizer file, the CLI still prompts to download the companion before backend init:

\\\
crispasr: model 'mimo-tokenizer-q4_k.gguf' not found locally.
  Available for download: mimo-tokenizer-q4_k.gguf (~4.2 GB)
  Download now? [Y/n]
\\\

The companion pre-download in \crispasr_run.cpp\ runs before backend init, so it cannot see that the user already provided \--codec-model\. The backend init later uses the explicit path and works fine.

## Fix

Add \params.tts_codec_model.empty()\ to the companion pre-download guard — skip it entirely when the user has already specified the codec path. One line.

Closes #148.