### PR TITLE
Support CUDA 13 by compiling against c++ 17 instead of c++ 11

### DIFF
--- a/cmake/DefaultTargetOptions.cmake
+++ b/cmake/DefaultTargetOptions.cmake
@@ -4,9 +4,14 @@ if (NOT TARGET)
     message(FATAL_ERROR "TARGET not set before including DefaultTargetOptions")
 endif()
 
+set(CRISPASR_CXX_STANDARD cxx_std_11)
+if (GGML_CUDA AND CUDAToolkit_VERSION VERSION_GREATER_EQUAL "13.0")
+    set(CRISPASR_CXX_STANDARD cxx_std_17)
+endif()
+
 target_compile_features(${TARGET}
     PRIVATE
-        cxx_std_11
+        ${CRISPASR_CXX_STANDARD}
     )
 
 set_target_properties(${TARGET}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -214,7 +214,12 @@ set_target_properties(crispasr-lib PROPERTIES
 )
 
 target_include_directories(crispasr-lib PUBLIC . ../include)
-target_compile_features   (crispasr-lib PUBLIC cxx_std_11) # don't bump
+
+set(CRISPASR_LIB_CXX_STANDARD cxx_std_11)
+if (GGML_CUDA AND CUDAToolkit_VERSION VERSION_GREATER_EQUAL "13.0")
+    set(CRISPASR_LIB_CXX_STANDARD cxx_std_17)
+endif()
+target_compile_features   (crispasr-lib PUBLIC ${CRISPASR_LIB_CXX_STANDARD}) # don't bump
 
 if (CMAKE_CXX_BYTE_ORDER STREQUAL "BIG_ENDIAN")
     target_compile_definitions(crispasr-lib PRIVATE CRISPASR_BIG_ENDIAN)


### PR DESCRIPTION
Hi @CrispStrobe,
  I am following the commit https://github.com/CrispStrobe/CrispASR/commit/02fdc3108945946e3ebb975356d121872829f460

I have changed the c++ version from c++ 111 to 17. As cuda 17 expects 17.

I verified that this fix works

```
./CrispASR/build/bin/crispasr \
  -m parakeet-tdt-0.6b-v3-q4_k.gguf \
  -f TranscriptionOffline/noisy_audio/audio_1.wav

```

```
crispasr 0.6.12 (git 4bdbc1d5, Release) [backends: cpu,cuda]
crispasr: auto-detected backend 'parakeet' from 'parakeet-tdt-0.6b-v3-q4_k.gguf'
ggml_cuda_init: found 1 CUDA devices (Total VRAM: 14912 MiB):
  Device 0: Tesla T4, compute capability 7.5, VMM: yes, VRAM: 14912 MiB
parakeet: vocab=8192  d_model=1024  n_layers=24  n_heads=8  ff=4096  pred=640  joint=640
parakeet: BN folded into conv_dw weights for 24 layers
crispasr: audio: 205760 samples (12.9 s) @ 16000 Hz, 2 threads
crispasr[lid]: downloading https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-tiny.bin
######################################################################## 100.0%
whisper_init_from_file_with_params_no_state: loading model from '/root/.cache/crispasr/ggml-tiny.bin'
whisper_init_with_params_no_state: use gpu    = 1
whisper_init_with_params_no_state: flash attn = 1
whisper_init_with_params_no_state: gpu_device = 0
whisper_init_with_params_no_state: dtw        = 0
whisper_init_with_params_no_state: devices    = 2
whisper_init_with_params_no_state: backends   = 2
whisper_model_load: loading model
whisper_model_load: n_vocab       = 51865
whisper_model_load: n_audio_ctx   = 1500
whisper_model_load: n_audio_state = 384
whisper_model_load: n_audio_head  = 6
whisper_model_load: n_audio_layer = 4
whisper_model_load: n_text_ctx    = 448
whisper_model_load: n_text_state  = 384
whisper_model_load: n_text_head   = 6
whisper_model_load: n_text_layer  = 4
whisper_model_load: n_mels        = 80
whisper_model_load: ftype         = 1
whisper_model_load: qntvr         = 0
whisper_model_load: type          = 1 (tiny)
whisper_model_load: adding 1608 extra tokens
whisper_model_load: n_langs       = 99
whisper_model_load:        CUDA0 total size =    77.11 MB
whisper_model_load: model size    =   77.11 MB
whisper_backend_init_gpu: device 0: CUDA0 (type: 1)
whisper_backend_init_gpu: found GPU device 0: CUDA0 (type: 1, cnt: 0)
whisper_backend_init_gpu: using CUDA0 backend
whisper_init_state: kv self size  =    3.15 MB
whisper_init_state: kv cross size =    9.44 MB
whisper_init_state: kv pad  size  =    2.36 MB
whisper_init_state: compute buffer (conv)   =   15.87 MB
whisper_init_state: compute buffer (encode) =   17.98 MB
whisper_init_state: compute buffer (cross)  =    4.16 MB
whisper_init_state: compute buffer (decode) =   97.09 MB
crispasr[lid]: detected 'en' (p=0.162) via whisper
crispasr: LID -> language = 'en' (whisper, p=0.162)
crispasr: parakeet backend — full-audio / library-internal streaming (use --chunk-seconds N if OOM, --vad for long files)
crispasr: transcribed 12.9s audio in 9.07s (1.4x realtime)
Okay, quality 4091, Rosnia Tower, Information Lima, QH 1014, Time Check 37, Cleet Oliage, Balto for Alpha Departure, Initial Clan 5,000 Ft and Scope 1000.
```


 