### PR TITLE
feat(espeak): bundle espeak-ng via FetchContent when system lib not found

### DIFF
--- a/examples/cli/crispasr_backend_piper.cpp
+++ b/examples/cli/crispasr_backend_piper.cpp
@@ -47,8 +47,8 @@ public:
             return false;
         }
 
-        // Apply voice/language override
-        if (!p.language.empty()) {
+        // Apply voice/language override (skip "auto" — not a valid espeak voice)
+        if (!p.language.empty() && p.language != "auto") {
             piper_tts_set_language(ctx_, p.language.c_str());
         }
 

--- a/examples/cli/crispasr_backend_piper.cpp
+++ b/examples/cli/crispasr_backend_piper.cpp
@@ -52,6 +52,11 @@ public:
             piper_tts_set_language(ctx_, p.language.c_str());
         }
 
+        if (!piper_tts_has_espeak()) {
+            fprintf(stderr, "piper: warning: espeak-ng not found; text input requires IPA phonemes.\n"
+                            "       Install espeak-ng for automatic text-to-phoneme conversion.\n");
+        }
+
         return true;
     }
 
@@ -74,11 +79,23 @@ public:
         float* pcm = nullptr;
         int sr = 0;
 
-        // Try full text→phoneme→synth first; if espeak-ng is unavailable
-        // fall back to treating the input as pre-phonemised IPA.
+        // Try full text→phoneme→synth first (requires espeak-ng).
         int n = piper_tts_synthesize(ctx_, text.c_str(), &pcm, &sr);
         if (n <= 0 || !pcm) {
-            n = piper_tts_synthesize_phonemes(ctx_, text.c_str(), &pcm, &sr);
+            // Only fall back to phoneme synthesis if the input looks like
+            // IPA (contains non-ASCII characters typical of IPA notation).
+            // Raw English text fed as "IPA" produces garbage audio because
+            // ASCII letters map to arbitrary phoneme IDs.
+            bool has_ipa_chars = false;
+            for (unsigned char c : text) {
+                if (c >= 0x80) { has_ipa_chars = true; break; }
+            }
+            if (has_ipa_chars) {
+                n = piper_tts_synthesize_phonemes(ctx_, text.c_str(), &pcm, &sr);
+            } else {
+                fprintf(stderr, "piper: espeak-ng not available and input is not IPA phonemes.\n"
+                                "       Install espeak-ng or pass pre-phonemised IPA input.\n");
+            }
         }
         if (n <= 0 || !pcm)
             return {};

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -989,20 +989,25 @@ if(NOT MSVC)
     target_compile_options(kokoro PRIVATE -O3)
 endif()
 
-# Optional libespeak-ng linkage. When ON we replace the popen("espeak-ng …")
-# shell-out with a direct espeak_TextToPhonemes() call (saves ~30–50 ms per
-# call, removes the shell-quoting surface, works in sandboxed processes).
-# AUTO: link if pkg-config finds it OR if Homebrew layout is present;
-# otherwise silently fall back to the popen path.
+# Optional libespeak-ng linkage. Replaces the popen("espeak-ng …") shell-out
+# with a direct espeak_TextToPhonemes() call (saves ~30–50 ms per call,
+# removes the shell-quoting surface, works in sandboxed processes).
+#
+# AUTO (default): try system first (pkg-config / Homebrew); if not found,
+#   build from source via FetchContent so espeak-ng is always available.
+# ON:  same as AUTO (always builds from source if system not found).
+# OFF: disable completely — runtime falls back to popen(espeak-ng).
 set(CRISPASR_WITH_ESPEAK_NG "AUTO" CACHE STRING
-    "Link kokoro against libespeak-ng for in-process phonemization (AUTO/ON/OFF)")
+    "Link against libespeak-ng for in-process phonemization (AUTO/ON/OFF)")
 set_property(CACHE CRISPASR_WITH_ESPEAK_NG PROPERTY STRINGS "AUTO" "ON" "OFF")
 
 if(NOT CRISPASR_WITH_ESPEAK_NG STREQUAL "OFF")
     set(_espeak_found FALSE)
+    set(_espeak_bundled FALSE)
     set(_espeak_include "")
     set(_espeak_lib "")
 
+    # --- Try system espeak-ng first ---
     find_package(PkgConfig QUIET)
     if(PkgConfig_FOUND)
         pkg_check_modules(ESPEAK_NG QUIET espeak-ng)
@@ -1027,16 +1032,61 @@ if(NOT CRISPASR_WITH_ESPEAK_NG STREQUAL "OFF")
         endif()
     endif()
 
+    # --- Bundled build from source via FetchContent ---
+    if(NOT _espeak_found)
+        message(STATUS "espeak-ng: system library not found, building from source")
+        include(FetchContent)
+        set(BUILD_SHARED_LIBS_SAVED ${BUILD_SHARED_LIBS})
+        set(BUILD_SHARED_LIBS OFF CACHE BOOL "" FORCE)
+        set(COMPILE_INTONATIONS ON CACHE BOOL "" FORCE)
+        set(ENABLE_TESTS OFF CACHE BOOL "" FORCE)
+        set(USE_MBROLA OFF CACHE BOOL "" FORCE)
+        set(USE_LIBPCAUDIO OFF CACHE BOOL "" FORCE)
+        set(USE_ASYNC OFF CACHE BOOL "" FORCE)
+        set(USE_KLATT OFF CACHE BOOL "" FORCE)
+        set(USE_SPEECHPLAYER OFF CACHE BOOL "" FORCE)
+        FetchContent_Declare(espeak-ng
+            GIT_REPOSITORY https://github.com/espeak-ng/espeak-ng.git
+            GIT_TAG        1.52.0
+            GIT_SHALLOW    TRUE
+        )
+        FetchContent_MakeAvailable(espeak-ng)
+        set(BUILD_SHARED_LIBS ${BUILD_SHARED_LIBS_SAVED} CACHE BOOL "" FORCE)
+
+        # espeak-ng's "espeak-include" INTERFACE target exports include/compat
+        # which contains a wchar.h that shadows the system header, breaking
+        # C++ compilation. Strip that directory from the interface includes;
+        # espeak-ng's own C sources already add it via BEFORE PRIVATE.
+        get_target_property(_ei_dirs espeak-include INTERFACE_INCLUDE_DIRECTORIES)
+        list(FILTER _ei_dirs EXCLUDE REGEX "compat")
+        set_target_properties(espeak-include PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${_ei_dirs}")
+
+        set(_espeak_found TRUE)
+        set(_espeak_bundled TRUE)
+        set(_espeak_lib espeak-ng)
+        set(_espeak_include ${espeak-ng_SOURCE_DIR}/src/include)
+        # The bundled build compiles phoneme data into
+        # ${espeak-ng_BINARY_DIR}/espeak-ng-data/. espeak_Initialize expects
+        # the PARENT directory (it appends /espeak-ng-data itself).
+        set(_espeak_data_path "${espeak-ng_BINARY_DIR}")
+        message(STATUS "espeak-ng: bundled build, data at ${_espeak_data_path}")
+    endif()
+
     if(_espeak_found)
         target_compile_definitions(kokoro PRIVATE CRISPASR_HAVE_ESPEAK_NG=1)
         target_include_directories(kokoro PRIVATE ${_espeak_include})
         if(_espeak_libdir)
-            target_link_directories(kokoro PUBLIC ${_espeak_libdir})
+            target_link_directories(kokoro PRIVATE ${_espeak_libdir})
         endif()
-        target_link_libraries(kokoro PUBLIC ${_espeak_lib})
+        # PRIVATE: don't leak espeak-ng's compat/ headers (wchar.h shadow)
+        # into downstream targets like crispasr-lib.
+        target_link_libraries(kokoro PRIVATE ${_espeak_lib})
+        if(_espeak_bundled)
+            target_compile_definitions(kokoro PRIVATE
+                "CRISPASR_ESPEAK_DATA_PATH=\"${_espeak_data_path}\"")
+            add_dependencies(kokoro data)
+        endif()
         message(STATUS "kokoro: libespeak-ng enabled (in-process phonemizer)")
-    elseif(CRISPASR_WITH_ESPEAK_NG STREQUAL "ON")
-        message(FATAL_ERROR "CRISPASR_WITH_ESPEAK_NG=ON but libespeak-ng not found. Install espeak-ng or set OFF.")
     else()
         message(STATUS "kokoro: libespeak-ng not found, falling back to popen(espeak-ng) at runtime")
     endif()
@@ -1207,9 +1257,14 @@ if(_espeak_found)
     target_compile_definitions(piper-tts PRIVATE CRISPASR_HAVE_ESPEAK_NG=1)
     target_include_directories(piper-tts PRIVATE ${_espeak_include})
     if(_espeak_libdir)
-        target_link_directories(piper-tts PUBLIC ${_espeak_libdir})
+        target_link_directories(piper-tts PRIVATE ${_espeak_libdir})
     endif()
-    target_link_libraries(piper-tts PUBLIC ${_espeak_lib})
+    target_link_libraries(piper-tts PRIVATE ${_espeak_lib})
+    if(_espeak_bundled)
+        target_compile_definitions(piper-tts PRIVATE
+            "CRISPASR_ESPEAK_DATA_PATH=\"${_espeak_data_path}\"")
+        add_dependencies(piper-tts data)
+    endif()
     message(STATUS "piper-tts: libespeak-ng enabled")
 endif()
 

--- a/src/kokoro.cpp
+++ b/src/kokoro.cpp
@@ -2913,6 +2913,10 @@ bool phonemize_espeak_lib(const std::string& lang, const std::string& text, std:
         // sandboxed apps and on systems where espeak-ng-data isn't in the
         // standard location).
         const char* path = std::getenv("CRISPASR_ESPEAK_DATA_PATH");
+#ifdef CRISPASR_ESPEAK_DATA_PATH
+        // Bundled build: use the compiled-in data path as fallback
+        if (!path) path = CRISPASR_ESPEAK_DATA_PATH;
+#endif
         int sr = espeak_Initialize(AUDIO_OUTPUT_SYNCHRONOUS, 0, path,
                                    espeakINITIALIZE_PHONEME_IPA | espeakINITIALIZE_DONT_EXIT);
         if (sr < 0) {

--- a/src/piper_tts.cpp
+++ b/src/piper_tts.cpp
@@ -195,10 +195,15 @@ static bool phonemize_espeak(const std::string& voice, const std::string& text, 
         return false;
     if (!g_piper_espeak_inited) {
         const char* data_path = getenv("CRISPASR_ESPEAK_DATA_PATH");
+#ifdef CRISPASR_ESPEAK_DATA_PATH
+        // Bundled build: use the compiled-in data path as fallback
+        if (!data_path) data_path = CRISPASR_ESPEAK_DATA_PATH;
+#endif
         int sr = espeak_Initialize(AUDIO_OUTPUT_SYNCHRONOUS, 0, data_path,
                                    espeakINITIALIZE_PHONEME_IPA | espeakINITIALIZE_DONT_EXIT);
         if (sr < 0) {
-            fprintf(stderr, "piper_tts: espeak_Initialize failed (rc=%d)\n", sr);
+            fprintf(stderr, "piper_tts: espeak_Initialize failed (rc=%d, path=%s)\n",
+                    sr, data_path ? data_path : "<default>");
             g_piper_espeak_init_failed = true;
             return false;
         }

--- a/src/piper_tts.cpp
+++ b/src/piper_tts.cpp
@@ -2199,6 +2199,29 @@ const char* piper_tts_espeak_voice(const struct piper_tts_context* ctx) {
     return ctx ? ctx->espeak_voice.c_str() : "en-us";
 }
 
+bool piper_tts_has_espeak(void) {
+#ifdef CRISPASR_HAVE_ESPEAK_NG
+    return true;
+#else
+    // Check if espeak-ng binary is on $PATH
+#ifdef _WIN32
+    FILE* fp = _popen("espeak-ng --version 2>NUL", "r");
+#else
+    FILE* fp = popen("espeak-ng --version 2>/dev/null", "r");
+#endif
+    if (!fp)
+        return false;
+    char buf[128];
+    bool ok = fgets(buf, sizeof(buf), fp) != nullptr;
+#ifdef _WIN32
+    _pclose(fp);
+#else
+    pclose(fp);
+#endif
+    return ok;
+#endif
+}
+
 void piper_tts_set_dump_dir(struct piper_tts_context* ctx, const char* dir) {
     if (ctx && dir)
         ctx->dump_dir = dir;

--- a/src/piper_tts.h
+++ b/src/piper_tts.h
@@ -65,6 +65,9 @@ int piper_tts_sample_rate(const struct piper_tts_context* ctx);
 int piper_tts_num_speakers(const struct piper_tts_context* ctx);
 const char* piper_tts_espeak_voice(const struct piper_tts_context* ctx);
 
+// Returns true if espeak-ng phonemization is available (linked or in $PATH).
+bool piper_tts_has_espeak(void);
+
 // Diff harness: dump all intermediates to this directory (empty = no dump).
 void piper_tts_set_dump_dir(struct piper_tts_context* ctx, const char* dir);
 


### PR DESCRIPTION
## Summary

- When libespeak-ng is not installed, CMake now auto-fetches and builds espeak-ng 1.52.0 from source via FetchContent
- Gives piper + kokoro in-process phonemization without requiring system espeak-ng installation
- Fixes segfault when default language="auto" was passed to espeak_SetVoiceByName()
- Wires up bundled build data path so espeak-ng finds its compiled phoneme/dict data

## Bugs fixed

1. `espeak_SetVoiceByName("auto")` segfault — the default CLI language "auto" was passed through to espeak-ng, which doesn't handle it
2. espeak-ng compat `wchar.h` header shadow — stripped from INTERFACE includes to prevent breaking downstream C++ compilation
3. Missing data path for bundled builds — `CRISPASR_ESPEAK_DATA_PATH` compiled-in fallback

## Test plan

- [x] Plain English text → piper TTS → whisper ASR roundtrip: "Hello world"
- [x] "This audio was generated by artificial intelligence" — the original failing phrase from the handover
- [x] "The quick brown fox jumps over the lazy dog"
- [ ] Verify system espeak-ng is still preferred when available (pkg-config probe)
- [ ] Verify kokoro TTS with bundled espeak-ng

🤖 Generated with [Claude Code](https://claude.com/claude-code)