### PR TITLE
conv1d transpose: efficient decomposed mul_mat + col2im_1d (~9× codec speedup)

### DIFF
--- a/ggml/include/ggml.h
+++ b/ggml/include/ggml.h
@@ -527,6 +527,7 @@ extern "C" {
         GGML_OP_ROPE_BACK,
         GGML_OP_CLAMP,
         GGML_OP_CONV_TRANSPOSE_1D,
+        GGML_OP_COL2IM_1D,
         GGML_OP_IM2COL,
         GGML_OP_IM2COL_BACK,
         GGML_OP_IM2COL_3D,
@@ -2065,6 +2066,17 @@ extern "C" {
             int                   s0,  // stride
             int                   p0,  // padding
             int                   d0); // dilation
+
+    // col2im_1d: gather columns → 1D signal (ConvTranspose1d decomp).
+    //   col: [K*OC, T_in]  F32/F16/BF16 — GEMM output (mul_mat of pre-permuted weight)
+    //   Output: [T_out, OC] F32  where T_out = (T_in-1)*s0 + K - p0
+    //   op_params: [s0=stride, OC, p0=left_crop]
+    GGML_API struct ggml_tensor * ggml_col2im_1d(
+            struct ggml_context * ctx,
+            struct ggml_tensor  * col, // [K*OC, T_in]
+            int                   s0,  // stride
+            int                   oc,  // output channels (= K*OC / K)
+            int                   p0); // left offset / pre-crop
 
     // CrispASR patch (PR #07-metal-aa-snake-beta): BigVGAN v2 anti-aliased
     // SnakeBeta — fused upsample 2× + sin²(α·x)/β + downsample 2×.

--- a/ggml/src/ggml-cpu/ggml-cpu.c
+++ b/ggml/src/ggml-cpu/ggml-cpu.c
@@ -1900,6 +1900,10 @@ static void ggml_compute_forward(struct ggml_compute_params * params, struct ggm
             {
                 ggml_compute_forward_conv_transpose_1d(params, tensor);
             } break;
+        case GGML_OP_COL2IM_1D:
+            {
+                ggml_compute_forward_col2im_1d(params, tensor);
+            } break;
         // CrispASR patch (PR #07-metal-aa-snake-beta) — MUST RE-APPLY after ggml bump.
         case GGML_OP_AA_SNAKE_BETA:
             {
@@ -2351,6 +2355,7 @@ static int ggml_get_n_tasks(struct ggml_tensor * node, int n_threads) {
         case GGML_OP_CONV_3D:
         case GGML_OP_CONV_2D_DW:
         case GGML_OP_CONV_TRANSPOSE_1D:
+        case GGML_OP_COL2IM_1D:
         case GGML_OP_CONV_TRANSPOSE_2D:
         // CrispASR patch (PR #07-metal-aa-snake-beta) — MUST RE-APPLY after ggml bump.
         case GGML_OP_AA_SNAKE_BETA:
@@ -2884,6 +2889,9 @@ struct ggml_cplan ggml_graph_plan(
                             GGML_ABORT("fatal error");
                         }
                     } break;
+                case GGML_OP_COL2IM_1D:
+                    // no work buffer needed — gather-only kernel
+                    break;
                 case GGML_OP_CONV_2D:
                 case GGML_OP_CONV_3D:
                     {

--- a/ggml/src/ggml-cpu/ops.cpp
+++ b/ggml/src/ggml-cpu/ops.cpp
@@ -6376,8 +6376,8 @@ static void ggml_compute_forward_col2im_1d_f32(
 
     if (ir0 >= ir1) return;
 
-    const float * __restrict__ cp = (const float *)col->data;
-    float       * __restrict__ dp = (float *)      dst->data;
+    const float * GGML_RESTRICT cp = (const float *)col->data;
+    float       * GGML_RESTRICT dp = (float *)      dst->data;
 
     for (int gidx = ir0; gidx < ir1; gidx++) {
         const int t_out = gidx % T_out;

--- a/ggml/src/ggml-cpu/ops.cpp
+++ b/ggml/src/ggml-cpu/ops.cpp
@@ -5126,7 +5126,7 @@ static void ggml_compute_forward_soft_max_ext_back_f32(const ggml_compute_params
             assert(!isnan(y[i]));
         }
 #endif // NDEBUG
-    // Jii = yi - yi*yi                                                                                                \
+        // Jii = yi - yi*yi                                                                                                \
     // Jij = -yi*yj                                                                                                    \
     // J = diag(y)-y.T*y                                                                                               \
     // dx = J * dy                                                                                                     \

--- a/ggml/src/ggml-cpu/ops.cpp
+++ b/ggml/src/ggml-cpu/ops.cpp
@@ -6342,6 +6342,77 @@ void ggml_compute_forward_conv_transpose_1d(
     }
 }
 
+// ggml_compute_forward_col2im_1d
+//
+// Gather-based col2im: each output position (t_out, oc) loops over its
+// contributing input columns and sums the pre-computed (oc, k) entries.
+// Matches the CUDA kernel in col2im-1d.cu bit-for-bit so GPU/CPU results
+// are interchangeable.
+static void ggml_compute_forward_col2im_1d_f32(
+        const ggml_compute_params * params,
+              ggml_tensor * dst) {
+
+    const ggml_tensor * col = dst->src[0];
+
+    GGML_ASSERT(col->type == GGML_TYPE_F32);
+    GGML_ASSERT(dst->type == GGML_TYPE_F32);
+
+    const int32_t s0 = ((const int32_t *)(dst->op_params))[0];
+    const int32_t OC = ((const int32_t *)(dst->op_params))[1];
+    const int32_t p0 = ((const int32_t *)(dst->op_params))[2];
+
+    const int K_OC = (int)col->ne[0];
+    const int T_in = (int)col->ne[1];
+    const int K    = K_OC / OC;
+    const int T_out = (int)dst->ne[0];
+
+    const int ith = params->ith;
+    const int nth = params->nth;
+
+    const int total  = T_out * OC;
+    const int dr     = (total + nth - 1) / nth;
+    const int ir0    = dr * ith;
+    const int ir1    = ir0 + dr < total ? ir0 + dr : total;
+
+    if (ir0 >= ir1) return;
+
+    const float * __restrict__ cp = (const float *)col->data;
+    float       * __restrict__ dp = (float *)      dst->data;
+
+    for (int gidx = ir0; gidx < ir1; gidx++) {
+        const int t_out = gidx % T_out;
+        const int oc    = gidx / T_out;
+        const int t_abs = t_out + p0;
+
+        int t_in_min = (t_abs - K + s0) / s0;
+        if (t_in_min < 0) t_in_min = 0;
+        int t_in_max = t_abs / s0;
+        if (t_in_max >= T_in) t_in_max = T_in - 1;
+
+        float sum = 0.0f;
+        for (int t_in = t_in_min; t_in <= t_in_max; t_in++) {
+            const int j = t_abs - t_in * s0;
+            sum += cp[(oc * K + j) + t_in * K_OC];
+        }
+        dp[gidx] = sum;
+    }
+}
+
+void ggml_compute_forward_col2im_1d(
+        const ggml_compute_params * params,
+              ggml_tensor * dst) {
+
+    const ggml_tensor * col = dst->src[0];
+
+    switch (col->type) {
+        case GGML_TYPE_F32:
+            ggml_compute_forward_col2im_1d_f32(params, dst);
+            break;
+        default:
+            GGML_ABORT("col2im_1d: unsupported type");
+    }
+}
+
 // ggml_compute_forward_aa_snake_beta
 //
 // CrispASR patch (PR #07-metal-aa-snake-beta): fused BigVGAN v2 anti-aliased

--- a/ggml/src/ggml-cpu/ops.cpp
+++ b/ggml/src/ggml-cpu/ops.cpp
@@ -5126,24 +5126,26 @@ static void ggml_compute_forward_soft_max_ext_back_f32(const ggml_compute_params
             assert(!isnan(y[i]));
         }
 #endif // NDEBUG
-        // Jii = yi - yi*yi                                                                                                \
-    // Jij = -yi*yj                                                                                                    \
-    // J = diag(y)-y.T*y                                                                                               \
-    // dx = J * dy                                                                                                     \
-    // dxk = sum_i(Jki * dyi)                                                                                          \
-    // dxk = sum_i(-yk*yi * dyi) - (-yk*yk)*dyk + (yk - yk*yk)*dyk                                                     \
-    // dxk = sum_i(-yk*yi * dyi) + yk*yk*dyk + yk*dyk - yk*yk*dyk                                                      \
-    // dxk = sum_i(-yk*yi * dyi) + yk*dyk                                                                              \
-    // dxk = -yk * sum_i(yi * dyi) + yk*dyk                                                                            \
-    // dxk = -yk * dot(y, dy) + yk*dyk                                                                                 \
-    // dxk = yk * (- dot(y, dy) + dyk)                                                                                 \
-    // dxk = yk * (dyk - dot(y, dy))                                                                                   \
-    //                                                                                                                 \
-    // post-order:                                                                                                     \
-    // dot_y_dy := dot(y, dy)                                                                                          \
-    // dx := dy                                                                                                        \
-    // dx := dx - dot_y_dy                                                                                             \
-    // dx := dx * y
+        /*
+         * Jii = yi - yi*yi
+         * Jij = -yi*yj
+         * J = diag(y)-y.T*y
+         * dx = J * dy
+         * dxk = sum_i(Jki * dyi)
+         * dxk = sum_i(-yk*yi * dyi) - (-yk*yk)*dyk + (yk - yk*yk)*dyk
+         * dxk = sum_i(-yk*yi * dyi) + yk*yk*dyk + yk*dyk - yk*yk*dyk
+         * dxk = sum_i(-yk*yi * dyi) + yk*dyk
+         * dxk = -yk * sum_i(yi * dyi) + yk*dyk
+         * dxk = -yk * dot(y, dy) + yk*dyk
+         * dxk = yk * (- dot(y, dy) + dyk)
+         * dxk = yk * (dyk - dot(y, dy))
+         *
+         * post-order:
+         * dot_y_dy := dot(y, dy)
+         * dx := dy
+         * dx := dx - dot_y_dy
+         * dx := dx * y
+         */
 
         // linear runtime, no additional memory
         float dot_y_dy = 0;

--- a/ggml/src/ggml-cpu/ops.cpp
+++ b/ggml/src/ggml-cpu/ops.cpp
@@ -15,11 +15,8 @@
 
 // ggml_compute_forward_dup
 
-static void ggml_compute_forward_dup_same_cont(
-        const ggml_compute_params * params,
-        ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
+static void ggml_compute_forward_dup_same_cont(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
 
     GGML_ASSERT(ggml_nelements(dst) == ggml_nelements(src0));
     GGML_ASSERT(ggml_is_contiguous(dst) && ggml_is_contiguous(src0));
@@ -31,25 +28,19 @@ static void ggml_compute_forward_dup_same_cont(
     const int nth = params->nth; // number of threads
 
     // parallelize by blocks
-    const int nk = ggml_nelements(src0)/ggml_blck_size(src0->type);
+    const int nk = ggml_nelements(src0) / ggml_blck_size(src0->type);
     const int dr = (nk + nth - 1) / nth;
     const int k0 = dr * ith;
     const int k1 = MIN(k0 + dr, nk);
 
     if (k0 < k1) {
-        memcpy(
-            ((char *)  dst->data + k0*nb0),
-            ((char *) src0->data + k0*nb0),
-            (k1 - k0) * nb0);
+        memcpy(((char*)dst->data + k0 * nb0), ((char*)src0->data + k0 * nb0), (k1 - k0) * nb0);
     }
 }
 
-template<typename src_t, typename dst_t>
-static void ggml_compute_forward_dup_flt(
-        const ggml_compute_params * params,
-        ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
+template <typename src_t, typename dst_t>
+static void ggml_compute_forward_dup_flt(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
 
     GGML_ASSERT(ggml_nelements(dst) == ggml_nelements(src0));
     GGML_ASSERT(!ggml_is_quantized(src0->type) && !ggml_is_quantized(dst->type));
@@ -68,18 +59,15 @@ static void ggml_compute_forward_dup_flt(
     const int ir1 = MIN(ir0 + dr, nr);
 
     // case: type & row size equal
-    if (src0->type == dst->type &&
-        ne00 == ne0 &&
-        nb00 == ggml_type_size(src0->type) && nb0 == ggml_type_size(dst->type)) {
+    if (src0->type == dst->type && ne00 == ne0 && nb00 == ggml_type_size(src0->type) &&
+        nb0 == ggml_type_size(dst->type)) {
         // copy by rows
-        const size_t rs = ne00*nb00;
+        const size_t rs = ne00 * nb00;
         for (int64_t i03 = 0; i03 < ne03; i03++) {
             for (int64_t i02 = 0; i02 < ne02; i02++) {
                 for (int64_t i01 = ir0; i01 < ir1; i01++) {
-                    memcpy(
-                        ((char *)  dst->data + i01*nb1  + i02*nb2  + i03*nb3),
-                        ((char *) src0->data + i01*nb01 + i02*nb02 + i03*nb03),
-                        rs);
+                    memcpy(((char*)dst->data + i01 * nb1 + i02 * nb2 + i03 * nb3),
+                           ((char*)src0->data + i01 * nb01 + i02 * nb02 + i03 * nb03), rs);
                 }
             }
         }
@@ -93,13 +81,13 @@ static void ggml_compute_forward_dup_flt(
                 // same type
                 size_t id = 0;
                 const size_t rs = ne00 * nb00;
-                char * dst_ptr = (char *) dst->data;
+                char* dst_ptr = (char*)dst->data;
 
                 for (int i03 = 0; i03 < ne03; i03++) {
                     for (int i02 = 0; i02 < ne02; i02++) {
                         id += rs * ir0;
                         for (int i01 = ir0; i01 < ir1; i01++) {
-                            const char * src0_ptr = (char *) src0->data + i01*nb01 + i02*nb02 + i03*nb03;
+                            const char* src0_ptr = (char*)src0->data + i01 * nb01 + i02 * nb02 + i03 * nb03;
                             memcpy(dst_ptr + id, src0_ptr, rs);
                             id += rs;
                         }
@@ -109,13 +97,13 @@ static void ggml_compute_forward_dup_flt(
             } else {
                 // casting between non-quantized types
                 size_t id = 0;
-                dst_t * dst_ptr = (dst_t *) dst->data;
+                dst_t* dst_ptr = (dst_t*)dst->data;
 
                 for (int i03 = 0; i03 < ne03; i03++) {
                     for (int i02 = 0; i02 < ne02; i02++) {
                         id += ne00 * ir0;
                         for (int i01 = ir0; i01 < ir1; i01++) {
-                            const src_t * src0_ptr = (src_t *) ((char *) src0->data + i01*nb01 + i02*nb02 + i03*nb03);
+                            const src_t* src0_ptr = (src_t*)((char*)src0->data + i01 * nb01 + i02 * nb02 + i03 * nb03);
                             for (int i00 = 0; i00 < ne00; i00++) {
                                 float tmp = type_conversion_table<src_t>::to_f32(src0_ptr[i00]);
                                 dst_ptr[id] = type_conversion_table<dst_t>::from_f32(tmp);
@@ -130,14 +118,15 @@ static void ggml_compute_forward_dup_flt(
             //printf("%s: this is not optimal - fix me\n", __func__);
 
             size_t id = 0;
-            dst_t * dst_ptr = (dst_t *) dst->data;
+            dst_t* dst_ptr = (dst_t*)dst->data;
 
             for (int i03 = 0; i03 < ne03; i03++) {
                 for (int i02 = 0; i02 < ne02; i02++) {
                     id += ne00 * ir0;
                     for (int i01 = ir0; i01 < ir1; i01++) {
                         for (int i00 = 0; i00 < ne00; i00++) {
-                            const src_t * src0_ptr = (src_t *) ((char *) src0->data + i00*nb00 + i01*nb01 + i02*nb02 + i03*nb03);
+                            const src_t* src0_ptr =
+                                (src_t*)((char*)src0->data + i00 * nb00 + i01 * nb01 + i02 * nb02 + i03 * nb03);
 
                             float tmp = type_conversion_table<src_t>::to_f32(*src0_ptr);
                             dst_ptr[id] = type_conversion_table<dst_t>::from_f32(tmp);
@@ -175,8 +164,8 @@ static void ggml_compute_forward_dup_flt(
                 }
                 for (int64_t i01 = ir0; i01 < ir1; i01++) {
                     for (int64_t i00 = 0; i00 < ne00; i00++) {
-                        const char * src0_ptr = ((char *) src0->data + i00*nb00 + i01*nb01 + i02*nb02 + i03*nb03);
-                              char * dst_ptr  = ((char *)  dst->data + i10*nb0  + i11*nb1  + i12*nb2  + i13*nb3);
+                        const char* src0_ptr = ((char*)src0->data + i00 * nb00 + i01 * nb01 + i02 * nb02 + i03 * nb03);
+                        char* dst_ptr = ((char*)dst->data + i10 * nb0 + i11 * nb1 + i12 * nb2 + i13 * nb3);
 
                         memcpy(dst_ptr, src0_ptr, sizeof(dst_t));
 
@@ -228,11 +217,11 @@ static void ggml_compute_forward_dup_flt(
                 }
                 for (int64_t i01 = ir0; i01 < ir1; i01++) {
                     for (int64_t i00 = 0; i00 < ne00; i00++) {
-                        const char * src0_ptr = ((char *) src0->data + i00*nb00 + i01*nb01 + i02*nb02 + i03*nb03);
-                              char * dst_ptr  = ((char *)  dst->data + i10*nb0  + i11*nb1  + i12*nb2  + i13*nb3);
+                        const char* src0_ptr = ((char*)src0->data + i00 * nb00 + i01 * nb01 + i02 * nb02 + i03 * nb03);
+                        char* dst_ptr = ((char*)dst->data + i10 * nb0 + i11 * nb1 + i12 * nb2 + i13 * nb3);
 
-                        float tmp = type_conversion_table<src_t>::to_f32(*(const src_t *) src0_ptr);
-                        *(dst_t *) dst_ptr = type_conversion_table<dst_t>::from_f32(tmp);
+                        float tmp = type_conversion_table<src_t>::to_f32(*(const src_t*)src0_ptr);
+                        *(dst_t*)dst_ptr = type_conversion_table<dst_t>::from_f32(tmp);
 
                         if (++i10 == ne0) {
                             i10 = 0;
@@ -267,12 +256,9 @@ static void ggml_compute_forward_dup_flt(
 }
 
 
-template<typename src_t>
-static void ggml_compute_forward_dup_to_q(
-        const ggml_compute_params * params,
-        ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
+template <typename src_t>
+static void ggml_compute_forward_dup_to_q(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
 
     GGML_ASSERT(ggml_nelements(dst) == ggml_nelements(src0));
     GGML_ASSERT(!ggml_is_quantized(src0->type));
@@ -290,22 +276,20 @@ static void ggml_compute_forward_dup_to_q(
     const int ir0 = dr * ith;
     const int ir1 = MIN(ir0 + dr, nr);
 
-    if (ggml_is_contiguous(dst) &&
-            nb00 == sizeof(src_t) &&
-            ggml_get_type_traits_cpu(dst->type)->from_float) {
+    if (ggml_is_contiguous(dst) && nb00 == sizeof(src_t) && ggml_get_type_traits_cpu(dst->type)->from_float) {
         // casting non-quantized types --> intermediate f32 --> quantized
         ggml_from_float_t const quantize_row_q = ggml_get_type_traits_cpu(dst->type)->from_float;
-        float * src0_f32 = (float *) params->wdata + (ne00 + CACHE_LINE_SIZE_F32) * ith;
+        float* src0_f32 = (float*)params->wdata + (ne00 + CACHE_LINE_SIZE_F32) * ith;
 
         size_t id = 0;
         size_t rs = nb0 * (ne00 / ggml_blck_size(dst->type));
-        char * dst_ptr = (char *) dst->data;
+        char* dst_ptr = (char*)dst->data;
 
         for (int i03 = 0; i03 < ne03; i03++) {
             for (int i02 = 0; i02 < ne02; i02++) {
                 id += rs * ir0;
                 for (int i01 = ir0; i01 < ir1; i01++) {
-                    const src_t * src0_ptr = (src_t *) ((char *) src0->data + i01*nb01 + i02*nb02 + i03*nb03);
+                    const src_t* src0_ptr = (src_t*)((char*)src0->data + i01 * nb01 + i02 * nb02 + i03 * nb03);
 
                     for (int i00 = 0; i00 < ne00; i00++) {
                         src0_f32[i00] = type_conversion_table<src_t>::to_f32(src0_ptr[i00]);
@@ -324,10 +308,8 @@ static void ggml_compute_forward_dup_to_q(
 }
 
 // A simplified version of ggml_compute_forward_dup that doesn't do float upcasting, and just plain old memcpy.
-static void ggml_compute_forward_dup_bytes(
-        const ggml_compute_params * params,
-        ggml_tensor * dst) {
-    const ggml_tensor * src0 = dst->src[0];
+static void ggml_compute_forward_dup_bytes(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
 
     GGML_ASSERT(ggml_nelements(dst) == ggml_nelements(src0));
     GGML_ASSERT(src0->type == dst->type);
@@ -352,18 +334,14 @@ static void ggml_compute_forward_dup_bytes(
     const int ir0 = dr * ith;
     const int ir1 = MIN(ir0 + dr, nr);
 
-    if (src0->type == dst->type &&
-        ggml_are_same_shape(src0, dst) &&
-        nb00 == type_size && nb0 == type_size) {
+    if (src0->type == dst->type && ggml_are_same_shape(src0, dst) && nb00 == type_size && nb0 == type_size) {
         // copy by rows
         const size_t rs = ggml_row_size(src0->type, ne00);
         for (int64_t i03 = 0; i03 < ne03; i03++) {
             for (int64_t i02 = 0; i02 < ne02; i02++) {
                 for (int64_t i01 = ir0; i01 < ir1; i01++) {
-                    memcpy(
-                        ((char *)  dst->data + i01*nb1  + i02*nb2  + i03*nb3),
-                        ((char *) src0->data + i01*nb01 + i02*nb02 + i03*nb03),
-                        rs);
+                    memcpy(((char*)dst->data + i01 * nb1 + i02 * nb2 + i03 * nb3),
+                           ((char*)src0->data + i01 * nb01 + i02 * nb02 + i03 * nb03), rs);
                 }
             }
         }
@@ -372,7 +350,7 @@ static void ggml_compute_forward_dup_bytes(
 
     if (ggml_is_contiguous(dst)) {
         size_t id = 0;
-        char * dst_ptr = (char *) dst->data;
+        char* dst_ptr = (char*)dst->data;
         const size_t rs = ne00 * type_size;
 
         if (nb00 == type_size) {
@@ -381,7 +359,7 @@ static void ggml_compute_forward_dup_bytes(
                 for (int64_t i02 = 0; i02 < ne02; i02++) {
                     id += rs * ir0;
                     for (int64_t i01 = ir0; i01 < ir1; i01++) {
-                        const char * src0_ptr = (char *) src0->data + i01*nb01 + i02*nb02 + i03*nb03;
+                        const char* src0_ptr = (char*)src0->data + i01 * nb01 + i02 * nb02 + i03 * nb03;
                         memcpy(dst_ptr + id, src0_ptr, rs);
                         id += rs;
                     }
@@ -396,7 +374,8 @@ static void ggml_compute_forward_dup_bytes(
                     id += rs * ir0;
                     for (int64_t i01 = ir0; i01 < ir1; i01++) {
                         for (int64_t i00 = 0; i00 < ne00; i00++) {
-                            const char * src0_ptr = (char *) src0->data + i00*nb00 + i01*nb01 + i02*nb02 + i03*nb03;
+                            const char* src0_ptr =
+                                (char*)src0->data + i00 * nb00 + i01 * nb01 + i02 * nb02 + i03 * nb03;
                             memcpy(dst_ptr + id, src0_ptr, type_size);
 
                             id += type_size;
@@ -418,7 +397,7 @@ static void ggml_compute_forward_dup_bytes(
 
     // number of blocks in a row
     const int64_t nk00 = ne00 / ggml_blck_size(src0->type);
-    const int64_t nk0  = ne0  / ggml_blck_size(dst->type);
+    const int64_t nk0 = ne0 / ggml_blck_size(dst->type);
 
     for (int64_t i03 = 0; i03 < ne03; i03++) {
         for (int64_t i02 = 0; i02 < ne02; i02++) {
@@ -437,8 +416,8 @@ static void ggml_compute_forward_dup_bytes(
             }
             for (int64_t i01 = ir0; i01 < ir1; i01++) {
                 for (int64_t k00 = 0; k00 < nk00; k00++) {
-                    const char * src0_ptr = ((char *) src0->data + k00*nb00 + i01*nb01 + i02*nb02 + i03*nb03);
-                          char * dst_ptr  = ((char *)  dst->data + k10*nb0  + i11*nb1  + i12*nb2  + i13*nb3);
+                    const char* src0_ptr = ((char*)src0->data + k00 * nb00 + i01 * nb01 + i02 * nb02 + i03 * nb03);
+                    char* dst_ptr = ((char*)dst->data + k10 * nb0 + i11 * nb1 + i12 * nb2 + i13 * nb3);
 
                     memcpy(dst_ptr, src0_ptr, type_size);
 
@@ -473,12 +452,9 @@ static void ggml_compute_forward_dup_bytes(
     }
 }
 
-static void ggml_compute_forward_dup_from_q(
-        const ggml_compute_params * params,
-              ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
-    const ggml_tensor * src1 = dst->src[1];
+static void ggml_compute_forward_dup_from_q(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
+    const ggml_tensor* src1 = dst->src[1];
 
     GGML_TENSOR_BINARY_OP_LOCALS
 
@@ -496,39 +472,33 @@ static void ggml_compute_forward_dup_from_q(
     const int ith = params->ith;
     const int nth = params->nth;
 
-    const int dr = (nr + nth - 1)/nth;
+    const int dr = (nr + nth - 1) / nth;
 
     // row range for this thread
-    const int ir0 = dr*ith;
+    const int ir0 = dr * ith;
     const int ir1 = MIN(ir0 + dr, nr);
 
     for (int64_t ir = ir0; ir < ir1; ++ir) {
-
         uint32_t i = ir * qk;
 
-        const int64_t i03 = i/(ne00 * ne01 * ne02);
-        const int64_t i02 = (i - i03*ne00*ne01*ne02 )/ (ne00*ne01);
-        const int64_t i01 = (i - i03*ne00*ne01*ne02  -  i02*ne01*ne00) / ne00;
-        const int64_t i00 = i - i03*ne00*ne01*ne02 - i02*ne01*ne00 - i01*ne00;
-        const int64_t x_offset = (i00/qk)*nb00 + i01*nb01 + i02*nb02 + i03 * nb03;
+        const int64_t i03 = i / (ne00 * ne01 * ne02);
+        const int64_t i02 = (i - i03 * ne00 * ne01 * ne02) / (ne00 * ne01);
+        const int64_t i01 = (i - i03 * ne00 * ne01 * ne02 - i02 * ne01 * ne00) / ne00;
+        const int64_t i00 = i - i03 * ne00 * ne01 * ne02 - i02 * ne01 * ne00 - i01 * ne00;
+        const int64_t x_offset = (i00 / qk) * nb00 + i01 * nb01 + i02 * nb02 + i03 * nb03;
 
-        const int64_t i13 = i/(ne10 * ne11 * ne12);
-        const int64_t i12 = (i - i13*ne10*ne11*ne12) / (ne10*ne11);
-        const int64_t i11 = (i - i13*ne10*ne11*ne12 - i12*ne10*ne11) / ne10;
-        const int64_t i10 = i - i13*ne10*ne11*ne12 - i12*ne10*ne11 - i11*ne10;
-        const int64_t dst_offset = i10*nb10 + i11*nb11 + i12*nb12 + i13*nb13;
+        const int64_t i13 = i / (ne10 * ne11 * ne12);
+        const int64_t i12 = (i - i13 * ne10 * ne11 * ne12) / (ne10 * ne11);
+        const int64_t i11 = (i - i13 * ne10 * ne11 * ne12 - i12 * ne10 * ne11) / ne10;
+        const int64_t i10 = i - i13 * ne10 * ne11 * ne12 - i12 * ne10 * ne11 - i11 * ne10;
+        const int64_t dst_offset = i10 * nb10 + i11 * nb11 + i12 * nb12 + i13 * nb13;
 
-        dequantize_row_q(
-                (const void *) ((char *) src0->data + x_offset),
-                     (float *) ((char *)  dst->data + dst_offset), qk);
+        dequantize_row_q((const void*)((char*)src0->data + x_offset), (float*)((char*)dst->data + dst_offset), qk);
     }
 }
 
-void ggml_compute_forward_dup(
-        const ggml_compute_params * params,
-        ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
+void ggml_compute_forward_dup(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
 
     if (src0->type == dst->type) {
         ggml_compute_forward_dup_bytes(params, dst);
@@ -536,56 +506,63 @@ void ggml_compute_forward_dup(
     }
 
     switch (src0->type) {
-        case GGML_TYPE_F16:
-            {
-                /**/ if (dst->type == GGML_TYPE_F16)  ggml_compute_forward_dup_flt<ggml_fp16_t, ggml_fp16_t>(params, dst);
-                else if (dst->type == GGML_TYPE_BF16) ggml_compute_forward_dup_flt<ggml_fp16_t, ggml_bf16_t>(params, dst);
-                else if (dst->type == GGML_TYPE_F32)  ggml_compute_forward_dup_flt<ggml_fp16_t, float      >(params, dst);
-                else ggml_compute_forward_dup_to_q<ggml_fp16_t>(params, dst);
-            } break;
-        case GGML_TYPE_BF16:
-            {
-                /**/ if (dst->type == GGML_TYPE_F16)  ggml_compute_forward_dup_flt<ggml_bf16_t, ggml_fp16_t>(params, dst);
-                else if (dst->type == GGML_TYPE_BF16) ggml_compute_forward_dup_flt<ggml_bf16_t, ggml_bf16_t>(params, dst);
-                else if (dst->type == GGML_TYPE_F32)  ggml_compute_forward_dup_flt<ggml_bf16_t, float      >(params, dst);
-                else ggml_compute_forward_dup_to_q<ggml_bf16_t>(params, dst);
-            } break;
-        case GGML_TYPE_F32:
-            {
-                /**/ if (dst->type == GGML_TYPE_F16)  ggml_compute_forward_dup_flt<float, ggml_fp16_t>(params, dst);
-                else if (dst->type == GGML_TYPE_BF16) ggml_compute_forward_dup_flt<float, ggml_bf16_t>(params, dst);
-                else if (dst->type == GGML_TYPE_F32)  ggml_compute_forward_dup_flt<float, float      >(params, dst);
-                else if (dst->type == GGML_TYPE_I32)  ggml_compute_forward_dup_flt<float, int32_t    >(params, dst);
-                else ggml_compute_forward_dup_to_q<float>(params, dst);
-            } break;
-        case GGML_TYPE_I32:
-            {
-                if (dst->type == GGML_TYPE_F32) ggml_compute_forward_dup_flt<int32_t, float>(params, dst);
-                else GGML_ABORT("not implemented");
-            } break;
-        default:
-            {
-                if (ggml_is_quantized(src0->type) && dst->type == GGML_TYPE_F32) {
-                    ggml_compute_forward_dup_from_q(params, dst);
-                    break;
-                }
-                GGML_ABORT("fatal error");
-            }
+    case GGML_TYPE_F16: {
+        /**/ if (dst->type == GGML_TYPE_F16)
+            ggml_compute_forward_dup_flt<ggml_fp16_t, ggml_fp16_t>(params, dst);
+        else if (dst->type == GGML_TYPE_BF16)
+            ggml_compute_forward_dup_flt<ggml_fp16_t, ggml_bf16_t>(params, dst);
+        else if (dst->type == GGML_TYPE_F32)
+            ggml_compute_forward_dup_flt<ggml_fp16_t, float>(params, dst);
+        else
+            ggml_compute_forward_dup_to_q<ggml_fp16_t>(params, dst);
+    } break;
+    case GGML_TYPE_BF16: {
+        /**/ if (dst->type == GGML_TYPE_F16)
+            ggml_compute_forward_dup_flt<ggml_bf16_t, ggml_fp16_t>(params, dst);
+        else if (dst->type == GGML_TYPE_BF16)
+            ggml_compute_forward_dup_flt<ggml_bf16_t, ggml_bf16_t>(params, dst);
+        else if (dst->type == GGML_TYPE_F32)
+            ggml_compute_forward_dup_flt<ggml_bf16_t, float>(params, dst);
+        else
+            ggml_compute_forward_dup_to_q<ggml_bf16_t>(params, dst);
+    } break;
+    case GGML_TYPE_F32: {
+        /**/ if (dst->type == GGML_TYPE_F16)
+            ggml_compute_forward_dup_flt<float, ggml_fp16_t>(params, dst);
+        else if (dst->type == GGML_TYPE_BF16)
+            ggml_compute_forward_dup_flt<float, ggml_bf16_t>(params, dst);
+        else if (dst->type == GGML_TYPE_F32)
+            ggml_compute_forward_dup_flt<float, float>(params, dst);
+        else if (dst->type == GGML_TYPE_I32)
+            ggml_compute_forward_dup_flt<float, int32_t>(params, dst);
+        else
+            ggml_compute_forward_dup_to_q<float>(params, dst);
+    } break;
+    case GGML_TYPE_I32: {
+        if (dst->type == GGML_TYPE_F32)
+            ggml_compute_forward_dup_flt<int32_t, float>(params, dst);
+        else
+            GGML_ABORT("not implemented");
+    } break;
+    default: {
+        if (ggml_is_quantized(src0->type) && dst->type == GGML_TYPE_F32) {
+            ggml_compute_forward_dup_from_q(params, dst);
+            break;
+        }
+        GGML_ABORT("fatal error");
+    }
     }
 }
 
 // ggml_compute_forward_add
 
-static void ggml_compute_forward_add_q_f32(
-        const ggml_compute_params * params,
-        ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
-    const ggml_tensor * src1 = dst->src[1];
+static void ggml_compute_forward_add_q_f32(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
+    const ggml_tensor* src1 = dst->src[1];
 
     GGML_ASSERT(ggml_are_same_shape(src0, src1) && ggml_are_same_shape(src0, dst));
 
-    const int nr  = ggml_nrows(src0);
+    const int nr = ggml_nrows(src0);
 
     GGML_TENSOR_BINARY_OP_LOCALS
 
@@ -610,19 +587,19 @@ static void ggml_compute_forward_add_q_f32(
     GGML_ASSERT(src1->type == GGML_TYPE_F32);
 
     // rows per thread
-    const int dr = (nr + nth - 1)/nth;
+    const int dr = (nr + nth - 1) / nth;
 
     // row range for this thread
-    const int ir0 = dr*ith;
+    const int ir0 = dr * ith;
     const int ir1 = MIN(ir0 + dr, nr);
 
-    float * wdata = (float *) params->wdata + (ne00 + CACHE_LINE_SIZE_F32) * ith;
+    float* wdata = (float*)params->wdata + (ne00 + CACHE_LINE_SIZE_F32) * ith;
 
     for (int ir = ir0; ir < ir1; ++ir) {
         // src0 indices
-        const int i03 = ir/(ne02*ne01);
-        const int i02 = (ir - i03*ne02*ne01)/ne01;
-        const int i01 = (ir - i03*ne02*ne01 - i02*ne01);
+        const int i03 = ir / (ne02 * ne01);
+        const int i02 = (ir - i03 * ne02 * ne01) / ne01;
+        const int i01 = (ir - i03 * ne02 * ne01 - i02 * ne01);
 
         // src1 and dst are same shape as src0 => same indices
         const int i13 = i03;
@@ -633,9 +610,9 @@ static void ggml_compute_forward_add_q_f32(
         const int i2 = i02;
         const int i1 = i01;
 
-        void  * src0_row = (void *) ((char *) src0->data + (i01*nb01 + i02*nb02 + i03*nb03));
-        float * src1_row = (float *)((char *) src1->data + (i11*nb11 + i12*nb12 + i13*nb13));
-        void  * dst_row  = (void *) ((char *)  dst->data + ( i1*nb1  +  i2*nb2  +  i3*nb3));
+        void* src0_row = (void*)((char*)src0->data + (i01 * nb01 + i02 * nb02 + i03 * nb03));
+        float* src1_row = (float*)((char*)src1->data + (i11 * nb11 + i12 * nb12 + i13 * nb13));
+        void* dst_row = (void*)((char*)dst->data + (i1 * nb1 + i2 * nb2 + i3 * nb3));
 
         assert(ne00 % 32 == 0);
 
@@ -647,69 +624,60 @@ static void ggml_compute_forward_add_q_f32(
         if (quantize_row_q != NULL) {
             quantize_row_q(wdata, dst_row, ne00);
         } else {
-            memcpy(dst_row, wdata, ne0*nb0);
+            memcpy(dst_row, wdata, ne0 * nb0);
         }
     }
 }
 
-void ggml_compute_forward_add(
-        const ggml_compute_params * params,
-        ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
+void ggml_compute_forward_add(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
 
     switch (src0->type) {
-        case GGML_TYPE_F32:
-        case GGML_TYPE_F16:
-        case GGML_TYPE_BF16:
-            {
-                ggml_compute_forward_add_non_quantized(params, dst);
-            } break;
-        case GGML_TYPE_Q1_0:
-        case GGML_TYPE_Q4_0:
-        case GGML_TYPE_Q4_1:
-        case GGML_TYPE_Q5_0:
-        case GGML_TYPE_Q5_1:
-        case GGML_TYPE_Q8_0:
-        case GGML_TYPE_MXFP4:
-        case GGML_TYPE_NVFP4:
-        case GGML_TYPE_Q2_K:
-        case GGML_TYPE_Q3_K:
-        case GGML_TYPE_Q4_K:
-        case GGML_TYPE_Q5_K:
-        case GGML_TYPE_Q6_K:
-        case GGML_TYPE_TQ1_0:
-        case GGML_TYPE_TQ2_0:
-        case GGML_TYPE_IQ2_XXS:
-        case GGML_TYPE_IQ2_XS:
-        case GGML_TYPE_IQ3_XXS:
-        case GGML_TYPE_IQ1_S:
-        case GGML_TYPE_IQ1_M:
-        case GGML_TYPE_IQ4_NL:
-        case GGML_TYPE_IQ4_XS:
-        case GGML_TYPE_IQ3_S:
-        case GGML_TYPE_IQ2_S:
-            {
-                ggml_compute_forward_add_q_f32(params, dst);
-            } break;
-        default:
-            {
-                GGML_ABORT("fatal error");
-            }
+    case GGML_TYPE_F32:
+    case GGML_TYPE_F16:
+    case GGML_TYPE_BF16: {
+        ggml_compute_forward_add_non_quantized(params, dst);
+    } break;
+    case GGML_TYPE_Q1_0:
+    case GGML_TYPE_Q4_0:
+    case GGML_TYPE_Q4_1:
+    case GGML_TYPE_Q5_0:
+    case GGML_TYPE_Q5_1:
+    case GGML_TYPE_Q8_0:
+    case GGML_TYPE_MXFP4:
+    case GGML_TYPE_NVFP4:
+    case GGML_TYPE_Q2_K:
+    case GGML_TYPE_Q3_K:
+    case GGML_TYPE_Q4_K:
+    case GGML_TYPE_Q5_K:
+    case GGML_TYPE_Q6_K:
+    case GGML_TYPE_TQ1_0:
+    case GGML_TYPE_TQ2_0:
+    case GGML_TYPE_IQ2_XXS:
+    case GGML_TYPE_IQ2_XS:
+    case GGML_TYPE_IQ3_XXS:
+    case GGML_TYPE_IQ1_S:
+    case GGML_TYPE_IQ1_M:
+    case GGML_TYPE_IQ4_NL:
+    case GGML_TYPE_IQ4_XS:
+    case GGML_TYPE_IQ3_S:
+    case GGML_TYPE_IQ2_S: {
+        ggml_compute_forward_add_q_f32(params, dst);
+    } break;
+    default: {
+        GGML_ABORT("fatal error");
+    }
     }
 }
 
 // ggml_compute_forward_add_id
 
-static void ggml_compute_forward_add_id_f32(
-        const ggml_compute_params * params,
-        ggml_tensor * dst) {
+static void ggml_compute_forward_add_id_f32(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
+    const ggml_tensor* src1 = dst->src[1];
+    const ggml_tensor* src2 = dst->src[2];
 
-    const ggml_tensor * src0 = dst->src[0];
-    const ggml_tensor * src1 = dst->src[1];
-    const ggml_tensor * src2 = dst->src[2];
-
-    GGML_ASSERT(dst->type  == GGML_TYPE_F32);
+    GGML_ASSERT(dst->type == GGML_TYPE_F32);
     GGML_ASSERT(src0->type == GGML_TYPE_F32);
     GGML_ASSERT(src1->type == GGML_TYPE_F32);
     GGML_ASSERT(src2->type == GGML_TYPE_I32);
@@ -720,64 +688,55 @@ static void ggml_compute_forward_add_id_f32(
     const int ith = params->ith;
     const int nth = params->nth;
 
-    const int nr  = ggml_nrows(src0);
+    const int nr = ggml_nrows(src0);
 
     GGML_TENSOR_TERNARY_OP_LOCALS
 
-    GGML_ASSERT( nb0 == sizeof(float));
+    GGML_ASSERT(nb0 == sizeof(float));
     GGML_ASSERT(nb10 == sizeof(float));
 
     // rows per thread
-    const int dr = (nr + nth - 1)/nth;
+    const int dr = (nr + nth - 1) / nth;
 
     // row range for this thread
-    const int ir0 = dr*ith;
+    const int ir0 = dr * ith;
     const int ir1 = MIN(ir0 + dr, nr);
 
     for (int ir = ir0; ir < ir1; ++ir) {
         // src0 indices
-        const int i3 = ir/(ne2*ne1);
-        const int i2 = (ir - i3*ne2*ne1)/ne1;
-        const int i1 = (ir - i3*ne2*ne1 - i2*ne1);
+        const int i3 = ir / (ne2 * ne1);
+        const int i2 = (ir - i3 * ne2 * ne1) / ne1;
+        const int i1 = (ir - i3 * ne2 * ne1 - i2 * ne1);
 
         // src1 indices
-        const int i11 = *(int32_t *) ((char *) src2->data + i1*nb20 + i2*nb21);
+        const int i11 = *(int32_t*)((char*)src2->data + i1 * nb20 + i2 * nb21);
 
         GGML_ASSERT(i11 >= 0 && i11 < ne11);
 
-        ggml_vec_add_f32(ne0,
-                (float *) ((char *) dst->data  + i3*nb3  + i2*nb2  + i1*nb1 ),
-                (float *) ((char *) src0->data + i3*nb03 + i2*nb02 + i1*nb01),
-                (float *) ((char *) src1->data + i11*nb11));
+        ggml_vec_add_f32(ne0, (float*)((char*)dst->data + i3 * nb3 + i2 * nb2 + i1 * nb1),
+                         (float*)((char*)src0->data + i3 * nb03 + i2 * nb02 + i1 * nb01),
+                         (float*)((char*)src1->data + i11 * nb11));
     }
 }
 
-void ggml_compute_forward_add_id(
-        const ggml_compute_params * params,
-        ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
+void ggml_compute_forward_add_id(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
 
     switch (src0->type) {
-        case GGML_TYPE_F32:
-            {
-                ggml_compute_forward_add_id_f32(params, dst);
-            } break;
-        default:
-            {
-                GGML_ABORT("unsupported type for ggml_compute_forward_add_id: %s", ggml_type_name(src0->type));
-            }
+    case GGML_TYPE_F32: {
+        ggml_compute_forward_add_id_f32(params, dst);
+    } break;
+    default: {
+        GGML_ABORT("unsupported type for ggml_compute_forward_add_id: %s", ggml_type_name(src0->type));
+    }
     }
 }
 
 // ggml_compute_forward_add1
 
-static void ggml_compute_forward_add1_f32(
-        const ggml_compute_params * params,
-        ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
-    const ggml_tensor * src1 = dst->src[1];
+static void ggml_compute_forward_add1_f32(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
+    const ggml_tensor* src1 = dst->src[1];
 
     GGML_ASSERT(ggml_are_same_shape(src0, dst));
     GGML_ASSERT(ggml_is_scalar(src1));
@@ -785,156 +744,142 @@ static void ggml_compute_forward_add1_f32(
     const int ith = params->ith;
     const int nth = params->nth;
 
-    const int nr  = ggml_nrows(src0);
+    const int nr = ggml_nrows(src0);
 
     GGML_TENSOR_UNARY_OP_LOCALS
 
-    GGML_ASSERT( nb0 == sizeof(float));
+    GGML_ASSERT(nb0 == sizeof(float));
     GGML_ASSERT(nb00 == sizeof(float));
 
     // rows per thread
-    const int dr = (nr + nth - 1)/nth;
+    const int dr = (nr + nth - 1) / nth;
 
     // row range for this thread
-    const int ir0 = dr*ith;
+    const int ir0 = dr * ith;
     const int ir1 = MIN(ir0 + dr, nr);
 
     for (int ir = ir0; ir < ir1; ++ir) {
         // src0 and dst are same shape => same indices
-        const int i3 = ir/(ne2*ne1);
-        const int i2 = (ir - i3*ne2*ne1)/ne1;
-        const int i1 = (ir - i3*ne2*ne1 - i2*ne1);
+        const int i3 = ir / (ne2 * ne1);
+        const int i2 = (ir - i3 * ne2 * ne1) / ne1;
+        const int i1 = (ir - i3 * ne2 * ne1 - i2 * ne1);
 
 #ifdef GGML_USE_ACCELERATE
         GGML_UNUSED(ggml_vec_add1_f32);
 
-        vDSP_vadd(
-                (float *) ((char *) src0->data + i3*nb03 + i2*nb02 + i1*nb01), 1,
-                (float *) ((char *) src1->data), 0,
-                (float *) ((char *) dst->data  + i3*nb3  + i2*nb2  + i1*nb1 ), 1,
-                ne0);
+        vDSP_vadd((float*)((char*)src0->data + i3 * nb03 + i2 * nb02 + i1 * nb01), 1, (float*)((char*)src1->data), 0,
+                  (float*)((char*)dst->data + i3 * nb3 + i2 * nb2 + i1 * nb1), 1, ne0);
 #else
-        ggml_vec_add1_f32(ne0,
-                (float *) ((char *) dst->data  + i3*nb3  + i2*nb2  + i1*nb1 ),
-                (float *) ((char *) src0->data + i3*nb03 + i2*nb02 + i1*nb01),
-               *(float *) src1->data);
+        ggml_vec_add1_f32(ne0, (float*)((char*)dst->data + i3 * nb3 + i2 * nb2 + i1 * nb1),
+                          (float*)((char*)src0->data + i3 * nb03 + i2 * nb02 + i1 * nb01), *(float*)src1->data);
 #endif
     }
 }
 
-static void ggml_compute_forward_add1_f16_f32(
-        const ggml_compute_params * params,
-        ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
-    const ggml_tensor * src1 = dst->src[1];
+static void ggml_compute_forward_add1_f16_f32(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
+    const ggml_tensor* src1 = dst->src[1];
 
     GGML_ASSERT(ggml_are_same_shape(src0, dst));
     GGML_ASSERT(ggml_is_scalar(src1));
 
     // scalar to add
-    const float v = *(float *) src1->data;
+    const float v = *(float*)src1->data;
 
     const int ith = params->ith;
     const int nth = params->nth;
 
-    const int nr  = ggml_nrows(src0);
+    const int nr = ggml_nrows(src0);
 
     GGML_TENSOR_UNARY_OP_LOCALS
 
     GGML_ASSERT(src0->type == GGML_TYPE_F16);
     GGML_ASSERT(src1->type == GGML_TYPE_F32);
-    GGML_ASSERT(dst->type  == GGML_TYPE_F16);
+    GGML_ASSERT(dst->type == GGML_TYPE_F16);
 
-    GGML_ASSERT( nb0 == sizeof(ggml_fp16_t));
+    GGML_ASSERT(nb0 == sizeof(ggml_fp16_t));
     GGML_ASSERT(nb00 == sizeof(ggml_fp16_t));
 
     // rows per thread
-    const int dr = (nr + nth - 1)/nth;
+    const int dr = (nr + nth - 1) / nth;
 
     // row range for this thread
-    const int ir0 = dr*ith;
+    const int ir0 = dr * ith;
     const int ir1 = MIN(ir0 + dr, nr);
 
     for (int ir = ir0; ir < ir1; ++ir) {
         // src0 and dst are same shape => same indices
-        const int i3 = ir/(ne2*ne1);
-        const int i2 = (ir - i3*ne2*ne1)/ne1;
-        const int i1 = (ir - i3*ne2*ne1 - i2*ne1);
+        const int i3 = ir / (ne2 * ne1);
+        const int i2 = (ir - i3 * ne2 * ne1) / ne1;
+        const int i1 = (ir - i3 * ne2 * ne1 - i2 * ne1);
 
-        ggml_fp16_t * dst_ptr  = (ggml_fp16_t *) ((char *) dst->data  + i3*nb3  + i2*nb2  + i1*nb1 );
-        ggml_fp16_t * src0_ptr = (ggml_fp16_t *) ((char *) src0->data + i3*nb03 + i2*nb02 + i1*nb01);
+        ggml_fp16_t* dst_ptr = (ggml_fp16_t*)((char*)dst->data + i3 * nb3 + i2 * nb2 + i1 * nb1);
+        ggml_fp16_t* src0_ptr = (ggml_fp16_t*)((char*)src0->data + i3 * nb03 + i2 * nb02 + i1 * nb01);
         for (int i = 0; i < ne0; i++) {
             dst_ptr[i] = GGML_CPU_FP32_TO_FP16(GGML_CPU_FP16_TO_FP32(src0_ptr[i]) + v);
         }
     }
 }
 
-static void ggml_compute_forward_add1_f16_f16(
-        const ggml_compute_params * params,
-        ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
-    const ggml_tensor * src1 = dst->src[1];
+static void ggml_compute_forward_add1_f16_f16(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
+    const ggml_tensor* src1 = dst->src[1];
 
     GGML_ASSERT(ggml_are_same_shape(src0, dst));
     GGML_ASSERT(ggml_is_scalar(src1));
 
     // scalar to add
-    const float v = GGML_CPU_FP16_TO_FP32(*(ggml_fp16_t *) src1->data);
+    const float v = GGML_CPU_FP16_TO_FP32(*(ggml_fp16_t*)src1->data);
 
     const int ith = params->ith;
     const int nth = params->nth;
 
-    const int nr  = ggml_nrows(src0);
+    const int nr = ggml_nrows(src0);
 
     GGML_TENSOR_UNARY_OP_LOCALS
 
     GGML_ASSERT(src0->type == GGML_TYPE_F16);
     GGML_ASSERT(src1->type == GGML_TYPE_F16);
-    GGML_ASSERT(dst->type  == GGML_TYPE_F16);
+    GGML_ASSERT(dst->type == GGML_TYPE_F16);
 
-    GGML_ASSERT( nb0 == sizeof(ggml_fp16_t));
+    GGML_ASSERT(nb0 == sizeof(ggml_fp16_t));
     GGML_ASSERT(nb00 == sizeof(ggml_fp16_t));
 
     // rows per thread
-    const int dr = (nr + nth - 1)/nth;
+    const int dr = (nr + nth - 1) / nth;
 
     // row range for this thread
-    const int ir0 = dr*ith;
+    const int ir0 = dr * ith;
     const int ir1 = MIN(ir0 + dr, nr);
 
     for (int ir = ir0; ir < ir1; ++ir) {
         // src0 and dst are same shape => same indices
-        const int i3 = ir/(ne2*ne1);
-        const int i2 = (ir - i3*ne2*ne1)/ne1;
-        const int i1 = (ir - i3*ne2*ne1 - i2*ne1);
+        const int i3 = ir / (ne2 * ne1);
+        const int i2 = (ir - i3 * ne2 * ne1) / ne1;
+        const int i1 = (ir - i3 * ne2 * ne1 - i2 * ne1);
 
-        ggml_fp16_t * dst_ptr  = (ggml_fp16_t *) ((char *) dst->data  + i3*nb3  + i2*nb2  + i1*nb1 );
-        ggml_fp16_t * src0_ptr = (ggml_fp16_t *) ((char *) src0->data + i3*nb03 + i2*nb02 + i1*nb01);
+        ggml_fp16_t* dst_ptr = (ggml_fp16_t*)((char*)dst->data + i3 * nb3 + i2 * nb2 + i1 * nb1);
+        ggml_fp16_t* src0_ptr = (ggml_fp16_t*)((char*)src0->data + i3 * nb03 + i2 * nb02 + i1 * nb01);
         for (int i = 0; i < ne0; i++) {
             dst_ptr[i] = GGML_CPU_FP32_TO_FP16(GGML_CPU_FP16_TO_FP32(src0_ptr[i]) + v);
         }
     }
 }
 
-static void ggml_compute_forward_add1_q_f32(
-        const ggml_compute_params * params,
-        ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
-    const ggml_tensor * src1 = dst->src[1];
+static void ggml_compute_forward_add1_q_f32(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
+    const ggml_tensor* src1 = dst->src[1];
 
     GGML_ASSERT(ggml_are_same_shape(src0, dst));
     GGML_ASSERT(ggml_is_scalar(src1));
 
     // scalar to add
-    const float v = *(float *) src1->data;
+    const float v = *(float*)src1->data;
 
     const int ith = params->ith;
     const int nth = params->nth;
 
-    const int nr  = ggml_nrows(src0);
+    const int nr = ggml_nrows(src0);
 
     GGML_TENSOR_UNARY_OP_LOCALS
 
@@ -955,22 +900,22 @@ static void ggml_compute_forward_add1_q_f32(
     GGML_ASSERT(src1->type == GGML_TYPE_F32);
 
     // rows per thread
-    const int dr = (nr + nth - 1)/nth;
+    const int dr = (nr + nth - 1) / nth;
 
     // row range for this thread
-    const int ir0 = dr*ith;
+    const int ir0 = dr * ith;
     const int ir1 = MIN(ir0 + dr, nr);
 
-    float * wdata = (float *) params->wdata + (ne0 + CACHE_LINE_SIZE_F32) * ith;
+    float* wdata = (float*)params->wdata + (ne0 + CACHE_LINE_SIZE_F32) * ith;
 
     for (int ir = ir0; ir < ir1; ++ir) {
         // src0 and dst are same shape => same indices
-        const int i3 = ir/(ne2*ne1);
-        const int i2 = (ir - i3*ne2*ne1)/ne1;
-        const int i1 = (ir - i3*ne2*ne1 - i2*ne1);
+        const int i3 = ir / (ne2 * ne1);
+        const int i2 = (ir - i3 * ne2 * ne1) / ne1;
+        const int i1 = (ir - i3 * ne2 * ne1 - i2 * ne1);
 
-        void  * src0_row = (void *) ((char *) src0->data + (i1*nb01 + i2*nb02 + i3*nb03));
-        void  * dst_row  = (void *) ((char *)  dst->data + (i1*nb1  + i2*nb2  + i3*nb0 ));
+        void* src0_row = (void*)((char*)src0->data + (i1 * nb01 + i2 * nb02 + i3 * nb03));
+        void* dst_row = (void*)((char*)dst->data + (i1 * nb1 + i2 * nb2 + i3 * nb0));
 
         assert(ne0 % 32 == 0);
 
@@ -983,201 +928,177 @@ static void ggml_compute_forward_add1_q_f32(
     }
 }
 
-static void ggml_compute_forward_add1_bf16_f32(
-        const ggml_compute_params * params,
-        ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
-    const ggml_tensor * src1 = dst->src[1];
+static void ggml_compute_forward_add1_bf16_f32(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
+    const ggml_tensor* src1 = dst->src[1];
 
     GGML_ASSERT(ggml_are_same_shape(src0, dst));
     GGML_ASSERT(ggml_is_scalar(src1));
 
     // scalar to add
-    const float v = *(float *) src1->data;
+    const float v = *(float*)src1->data;
 
     const int ith = params->ith;
     const int nth = params->nth;
 
-    const int nr  = ggml_nrows(src0);
+    const int nr = ggml_nrows(src0);
 
     GGML_TENSOR_UNARY_OP_LOCALS
 
     GGML_ASSERT(src0->type == GGML_TYPE_BF16);
     GGML_ASSERT(src1->type == GGML_TYPE_F32);
-    GGML_ASSERT(dst->type  == GGML_TYPE_BF16);
+    GGML_ASSERT(dst->type == GGML_TYPE_BF16);
 
-    GGML_ASSERT( nb0 == sizeof(ggml_bf16_t));
+    GGML_ASSERT(nb0 == sizeof(ggml_bf16_t));
     GGML_ASSERT(nb00 == sizeof(ggml_bf16_t));
 
     // rows per thread
-    const int dr = (nr + nth - 1)/nth;
+    const int dr = (nr + nth - 1) / nth;
 
     // row range for this thread
-    const int ir0 = dr*ith;
+    const int ir0 = dr * ith;
     const int ir1 = MIN(ir0 + dr, nr);
 
     for (int ir = ir0; ir < ir1; ++ir) {
         // src0 and dst are same shape => same indices
-        const int i3 = ir/(ne2*ne1);
-        const int i2 = (ir - i3*ne2*ne1)/ne1;
-        const int i1 = (ir - i3*ne2*ne1 - i2*ne1);
+        const int i3 = ir / (ne2 * ne1);
+        const int i2 = (ir - i3 * ne2 * ne1) / ne1;
+        const int i1 = (ir - i3 * ne2 * ne1 - i2 * ne1);
 
-        ggml_bf16_t * dst_ptr  = (ggml_bf16_t *) ((char *) dst->data  + i3*nb3  + i2*nb2  + i1*nb1 );
-        ggml_bf16_t * src0_ptr = (ggml_bf16_t *) ((char *) src0->data + i3*nb03 + i2*nb02 + i1*nb01);
+        ggml_bf16_t* dst_ptr = (ggml_bf16_t*)((char*)dst->data + i3 * nb3 + i2 * nb2 + i1 * nb1);
+        ggml_bf16_t* src0_ptr = (ggml_bf16_t*)((char*)src0->data + i3 * nb03 + i2 * nb02 + i1 * nb01);
         for (int i = 0; i < ne0; i++) {
             dst_ptr[i] = GGML_FP32_TO_BF16(GGML_BF16_TO_FP32(src0_ptr[i]) + v);
         }
     }
 }
 
-static void ggml_compute_forward_add1_bf16_bf16(
-        const ggml_compute_params * params,
-        ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
-    const ggml_tensor * src1 = dst->src[1];
+static void ggml_compute_forward_add1_bf16_bf16(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
+    const ggml_tensor* src1 = dst->src[1];
 
     GGML_ASSERT(ggml_are_same_shape(src0, dst));
     GGML_ASSERT(ggml_is_scalar(src1));
 
     // scalar to add
-    const float v = GGML_BF16_TO_FP32(*(ggml_bf16_t *) src1->data);
+    const float v = GGML_BF16_TO_FP32(*(ggml_bf16_t*)src1->data);
 
     const int ith = params->ith;
     const int nth = params->nth;
 
-    const int nr  = ggml_nrows(src0);
+    const int nr = ggml_nrows(src0);
 
     GGML_TENSOR_UNARY_OP_LOCALS
 
     GGML_ASSERT(src0->type == GGML_TYPE_BF16);
     GGML_ASSERT(src1->type == GGML_TYPE_BF16);
-    GGML_ASSERT(dst->type  == GGML_TYPE_BF16);
+    GGML_ASSERT(dst->type == GGML_TYPE_BF16);
 
-    GGML_ASSERT( nb0 == sizeof(ggml_bf16_t));
+    GGML_ASSERT(nb0 == sizeof(ggml_bf16_t));
     GGML_ASSERT(nb00 == sizeof(ggml_bf16_t));
 
     // rows per thread
-    const int dr = (nr + nth - 1)/nth;
+    const int dr = (nr + nth - 1) / nth;
 
     // row range for this thread
-    const int ir0 = dr*ith;
+    const int ir0 = dr * ith;
     const int ir1 = MIN(ir0 + dr, nr);
 
     for (int ir = ir0; ir < ir1; ++ir) {
         // src0 and dst are same shape => same indices
-        const int i3 = ir/(ne2*ne1);
-        const int i2 = (ir - i3*ne2*ne1)/ne1;
-        const int i1 = (ir - i3*ne2*ne1 - i2*ne1);
+        const int i3 = ir / (ne2 * ne1);
+        const int i2 = (ir - i3 * ne2 * ne1) / ne1;
+        const int i1 = (ir - i3 * ne2 * ne1 - i2 * ne1);
 
-        ggml_bf16_t * dst_ptr  = (ggml_bf16_t *) ((char *) dst->data  + i3*nb3  + i2*nb2  + i1*nb1 );
-        ggml_bf16_t * src0_ptr = (ggml_bf16_t *) ((char *) src0->data + i3*nb03 + i2*nb02 + i1*nb01);
+        ggml_bf16_t* dst_ptr = (ggml_bf16_t*)((char*)dst->data + i3 * nb3 + i2 * nb2 + i1 * nb1);
+        ggml_bf16_t* src0_ptr = (ggml_bf16_t*)((char*)src0->data + i3 * nb03 + i2 * nb02 + i1 * nb01);
         for (int i = 0; i < ne0; i++) {
             dst_ptr[i] = GGML_FP32_TO_BF16(GGML_BF16_TO_FP32(src0_ptr[i]) + v);
         }
     }
 }
 
-void ggml_compute_forward_add1(
-        const ggml_compute_params * params,
-        ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
-    const ggml_tensor * src1 = dst->src[1];
+void ggml_compute_forward_add1(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
+    const ggml_tensor* src1 = dst->src[1];
 
     switch (src0->type) {
-        case GGML_TYPE_F32:
-            {
-                ggml_compute_forward_add1_f32(params, dst);
-            } break;
-        case GGML_TYPE_F16:
-            {
-                if (src1->type == GGML_TYPE_F16) {
-                    ggml_compute_forward_add1_f16_f16(params, dst);
-                }
-                else if (src1->type == GGML_TYPE_F32) {
-                    ggml_compute_forward_add1_f16_f32(params, dst);
-                }
-                else {
-                    GGML_ABORT("fatal error");
-                }
-            } break;
-        case GGML_TYPE_BF16:
-            {
-                if (src1->type == GGML_TYPE_BF16) {
-                    ggml_compute_forward_add1_bf16_bf16(params, dst);
-                }
-                else if (src1->type == GGML_TYPE_F32) {
-                    ggml_compute_forward_add1_bf16_f32(params, dst);
-                }
-                else {
-                    GGML_ABORT("fatal error");
-                }
-            } break;
-        case GGML_TYPE_Q1_0:
-        case GGML_TYPE_Q4_0:
-        case GGML_TYPE_Q4_1:
-        case GGML_TYPE_Q5_0:
-        case GGML_TYPE_Q5_1:
-        case GGML_TYPE_Q8_0:
-        case GGML_TYPE_Q8_1:
-        case GGML_TYPE_MXFP4:
-        case GGML_TYPE_NVFP4:
-        case GGML_TYPE_Q2_K:
-        case GGML_TYPE_Q3_K:
-        case GGML_TYPE_Q4_K:
-        case GGML_TYPE_Q5_K:
-        case GGML_TYPE_Q6_K:
-        case GGML_TYPE_TQ1_0:
-        case GGML_TYPE_TQ2_0:
-        case GGML_TYPE_IQ2_XXS:
-        case GGML_TYPE_IQ2_XS:
-        case GGML_TYPE_IQ3_XXS:
-        case GGML_TYPE_IQ1_S:
-        case GGML_TYPE_IQ1_M:
-        case GGML_TYPE_IQ4_NL:
-        case GGML_TYPE_IQ4_XS:
-        case GGML_TYPE_IQ3_S:
-        case GGML_TYPE_IQ2_S:
-            {
-                ggml_compute_forward_add1_q_f32(params, dst);
-            } break;
-        default:
-            {
-                GGML_ABORT("fatal error");
-            }
+    case GGML_TYPE_F32: {
+        ggml_compute_forward_add1_f32(params, dst);
+    } break;
+    case GGML_TYPE_F16: {
+        if (src1->type == GGML_TYPE_F16) {
+            ggml_compute_forward_add1_f16_f16(params, dst);
+        } else if (src1->type == GGML_TYPE_F32) {
+            ggml_compute_forward_add1_f16_f32(params, dst);
+        } else {
+            GGML_ABORT("fatal error");
+        }
+    } break;
+    case GGML_TYPE_BF16: {
+        if (src1->type == GGML_TYPE_BF16) {
+            ggml_compute_forward_add1_bf16_bf16(params, dst);
+        } else if (src1->type == GGML_TYPE_F32) {
+            ggml_compute_forward_add1_bf16_f32(params, dst);
+        } else {
+            GGML_ABORT("fatal error");
+        }
+    } break;
+    case GGML_TYPE_Q1_0:
+    case GGML_TYPE_Q4_0:
+    case GGML_TYPE_Q4_1:
+    case GGML_TYPE_Q5_0:
+    case GGML_TYPE_Q5_1:
+    case GGML_TYPE_Q8_0:
+    case GGML_TYPE_Q8_1:
+    case GGML_TYPE_MXFP4:
+    case GGML_TYPE_NVFP4:
+    case GGML_TYPE_Q2_K:
+    case GGML_TYPE_Q3_K:
+    case GGML_TYPE_Q4_K:
+    case GGML_TYPE_Q5_K:
+    case GGML_TYPE_Q6_K:
+    case GGML_TYPE_TQ1_0:
+    case GGML_TYPE_TQ2_0:
+    case GGML_TYPE_IQ2_XXS:
+    case GGML_TYPE_IQ2_XS:
+    case GGML_TYPE_IQ3_XXS:
+    case GGML_TYPE_IQ1_S:
+    case GGML_TYPE_IQ1_M:
+    case GGML_TYPE_IQ4_NL:
+    case GGML_TYPE_IQ4_XS:
+    case GGML_TYPE_IQ3_S:
+    case GGML_TYPE_IQ2_S: {
+        ggml_compute_forward_add1_q_f32(params, dst);
+    } break;
+    default: {
+        GGML_ABORT("fatal error");
+    }
     }
 }
 
 // ggml_compute_forward_acc
 
-static void ggml_compute_forward_acc_f32(
-        const ggml_compute_params * params,
-        ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
-    const ggml_tensor * src1 = dst->src[1];
+static void ggml_compute_forward_acc_f32(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
+    const ggml_tensor* src1 = dst->src[1];
 
     GGML_ASSERT(ggml_are_same_shape(src0, dst));
     GGML_ASSERT(ggml_is_contiguous(dst) && ggml_is_contiguous(src0));
 
     // view src0 and dst with these strides and data offset inbytes during acc
     // nb0 is implicitly element_size because src0 and dst are contiguous
-    size_t nb1     = ((int32_t *) dst->op_params)[0];
-    size_t nb2     = ((int32_t *) dst->op_params)[1];
-    size_t nb3     = ((int32_t *) dst->op_params)[2];
-    size_t offset  = ((int32_t *) dst->op_params)[3];
-    bool   inplace = (bool) ((int32_t *) dst->op_params)[4];
+    size_t nb1 = ((int32_t*)dst->op_params)[0];
+    size_t nb2 = ((int32_t*)dst->op_params)[1];
+    size_t nb3 = ((int32_t*)dst->op_params)[2];
+    size_t offset = ((int32_t*)dst->op_params)[3];
+    bool inplace = (bool)((int32_t*)dst->op_params)[4];
 
     if (!inplace) {
         if (params->ith == 0) {
             // memcpy needs to be synchronized across threads to avoid race conditions.
             // => do it in INIT phase
-            memcpy(
-                ((char *)  dst->data),
-                ((char *) src0->data),
-                ggml_nbytes(dst));
+            memcpy(((char*)dst->data), ((char*)src0->data), ggml_nbytes(dst));
         }
         ggml_barrier(params->threadpool);
     }
@@ -1189,7 +1110,7 @@ static void ggml_compute_forward_acc_f32(
     const int nc = src1->ne[0];
 
     GGML_TENSOR_LOCALS(int64_t, ne1, src1, ne)
-    GGML_TENSOR_LOCALS(size_t,  nb1, src1, nb)
+    GGML_TENSOR_LOCALS(size_t, nb1, src1, nb)
 
     // src0 and dst as viewed during acc
     const size_t nb0 = ggml_element_size(src0);
@@ -1199,91 +1120,85 @@ static void ggml_compute_forward_acc_f32(
     const size_t nb02 = nb2;
     const size_t nb03 = nb3;
 
-    GGML_ASSERT(offset + (ne10 == 0 ? 0 : ne10-1)*nb0  + (ne11 == 0 ? 0 : ne11-1)*nb1  + (ne12 == 0 ? 0 : ne12-1)*nb2  + (ne13 == 0 ? 0 : ne13-1)*nb3  < ggml_nbytes(dst));
-    GGML_ASSERT(offset + (ne10 == 0 ? 0 : ne10-1)*nb00 + (ne11 == 0 ? 0 : ne11-1)*nb01 + (ne12 == 0 ? 0 : ne12-1)*nb02 + (ne13 == 0 ? 0 : ne13-1)*nb03 < ggml_nbytes(src0));
+    GGML_ASSERT(offset + (ne10 == 0 ? 0 : ne10 - 1) * nb0 + (ne11 == 0 ? 0 : ne11 - 1) * nb1 +
+                    (ne12 == 0 ? 0 : ne12 - 1) * nb2 + (ne13 == 0 ? 0 : ne13 - 1) * nb3 <
+                ggml_nbytes(dst));
+    GGML_ASSERT(offset + (ne10 == 0 ? 0 : ne10 - 1) * nb00 + (ne11 == 0 ? 0 : ne11 - 1) * nb01 +
+                    (ne12 == 0 ? 0 : ne12 - 1) * nb02 + (ne13 == 0 ? 0 : ne13 - 1) * nb03 <
+                ggml_nbytes(src0));
 
     GGML_ASSERT(nb10 == sizeof(float));
 
     // rows per thread
-    const int dr = (nr + nth - 1)/nth;
+    const int dr = (nr + nth - 1) / nth;
 
     // row range for this thread
-    const int ir0 = dr*ith;
+    const int ir0 = dr * ith;
     const int ir1 = MIN(ir0 + dr, nr);
 
     for (int ir = ir0; ir < ir1; ++ir) {
         // src0 and dst are viewed with shape of src1 and offset
         // => same indices
-        const int i3 = ir/(ne12*ne11);
-        const int i2 = (ir - i3*ne12*ne11)/ne11;
-        const int i1 = (ir - i3*ne12*ne11 - i2*ne11);
+        const int i3 = ir / (ne12 * ne11);
+        const int i2 = (ir - i3 * ne12 * ne11) / ne11;
+        const int i1 = (ir - i3 * ne12 * ne11 - i2 * ne11);
 
 #ifdef GGML_USE_ACCELERATE
-        vDSP_vadd(
-                (float *) ((char *) src0->data + i3*nb03 + i2*nb02 + i1*nb01 + offset), 1,
-                (float *) ((char *) src1->data + i3*nb13 + i2*nb12 + i1*nb11), 1,
-                (float *) ((char *) dst->data  + i3*nb3  + i2*nb2  + i1*nb1  + offset), 1, nc);
+        vDSP_vadd((float*)((char*)src0->data + i3 * nb03 + i2 * nb02 + i1 * nb01 + offset), 1,
+                  (float*)((char*)src1->data + i3 * nb13 + i2 * nb12 + i1 * nb11), 1,
+                  (float*)((char*)dst->data + i3 * nb3 + i2 * nb2 + i1 * nb1 + offset), 1, nc);
 #else
-        ggml_vec_add_f32(nc,
-                (float *) ((char *)  dst->data + i3*nb3  + i2*nb2  + i1*nb1  + offset),
-                (float *) ((char *) src0->data + i3*nb03 + i2*nb02 + i1*nb01 + offset),
-                (float *) ((char *) src1->data + i3*nb13 + i2*nb12 + i1*nb11));
+        ggml_vec_add_f32(nc, (float*)((char*)dst->data + i3 * nb3 + i2 * nb2 + i1 * nb1 + offset),
+                         (float*)((char*)src0->data + i3 * nb03 + i2 * nb02 + i1 * nb01 + offset),
+                         (float*)((char*)src1->data + i3 * nb13 + i2 * nb12 + i1 * nb11));
 #endif
     }
 }
 
-void ggml_compute_forward_acc(
-        const ggml_compute_params * params,
-        ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
+void ggml_compute_forward_acc(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
 
     switch (src0->type) {
-        case GGML_TYPE_F32:
-            {
-                ggml_compute_forward_acc_f32(params, dst);
-            } break;
-        case GGML_TYPE_F16:
-        case GGML_TYPE_BF16:
-        case GGML_TYPE_Q1_0:
-        case GGML_TYPE_Q4_0:
-        case GGML_TYPE_Q4_1:
-        case GGML_TYPE_Q5_0:
-        case GGML_TYPE_Q5_1:
-        case GGML_TYPE_Q8_0:
-        case GGML_TYPE_Q8_1:
-        case GGML_TYPE_MXFP4:
-        case GGML_TYPE_NVFP4:
-        case GGML_TYPE_Q2_K:
-        case GGML_TYPE_Q3_K:
-        case GGML_TYPE_Q4_K:
-        case GGML_TYPE_Q5_K:
-        case GGML_TYPE_Q6_K:
-        case GGML_TYPE_TQ1_0:
-        case GGML_TYPE_TQ2_0:
-        case GGML_TYPE_IQ2_XXS:
-        case GGML_TYPE_IQ2_XS:
-        case GGML_TYPE_IQ3_XXS:
-        case GGML_TYPE_IQ1_S:
-        case GGML_TYPE_IQ1_M:
-        case GGML_TYPE_IQ4_NL:
-        case GGML_TYPE_IQ4_XS:
-        case GGML_TYPE_IQ3_S:
-        case GGML_TYPE_IQ2_S:
-        default:
-            {
-                GGML_ABORT("fatal error");
-            }
+    case GGML_TYPE_F32: {
+        ggml_compute_forward_acc_f32(params, dst);
+    } break;
+    case GGML_TYPE_F16:
+    case GGML_TYPE_BF16:
+    case GGML_TYPE_Q1_0:
+    case GGML_TYPE_Q4_0:
+    case GGML_TYPE_Q4_1:
+    case GGML_TYPE_Q5_0:
+    case GGML_TYPE_Q5_1:
+    case GGML_TYPE_Q8_0:
+    case GGML_TYPE_Q8_1:
+    case GGML_TYPE_MXFP4:
+    case GGML_TYPE_NVFP4:
+    case GGML_TYPE_Q2_K:
+    case GGML_TYPE_Q3_K:
+    case GGML_TYPE_Q4_K:
+    case GGML_TYPE_Q5_K:
+    case GGML_TYPE_Q6_K:
+    case GGML_TYPE_TQ1_0:
+    case GGML_TYPE_TQ2_0:
+    case GGML_TYPE_IQ2_XXS:
+    case GGML_TYPE_IQ2_XS:
+    case GGML_TYPE_IQ3_XXS:
+    case GGML_TYPE_IQ1_S:
+    case GGML_TYPE_IQ1_M:
+    case GGML_TYPE_IQ4_NL:
+    case GGML_TYPE_IQ4_XS:
+    case GGML_TYPE_IQ3_S:
+    case GGML_TYPE_IQ2_S:
+    default: {
+        GGML_ABORT("fatal error");
+    }
     }
 }
 
 // ggml_compute_forward_sum
 
-static void ggml_compute_forward_sum_f32(
-        const ggml_compute_params * params,
-        ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
+static void ggml_compute_forward_sum_f32(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
 
     if (params->ith != 0) {
         return;
@@ -1293,29 +1208,25 @@ static void ggml_compute_forward_sum_f32(
     assert(src0->nb[0] == sizeof(float));
 
     GGML_TENSOR_LOCALS(int64_t, ne0, src0, ne)
-    GGML_TENSOR_LOCALS(size_t,  nb0, src0, nb)
+    GGML_TENSOR_LOCALS(size_t, nb0, src0, nb)
 
-    ggml_float sum     = 0;
+    ggml_float sum = 0;
     ggml_float row_sum = 0;
 
     for (int64_t i03 = 0; i03 < ne03; i03++) {
         for (int64_t i02 = 0; i02 < ne02; i02++) {
             for (int64_t i01 = 0; i01 < ne01; i01++) {
-                ggml_vec_sum_f32_ggf(ne00,
-                        &row_sum,
-                        (float *) ((char *) src0->data + i01*nb01 + i02*nb02 + i03*nb03));
+                ggml_vec_sum_f32_ggf(ne00, &row_sum,
+                                     (float*)((char*)src0->data + i01 * nb01 + i02 * nb02 + i03 * nb03));
                 sum += row_sum;
             }
         }
     }
-    ((float *) dst->data)[0] = sum;
+    ((float*)dst->data)[0] = sum;
 }
 
-static void ggml_compute_forward_sum_f16(
-    const ggml_compute_params * params,
-          ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
+static void ggml_compute_forward_sum_f16(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
 
     if (params->ith != 0) {
         return;
@@ -1326,7 +1237,7 @@ static void ggml_compute_forward_sum_f16(
     assert(src0->nb[0] == sizeof(ggml_fp16_t));
 
     GGML_TENSOR_LOCALS(int64_t, ne0, src0, ne)
-    GGML_TENSOR_LOCALS(size_t,  nb0, src0, nb)
+    GGML_TENSOR_LOCALS(size_t, nb0, src0, nb)
 
     float sum = 0;
     float row_sum = 0;
@@ -1334,21 +1245,17 @@ static void ggml_compute_forward_sum_f16(
     for (int64_t i03 = 0; i03 < ne03; i03++) {
         for (int64_t i02 = 0; i02 < ne02; i02++) {
             for (int64_t i01 = 0; i01 < ne01; i01++) {
-                ggml_vec_sum_f16_ggf(ne00,
-                    &row_sum,
-                    (ggml_fp16_t *) ((char *) src0->data + i01 * nb01 + i02 * nb02 + i03 * nb03));
+                ggml_vec_sum_f16_ggf(ne00, &row_sum,
+                                     (ggml_fp16_t*)((char*)src0->data + i01 * nb01 + i02 * nb02 + i03 * nb03));
                 sum += row_sum;
             }
         }
     }
-    ((ggml_fp16_t *) dst->data)[0] = GGML_CPU_FP32_TO_FP16(sum);
+    ((ggml_fp16_t*)dst->data)[0] = GGML_CPU_FP32_TO_FP16(sum);
 }
 
-static void ggml_compute_forward_sum_bf16(
-    const ggml_compute_params * params,
-          ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
+static void ggml_compute_forward_sum_bf16(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
 
     if (params->ith != 0) {
         return;
@@ -1359,7 +1266,7 @@ static void ggml_compute_forward_sum_bf16(
     assert(src0->nb[0] == sizeof(ggml_bf16_t));
 
     GGML_TENSOR_LOCALS(int64_t, ne0, src0, ne)
-    GGML_TENSOR_LOCALS(size_t,  nb0, src0, nb)
+    GGML_TENSOR_LOCALS(size_t, nb0, src0, nb)
 
     float sum = 0;
     float row_sum = 0;
@@ -1367,49 +1274,38 @@ static void ggml_compute_forward_sum_bf16(
     for (int64_t i03 = 0; i03 < ne03; i03++) {
         for (int64_t i02 = 0; i02 < ne02; i02++) {
             for (int64_t i01 = 0; i01 < ne01; i01++) {
-                ggml_vec_sum_bf16_ggf(ne00,
-                    &row_sum,
-                    (ggml_bf16_t *) ((char *) src0->data + i01 * nb01 + i02 * nb02 + i03 * nb03));
+                ggml_vec_sum_bf16_ggf(ne00, &row_sum,
+                                      (ggml_bf16_t*)((char*)src0->data + i01 * nb01 + i02 * nb02 + i03 * nb03));
                 sum += row_sum;
             }
         }
     }
-    ((ggml_bf16_t *) dst->data)[0] = GGML_FP32_TO_BF16(sum);
+    ((ggml_bf16_t*)dst->data)[0] = GGML_FP32_TO_BF16(sum);
 }
 
-void ggml_compute_forward_sum(
-        const ggml_compute_params * params,
-        ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
+void ggml_compute_forward_sum(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
 
     switch (src0->type) {
-        case GGML_TYPE_F32:
-            {
-                ggml_compute_forward_sum_f32(params, dst);
-            } break;
-        case GGML_TYPE_F16:
-            {
-                ggml_compute_forward_sum_f16(params, dst);
-            } break;
-        case GGML_TYPE_BF16:
-            {
-                ggml_compute_forward_sum_bf16(params, dst);
-            } break;
-        default:
-            {
-                GGML_ABORT("fatal error");
-            }
+    case GGML_TYPE_F32: {
+        ggml_compute_forward_sum_f32(params, dst);
+    } break;
+    case GGML_TYPE_F16: {
+        ggml_compute_forward_sum_f16(params, dst);
+    } break;
+    case GGML_TYPE_BF16: {
+        ggml_compute_forward_sum_bf16(params, dst);
+    } break;
+    default: {
+        GGML_ABORT("fatal error");
+    }
     }
 }
 
 // ggml_compute_forward_cumsum
 
-static void ggml_compute_forward_cumsum_f32(
-        const ggml_compute_params * params,
-        ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
+static void ggml_compute_forward_cumsum_f32(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
 
     GGML_ASSERT(src0->nb[0] == sizeof(float));
     GGML_ASSERT(dst->nb[0] == sizeof(float));
@@ -1424,42 +1320,34 @@ static void ggml_compute_forward_cumsum_f32(
     const auto [ir0, ir1] = get_thread_range(params, src0);
 
     for (int64_t ir = ir0; ir < ir1; ++ir) {
-        const int64_t i03 = ir/(ne02*ne01);
-        const int64_t i02 = (ir - i03*ne02*ne01)/ne01;
-        const int64_t i01 = (ir - i03*ne02*ne01 - i02*ne01);
+        const int64_t i03 = ir / (ne02 * ne01);
+        const int64_t i02 = (ir - i03 * ne02 * ne01) / ne01;
+        const int64_t i01 = (ir - i03 * ne02 * ne01 - i02 * ne01);
 
-        float * src_row = (float *) ((char *) src0->data + i01*nb01 + i02*nb02 + i03*nb03);
-        float * dst_row = (float *) ((char *) dst->data  + i01*nb1  + i02*nb2  + i03*nb3);
+        float* src_row = (float*)((char*)src0->data + i01 * nb01 + i02 * nb02 + i03 * nb03);
+        float* dst_row = (float*)((char*)dst->data + i01 * nb1 + i02 * nb2 + i03 * nb3);
 
         ggml_vec_cumsum_f32(ne00, dst_row, src_row);
     }
 }
 
-void ggml_compute_forward_cumsum(
-        const ggml_compute_params * params,
-        ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
+void ggml_compute_forward_cumsum(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
 
     switch (src0->type) {
-        case GGML_TYPE_F32:
-            {
-                ggml_compute_forward_cumsum_f32(params, dst);
-            } break;
-        default:
-            {
-                GGML_ABORT("fatal error");
-            }
+    case GGML_TYPE_F32: {
+        ggml_compute_forward_cumsum_f32(params, dst);
+    } break;
+    default: {
+        GGML_ABORT("fatal error");
+    }
     }
 }
 
 // ggml_compute_forward_sum_rows
 
-static void ggml_compute_forward_sum_rows_f32(
-        const ggml_compute_params * params,
-        ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
+static void ggml_compute_forward_sum_rows_f32(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
 
     if (params->ith != 0) {
         return;
@@ -1478,8 +1366,8 @@ static void ggml_compute_forward_sum_rows_f32(
     for (int64_t i3 = 0; i3 < ne03; i3++) {
         for (int64_t i2 = 0; i2 < ne02; i2++) {
             for (int64_t i1 = 0; i1 < ne01; i1++) {
-                float * src_row = (float *) ((char *) src0->data + i1*nb01 + i2*nb02 + i3*nb03);
-                float * dst_row = (float *) ((char *) dst->data  + i1*nb1  + i2*nb2  + i3*nb3);
+                float* src_row = (float*)((char*)src0->data + i1 * nb01 + i2 * nb02 + i3 * nb03);
+                float* dst_row = (float*)((char*)dst->data + i1 * nb1 + i2 * nb2 + i3 * nb3);
                 float row_sum = 0;
                 ggml_vec_sum_f32(ne00, &row_sum, src_row);
                 dst_row[0] = row_sum;
@@ -1488,31 +1376,23 @@ static void ggml_compute_forward_sum_rows_f32(
     }
 }
 
-void ggml_compute_forward_sum_rows(
-        const ggml_compute_params * params,
-        ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
+void ggml_compute_forward_sum_rows(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
 
     switch (src0->type) {
-        case GGML_TYPE_F32:
-            {
-                ggml_compute_forward_sum_rows_f32(params, dst);
-            } break;
-        default:
-            {
-                GGML_ABORT("fatal error");
-            }
+    case GGML_TYPE_F32: {
+        ggml_compute_forward_sum_rows_f32(params, dst);
+    } break;
+    default: {
+        GGML_ABORT("fatal error");
+    }
     }
 }
 
 // ggml_compute_forward_mean
 
-static void ggml_compute_forward_mean_f32(
-        const ggml_compute_params * params,
-        ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
+static void ggml_compute_forward_mean_f32(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
 
     if (params->ith != 0) {
         return;
@@ -1535,41 +1415,32 @@ static void ggml_compute_forward_mean_f32(
     for (int64_t i03 = 0; i03 < ne03; i03++) {
         for (int64_t i02 = 0; i02 < ne02; i02++) {
             for (int64_t i01 = 0; i01 < ne01; i01++) {
-                ggml_vec_sum_f32(ne00,
-                        (float *) ((char *)  dst->data + i01*nb1  + i02*nb2  + i03*nb3),
-                        (float *) ((char *) src0->data + i01*nb01 + i02*nb02 + i03*nb03));
+                ggml_vec_sum_f32(ne00, (float*)((char*)dst->data + i01 * nb1 + i02 * nb2 + i03 * nb3),
+                                 (float*)((char*)src0->data + i01 * nb01 + i02 * nb02 + i03 * nb03));
 
-                *(float *) ((char *) dst->data + i01*nb1 + i02*nb2 + i03*nb3) /= (float) ne00;
+                *(float*)((char*)dst->data + i01 * nb1 + i02 * nb2 + i03 * nb3) /= (float)ne00;
             }
         }
     }
 }
 
-void ggml_compute_forward_mean(
-        const ggml_compute_params * params,
-        ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
+void ggml_compute_forward_mean(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
 
     switch (src0->type) {
-        case GGML_TYPE_F32:
-            {
-                ggml_compute_forward_mean_f32(params, dst);
-            } break;
-        default:
-            {
-                GGML_ABORT("fatal error");
-            }
+    case GGML_TYPE_F32: {
+        ggml_compute_forward_mean_f32(params, dst);
+    } break;
+    default: {
+        GGML_ABORT("fatal error");
+    }
     }
 }
 
 // ggml_compute_forward_argmax
 
-static void ggml_compute_forward_argmax_f32(
-        const ggml_compute_params * params,
-        ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
+static void ggml_compute_forward_argmax_f32(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
 
     if (params->ith != 0) {
         return;
@@ -1585,40 +1456,32 @@ static void ggml_compute_forward_argmax_f32(
     const size_t nb0 = dst->nb[0];
 
     for (int64_t i1 = 0; i1 < ne01; i1++) {
-        float * src = (float *) ((char *) src0->data + i1*nb01);
-        int32_t * dst_ = (int32_t *) ((char *)  dst->data + i1*nb0);
+        float* src = (float*)((char*)src0->data + i1 * nb01);
+        int32_t* dst_ = (int32_t*)((char*)dst->data + i1 * nb0);
         int v = 0;
         ggml_vec_argmax_f32(ne00, &v, src);
         dst_[0] = v;
     }
 }
 
-void ggml_compute_forward_argmax(
-        const ggml_compute_params * params,
-        ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
+void ggml_compute_forward_argmax(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
 
     switch (src0->type) {
-        case GGML_TYPE_F32:
-            {
-                ggml_compute_forward_argmax_f32(params, dst);
-            } break;
-        default:
-            {
-                GGML_ABORT("fatal error");
-            }
+    case GGML_TYPE_F32: {
+        ggml_compute_forward_argmax_f32(params, dst);
+    } break;
+    default: {
+        GGML_ABORT("fatal error");
+    }
     }
 }
 
 // ggml_compute_forward_count_equal
 
-static void ggml_compute_forward_count_equal_i32(
-        const ggml_compute_params * params,
-        ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
-    const ggml_tensor * src1 = dst->src[1];
+static void ggml_compute_forward_count_equal_i32(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
+    const ggml_tensor* src1 = dst->src[1];
 
     GGML_TENSOR_BINARY_OP_LOCALS;
 
@@ -1633,27 +1496,27 @@ static void ggml_compute_forward_count_equal_i32(
     const int ith = params->ith;
     const int nth = params->nth;
 
-    int64_t * sums = (int64_t *) params->wdata;
+    int64_t* sums = (int64_t*)params->wdata;
     int64_t sum_thread = 0;
 
     // rows per thread
-    const int64_t dr = (nr + nth - 1)/nth;
+    const int64_t dr = (nr + nth - 1) / nth;
 
     // row range for this thread
-    const int64_t ir0 = dr*ith;
+    const int64_t ir0 = dr * ith;
     const int64_t ir1 = MIN(ir0 + dr, nr);
 
     for (int64_t ir = ir0; ir < ir1; ++ir) {
-        const int64_t i03 =  ir                        / (ne02*ne01);
-        const int64_t i02 = (ir - i03*ne03)            /       ne01;
-        const int64_t i01 =  ir - i03*ne03 - i02*ne02;
+        const int64_t i03 = ir / (ne02 * ne01);
+        const int64_t i02 = (ir - i03 * ne03) / ne01;
+        const int64_t i01 = ir - i03 * ne03 - i02 * ne02;
 
-        const char * data0 = (const char *) src0->data + i03*nb03 + i02*nb02 + i01*nb01;
-        const char * data1 = (const char *) src1->data + i03*nb13 + i02*nb12 + i01*nb11;
+        const char* data0 = (const char*)src0->data + i03 * nb03 + i02 * nb02 + i01 * nb01;
+        const char* data1 = (const char*)src1->data + i03 * nb13 + i02 * nb12 + i01 * nb11;
 
         for (int64_t i00 = 0; i00 < ne00; ++i00) {
-            const int32_t val0 = *((const int32_t *) (data0 + i00*nb00));
-            const int32_t val1 = *((const int32_t *) (data1 + i00*nb10));
+            const int32_t val0 = *((const int32_t*)(data0 + i00 * nb00));
+            const int32_t val1 = *((const int32_t*)(data1 + i00 * nb10));
 
             sum_thread += val0 == val1;
         }
@@ -1670,34 +1533,26 @@ static void ggml_compute_forward_count_equal_i32(
     for (int ith_other = 1; ith_other < nth; ++ith_other) {
         sum_thread += sums[ith_other];
     }
-    *((int64_t *) dst->data) = sum_thread;
+    *((int64_t*)dst->data) = sum_thread;
 }
 
-void ggml_compute_forward_count_equal(
-        const ggml_compute_params * params,
-        ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
+void ggml_compute_forward_count_equal(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
 
     switch (src0->type) {
-        case GGML_TYPE_I32:
-            {
-                ggml_compute_forward_count_equal_i32(params, dst);
-            } break;
-        default:
-            {
-                GGML_ABORT("fatal error");
-            }
+    case GGML_TYPE_I32: {
+        ggml_compute_forward_count_equal_i32(params, dst);
+    } break;
+    default: {
+        GGML_ABORT("fatal error");
+    }
     }
 }
 
 // ggml_compute_forward_repeat
 
-static void ggml_compute_forward_repeat_f32(
-        const ggml_compute_params * params,
-        ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
+static void ggml_compute_forward_repeat_f32(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
 
     if (params->ith != 0) {
         return;
@@ -1708,26 +1563,28 @@ static void ggml_compute_forward_repeat_f32(
     GGML_TENSOR_UNARY_OP_LOCALS
 
     // guaranteed to be an integer due to the check in ggml_can_repeat
-    const int nr0 = (int)(ne0/ne00);
-    const int nr1 = (int)(ne1/ne01);
-    const int nr2 = (int)(ne2/ne02);
-    const int nr3 = (int)(ne3/ne03);
+    const int nr0 = (int)(ne0 / ne00);
+    const int nr1 = (int)(ne1 / ne01);
+    const int nr2 = (int)(ne2 / ne02);
+    const int nr3 = (int)(ne3 / ne03);
 
     // TODO: support for transposed / permuted tensors
-    GGML_ASSERT(nb0  == sizeof(float));
+    GGML_ASSERT(nb0 == sizeof(float));
     GGML_ASSERT(nb00 == sizeof(float));
 
     // TODO: maybe this is not optimal?
-    for                         (int i3 = 0; i3 < nr3;  i3++) {
-        for                     (int k3 = 0; k3 < ne03; k3++) {
-            for                 (int i2 = 0; i2 < nr2;  i2++) {
-                for             (int k2 = 0; k2 < ne02; k2++) {
-                    for         (int i1 = 0; i1 < nr1;  i1++) {
-                        for     (int k1 = 0; k1 < ne01; k1++) {
-                            for (int i0 = 0; i0 < nr0;  i0++) {
+    for (int i3 = 0; i3 < nr3; i3++) {
+        for (int k3 = 0; k3 < ne03; k3++) {
+            for (int i2 = 0; i2 < nr2; i2++) {
+                for (int k2 = 0; k2 < ne02; k2++) {
+                    for (int i1 = 0; i1 < nr1; i1++) {
+                        for (int k1 = 0; k1 < ne01; k1++) {
+                            for (int i0 = 0; i0 < nr0; i0++) {
                                 ggml_vec_cpy_f32(ne00,
-                                        (float *) ((char *)  dst->data + (i3*ne03 + k3)*nb3  + (i2*ne02 + k2)*nb2  + (i1*ne01 + k1)*nb1  + (i0*ne00)*nb0),
-                                        (float *) ((char *) src0->data + (          k3)*nb03 + (          k2)*nb02 + (          k1)*nb01));
+                                                 (float*)((char*)dst->data + (i3 * ne03 + k3) * nb3 +
+                                                          (i2 * ne02 + k2) * nb2 + (i1 * ne01 + k1) * nb1 +
+                                                          (i0 * ne00) * nb0),
+                                                 (float*)((char*)src0->data + (k3)*nb03 + (k2)*nb02 + (k1)*nb01));
                             }
                         }
                     }
@@ -1737,11 +1594,8 @@ static void ggml_compute_forward_repeat_f32(
     }
 }
 
-static void ggml_compute_forward_repeat_f16(
-        const ggml_compute_params * params,
-        ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
+static void ggml_compute_forward_repeat_f16(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
 
     if (params->ith != 0) {
         return;
@@ -1752,28 +1606,30 @@ static void ggml_compute_forward_repeat_f16(
     GGML_TENSOR_UNARY_OP_LOCALS
 
     // guaranteed to be an integer due to the check in ggml_can_repeat
-    const int nr0 = (int)(ne0/ne00);
-    const int nr1 = (int)(ne1/ne01);
-    const int nr2 = (int)(ne2/ne02);
-    const int nr3 = (int)(ne3/ne03);
+    const int nr0 = (int)(ne0 / ne00);
+    const int nr1 = (int)(ne1 / ne01);
+    const int nr2 = (int)(ne2 / ne02);
+    const int nr3 = (int)(ne3 / ne03);
 
     // TODO: support for transposed / permuted tensors
-    GGML_ASSERT(nb0  == sizeof(ggml_fp16_t));
+    GGML_ASSERT(nb0 == sizeof(ggml_fp16_t));
     GGML_ASSERT(nb00 == sizeof(ggml_fp16_t));
 
     // TODO: maybe this is not optimal?
-    for                         (int i3 = 0; i3 < nr3;  i3++) {
-        for                     (int k3 = 0; k3 < ne03; k3++) {
-            for                 (int i2 = 0; i2 < nr2;  i2++) {
-                for             (int k2 = 0; k2 < ne02; k2++) {
-                    for         (int i1 = 0; i1 < nr1;  i1++) {
-                        for     (int k1 = 0; k1 < ne01; k1++) {
-                            for (int i0 = 0; i0 < nr0;  i0++) {
-                                ggml_fp16_t * y = (ggml_fp16_t *) ((char *)  dst->data + (i3*ne03 + k3)*nb3  + (i2*ne02 + k2)*nb2  + (i1*ne01 + k1)*nb1  + (i0*ne00)*nb0);
-                                ggml_fp16_t * x = (ggml_fp16_t *) ((char *) src0->data + (          k3)*nb03 + (          k2)*nb02 + (          k1)*nb01);
+    for (int i3 = 0; i3 < nr3; i3++) {
+        for (int k3 = 0; k3 < ne03; k3++) {
+            for (int i2 = 0; i2 < nr2; i2++) {
+                for (int k2 = 0; k2 < ne02; k2++) {
+                    for (int i1 = 0; i1 < nr1; i1++) {
+                        for (int k1 = 0; k1 < ne01; k1++) {
+                            for (int i0 = 0; i0 < nr0; i0++) {
+                                ggml_fp16_t* y =
+                                    (ggml_fp16_t*)((char*)dst->data + (i3 * ne03 + k3) * nb3 + (i2 * ne02 + k2) * nb2 +
+                                                   (i1 * ne01 + k1) * nb1 + (i0 * ne00) * nb0);
+                                ggml_fp16_t* x = (ggml_fp16_t*)((char*)src0->data + (k3)*nb03 + (k2)*nb02 + (k1)*nb01);
                                 // ggml_vec_cpy_f16(ne00, y, x)
                                 for (int i = 0; i < ne00; ++i) {
-                                    y[i]  = x[i];
+                                    y[i] = x[i];
                                 }
                             }
                         }
@@ -1784,44 +1640,35 @@ static void ggml_compute_forward_repeat_f16(
     }
 }
 
-void ggml_compute_forward_repeat(
-        const ggml_compute_params * params,
-        ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
+void ggml_compute_forward_repeat(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
 
     switch (src0->type) {
-        case GGML_TYPE_F16:
-        case GGML_TYPE_BF16:
-        case GGML_TYPE_I16:
-            {
-                ggml_compute_forward_repeat_f16(params, dst);
-            } break;
-        case GGML_TYPE_F32:
-        case GGML_TYPE_I32:
-            {
-                ggml_compute_forward_repeat_f32(params, dst);
-            } break;
-        // TODO: templateify the implementation and support for I64
-        //       ref https://github.com/ggml-org/llama.cpp/pull/14274#discussion_r2169492225
-        //case GGML_TYPE_I64:
-        //    {
-        //        ggml_compute_forward_repeat_i64(params, dst);
-        //    } break;
-        default:
-            {
-                GGML_ABORT("fatal error");
-            }
+    case GGML_TYPE_F16:
+    case GGML_TYPE_BF16:
+    case GGML_TYPE_I16: {
+        ggml_compute_forward_repeat_f16(params, dst);
+    } break;
+    case GGML_TYPE_F32:
+    case GGML_TYPE_I32: {
+        ggml_compute_forward_repeat_f32(params, dst);
+    } break;
+    // TODO: templateify the implementation and support for I64
+    //       ref https://github.com/ggml-org/llama.cpp/pull/14274#discussion_r2169492225
+    //case GGML_TYPE_I64:
+    //    {
+    //        ggml_compute_forward_repeat_i64(params, dst);
+    //    } break;
+    default: {
+        GGML_ABORT("fatal error");
+    }
     }
 }
 
 // ggml_compute_forward_repeat_back
 
-static void ggml_compute_forward_repeat_back_f32(
-        const ggml_compute_params * params,
-        ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
+static void ggml_compute_forward_repeat_back_f32(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
 
     if (params->ith != 0) {
         return;
@@ -1832,40 +1679,39 @@ static void ggml_compute_forward_repeat_back_f32(
     GGML_TENSOR_UNARY_OP_LOCALS
 
     // guaranteed to be an integer due to the check in ggml_can_repeat
-    const int nr0 = (int)(ne00/ne0);
-    const int nr1 = (int)(ne01/ne1);
-    const int nr2 = (int)(ne02/ne2);
-    const int nr3 = (int)(ne03/ne3);
+    const int nr0 = (int)(ne00 / ne0);
+    const int nr1 = (int)(ne01 / ne1);
+    const int nr2 = (int)(ne02 / ne2);
+    const int nr3 = (int)(ne03 / ne3);
 
     // TODO: support for transposed / permuted tensors
-    GGML_ASSERT(nb0  == sizeof(float));
+    GGML_ASSERT(nb0 == sizeof(float));
     GGML_ASSERT(nb00 == sizeof(float));
 
     if (ggml_is_contiguous(dst)) {
-        ggml_vec_set_f32(ne0*ne1*ne2*ne3, (float *)dst->data, 0);
+        ggml_vec_set_f32(ne0 * ne1 * ne2 * ne3, (float*)dst->data, 0);
     } else {
-        for         (int k3 = 0; k3 < ne3; k3++) {
-            for     (int k2 = 0; k2 < ne2; k2++) {
+        for (int k3 = 0; k3 < ne3; k3++) {
+            for (int k2 = 0; k2 < ne2; k2++) {
                 for (int k1 = 0; k1 < ne1; k1++) {
-                    ggml_vec_set_f32(ne0,
-                        (float *) ((char *) dst->data + k1*nb1 + k2*nb2 + k3*nb3),
-                        0);
+                    ggml_vec_set_f32(ne0, (float*)((char*)dst->data + k1 * nb1 + k2 * nb2 + k3 * nb3), 0);
                 }
             }
         }
     }
 
     // TODO: maybe this is not optimal?
-    for                         (int i3 = 0; i3 < nr3; i3++) {
-        for                     (int k3 = 0; k3 < ne3; k3++) {
-            for                 (int i2 = 0; i2 < nr2; i2++) {
-                for             (int k2 = 0; k2 < ne2; k2++) {
-                    for         (int i1 = 0; i1 < nr1; i1++) {
-                        for     (int k1 = 0; k1 < ne1; k1++) {
+    for (int i3 = 0; i3 < nr3; i3++) {
+        for (int k3 = 0; k3 < ne3; k3++) {
+            for (int i2 = 0; i2 < nr2; i2++) {
+                for (int k2 = 0; k2 < ne2; k2++) {
+                    for (int i1 = 0; i1 < nr1; i1++) {
+                        for (int k1 = 0; k1 < ne1; k1++) {
                             for (int i0 = 0; i0 < nr0; i0++) {
-                                ggml_vec_acc_f32(ne0,
-                                        (float *) ((char *)  dst->data + (         k3)*nb3  + (         k2)*nb2  + (         k1)*nb1),
-                                        (float *) ((char *) src0->data + (i3*ne3 + k3)*nb03 + (i2*ne2 + k2)*nb02 + (i1*ne1 + k1)*nb01 + (i0*ne0)*nb00));
+                                ggml_vec_acc_f32(ne0, (float*)((char*)dst->data + (k3)*nb3 + (k2)*nb2 + (k1)*nb1),
+                                                 (float*)((char*)src0->data + (i3 * ne3 + k3) * nb03 +
+                                                          (i2 * ne2 + k2) * nb02 + (i1 * ne1 + k1) * nb01 +
+                                                          (i0 * ne0) * nb00));
                             }
                         }
                     }
@@ -1875,32 +1721,24 @@ static void ggml_compute_forward_repeat_back_f32(
     }
 }
 
-void ggml_compute_forward_repeat_back(
-        const ggml_compute_params * params,
-        ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
+void ggml_compute_forward_repeat_back(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
 
     switch (src0->type) {
-        case GGML_TYPE_F32:
-            {
-                ggml_compute_forward_repeat_back_f32(params, dst);
-            } break;
-        default:
-            {
-                GGML_ABORT("fatal error");
-            }
+    case GGML_TYPE_F32: {
+        ggml_compute_forward_repeat_back_f32(params, dst);
+    } break;
+    default: {
+        GGML_ABORT("fatal error");
+    }
     }
 }
 
 // ggml_compute_forward_concat
 
-static void ggml_compute_forward_concat_any(
-    const ggml_compute_params * params,
-    ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
-    const ggml_tensor * src1 = dst->src[1];
+static void ggml_compute_forward_concat_any(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
+    const ggml_tensor* src1 = dst->src[1];
 
     const size_t len = ggml_type_size(src0->type);
 
@@ -1916,7 +1754,7 @@ static void ggml_compute_forward_concat_any(
     int64_t o[4] = {0, 0, 0, 0};
     o[dim] = src0->ne[dim];
 
-    const char * x;
+    const char* x;
 
     // TODO: smarter multi-theading
     for (int i3 = 0; i3 < ne3; i3++) {
@@ -1924,12 +1762,13 @@ static void ggml_compute_forward_concat_any(
             for (int i1 = 0; i1 < ne1; i1++) {
                 for (int i0 = 0; i0 < ne0; i0++) {
                     if (i0 < ne00 && i1 < ne01 && i2 < ne02 && i3 < ne03) {
-                        x = (const char *)src0->data + (i0       )*nb00 + (i1       )*nb01 + (i2       )*nb02 + (i3       )*nb03;
+                        x = (const char*)src0->data + (i0)*nb00 + (i1)*nb01 + (i2)*nb02 + (i3)*nb03;
                     } else {
-                        x = (const char *)src1->data + (i0 - o[0])*nb10 + (i1 - o[1])*nb11 + (i2 - o[2])*nb12 + (i3 - o[3])*nb13;
+                        x = (const char*)src1->data + (i0 - o[0]) * nb10 + (i1 - o[1]) * nb11 + (i2 - o[2]) * nb12 +
+                            (i3 - o[3]) * nb13;
                     }
 
-                    char * y = (char *)dst->data + i0*nb0 + i1*nb1 + i2*nb2 + i3*nb3;
+                    char* y = (char*)dst->data + i0 * nb0 + i1 * nb1 + i2 * nb2 + i3 * nb3;
 
                     memcpy(y, x, len);
                 }
@@ -1938,12 +1777,9 @@ static void ggml_compute_forward_concat_any(
     }
 }
 
-static void ggml_compute_forward_concat_i8(
-    const ggml_compute_params * params,
-    ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
-    const ggml_tensor * src1 = dst->src[1];
+static void ggml_compute_forward_concat_i8(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
+    const ggml_tensor* src1 = dst->src[1];
 
     GGML_ASSERT(ggml_type_size(src0->type) == sizeof(int8_t));
 
@@ -1959,7 +1795,7 @@ static void ggml_compute_forward_concat_i8(
     int64_t o[4] = {0, 0, 0, 0};
     o[dim] = src0->ne[dim];
 
-    const int8_t * x;
+    const int8_t* x;
 
     // TODO: smarter multi-theading
     for (int i3 = 0; i3 < ne3; i3++) {
@@ -1967,12 +1803,13 @@ static void ggml_compute_forward_concat_i8(
             for (int i1 = 0; i1 < ne1; i1++) {
                 for (int i0 = 0; i0 < ne0; i0++) {
                     if (i0 < ne00 && i1 < ne01 && i2 < ne02 && i3 < ne03) {
-                        x = (const int8_t *) ((const char *)src0->data + (i0       )*nb00 + (i1       )*nb01 + (i2       )*nb02 + (i3       )*nb03);
+                        x = (const int8_t*)((const char*)src0->data + (i0)*nb00 + (i1)*nb01 + (i2)*nb02 + (i3)*nb03);
                     } else {
-                        x = (const int8_t *) ((const char *)src1->data + (i0 - o[0])*nb10 + (i1 - o[1])*nb11 + (i2 - o[2])*nb12 + (i3 - o[3])*nb13);
+                        x = (const int8_t*)((const char*)src1->data + (i0 - o[0]) * nb10 + (i1 - o[1]) * nb11 +
+                                            (i2 - o[2]) * nb12 + (i3 - o[3]) * nb13);
                     }
 
-                    int8_t * y = (int8_t *)((char *)dst->data + i0*nb0 + i1*nb1 + i2*nb2 + i3*nb3);
+                    int8_t* y = (int8_t*)((char*)dst->data + i0 * nb0 + i1 * nb1 + i2 * nb2 + i3 * nb3);
 
                     *y = *x;
                 }
@@ -1981,12 +1818,9 @@ static void ggml_compute_forward_concat_i8(
     }
 }
 
-static void ggml_compute_forward_concat_f16(
-    const ggml_compute_params * params,
-    ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
-    const ggml_tensor * src1 = dst->src[1];
+static void ggml_compute_forward_concat_f16(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
+    const ggml_tensor* src1 = dst->src[1];
 
     GGML_ASSERT(ggml_type_size(src0->type) == sizeof(ggml_fp16_t));
 
@@ -2002,7 +1836,7 @@ static void ggml_compute_forward_concat_f16(
     int64_t o[4] = {0, 0, 0, 0};
     o[dim] = src0->ne[dim];
 
-    const ggml_fp16_t * x;
+    const ggml_fp16_t* x;
 
     // TODO: smarter multi-theading
     for (int i3 = 0; i3 < ne3; i3++) {
@@ -2010,12 +1844,14 @@ static void ggml_compute_forward_concat_f16(
             for (int i1 = 0; i1 < ne1; i1++) {
                 for (int i0 = 0; i0 < ne0; i0++) {
                     if (i0 < ne00 && i1 < ne01 && i2 < ne02 && i3 < ne03) {
-                        x = (const ggml_fp16_t *) ((const char *)src0->data + (i0       )*nb00 + (i1       )*nb01 + (i2       )*nb02 + (i3       )*nb03);
+                        x = (const ggml_fp16_t*)((const char*)src0->data + (i0)*nb00 + (i1)*nb01 + (i2)*nb02 +
+                                                 (i3)*nb03);
                     } else {
-                        x = (const ggml_fp16_t *) ((const char *)src1->data + (i0 - o[0])*nb10 + (i1 - o[1])*nb11 + (i2 - o[2])*nb12 + (i3 - o[3])*nb13);
+                        x = (const ggml_fp16_t*)((const char*)src1->data + (i0 - o[0]) * nb10 + (i1 - o[1]) * nb11 +
+                                                 (i2 - o[2]) * nb12 + (i3 - o[3]) * nb13);
                     }
 
-                    ggml_fp16_t * y = (ggml_fp16_t *)((char *)dst->data + i0*nb0 + i1*nb1 + i2*nb2 + i3*nb3);
+                    ggml_fp16_t* y = (ggml_fp16_t*)((char*)dst->data + i0 * nb0 + i1 * nb1 + i2 * nb2 + i3 * nb3);
 
                     *y = *x;
                 }
@@ -2024,12 +1860,9 @@ static void ggml_compute_forward_concat_f16(
     }
 }
 
-static void ggml_compute_forward_concat_f32(
-    const ggml_compute_params * params,
-    ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
-    const ggml_tensor * src1 = dst->src[1];
+static void ggml_compute_forward_concat_f32(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
+    const ggml_tensor* src1 = dst->src[1];
 
     GGML_ASSERT(ggml_type_size(src0->type) == sizeof(float));
 
@@ -2045,7 +1878,7 @@ static void ggml_compute_forward_concat_f32(
     int64_t o[4] = {0, 0, 0, 0};
     o[dim] = src0->ne[dim];
 
-    const float * x;
+    const float* x;
 
     // TODO: smarter multi-theading
     for (int i3 = 0; i3 < ne3; i3++) {
@@ -2053,12 +1886,13 @@ static void ggml_compute_forward_concat_f32(
             for (int i1 = 0; i1 < ne1; i1++) {
                 for (int i0 = 0; i0 < ne0; i0++) {
                     if (i0 < ne00 && i1 < ne01 && i2 < ne02 && i3 < ne03) {
-                        x = (const float *) ((const char *)src0->data + (i0       )*nb00 + (i1       )*nb01 + (i2       )*nb02 + (i3       )*nb03);
+                        x = (const float*)((const char*)src0->data + (i0)*nb00 + (i1)*nb01 + (i2)*nb02 + (i3)*nb03);
                     } else {
-                        x = (const float *) ((const char *)src1->data + (i0 - o[0])*nb10 + (i1 - o[1])*nb11 + (i2 - o[2])*nb12 + (i3 - o[3])*nb13);
+                        x = (const float*)((const char*)src1->data + (i0 - o[0]) * nb10 + (i1 - o[1]) * nb11 +
+                                           (i2 - o[2]) * nb12 + (i3 - o[3]) * nb13);
                     }
 
-                    float * y = (float *)((char *)dst->data + i0*nb0 + i1*nb1 + i2*nb2 + i3*nb3);
+                    float* y = (float*)((char*)dst->data + i0 * nb0 + i1 * nb1 + i2 * nb2 + i3 * nb3);
 
                     *y = *x;
                 }
@@ -2067,50 +1901,40 @@ static void ggml_compute_forward_concat_f32(
     }
 }
 
-void ggml_compute_forward_concat(
-    const ggml_compute_params * params,
-    ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
+void ggml_compute_forward_concat(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
 
     switch (src0->type) {
-        case GGML_TYPE_F16:
-        case GGML_TYPE_BF16:
-        case GGML_TYPE_I16:
-            {
-                ggml_compute_forward_concat_f16(params, dst);
-            } break;
-        case GGML_TYPE_I8:
-            {
-                ggml_compute_forward_concat_i8(params, dst);
-            } break;
-        case GGML_TYPE_F32:
-        case GGML_TYPE_I32:
-            {
-                ggml_compute_forward_concat_f32(params, dst);
-            } break;
-        default:
-            {
-                ggml_compute_forward_concat_any(params, dst);
-            }
+    case GGML_TYPE_F16:
+    case GGML_TYPE_BF16:
+    case GGML_TYPE_I16: {
+        ggml_compute_forward_concat_f16(params, dst);
+    } break;
+    case GGML_TYPE_I8: {
+        ggml_compute_forward_concat_i8(params, dst);
+    } break;
+    case GGML_TYPE_F32:
+    case GGML_TYPE_I32: {
+        ggml_compute_forward_concat_f32(params, dst);
+    } break;
+    default: {
+        ggml_compute_forward_concat_any(params, dst);
+    }
     }
 }
 
 // ggml_compute_forward_gelu
 
-static void ggml_compute_forward_gelu_f32(
-        const ggml_compute_params * params,
-        ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
+static void ggml_compute_forward_gelu_f32(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
 
     assert(ggml_is_contiguous_rows(src0));
     assert(ggml_are_same_shape(src0, dst));
 
     GGML_TENSOR_LOCALS(int64_t, ne0, src0, ne)
-    GGML_TENSOR_LOCALS(size_t,  nb0, src0, nb)
-    GGML_TENSOR_LOCALS(int64_t, ne,  dst,  ne)
-    GGML_TENSOR_LOCALS(size_t,  nb,  dst,  nb)
+    GGML_TENSOR_LOCALS(size_t, nb0, src0, nb)
+    GGML_TENSOR_LOCALS(int64_t, ne, dst, ne)
+    GGML_TENSOR_LOCALS(size_t, nb, dst, nb)
 
     const int ith = params->ith;
     const int nth = params->nth;
@@ -2119,24 +1943,23 @@ static void ggml_compute_forward_gelu_f32(
     const int nr = ggml_nrows(src0);
 
     // rows per thread
-    const int dr = (nr + nth - 1)/nth;
+    const int dr = (nr + nth - 1) / nth;
 
     // row range for this thread
-    const int ir0 = dr*ith;
+    const int ir0 = dr * ith;
     const int ir1 = MIN(ir0 + dr, nr);
 
     for (int ir = ir0; ir < ir1; ++ir) {
-        const int i3 = ir/(ne02*ne01);
-        const int i2 = (ir - i3*ne02*ne01)/ne01;
-        const int i1 = (ir - i3*ne02*ne01 - i2*ne01);
+        const int i3 = ir / (ne02 * ne01);
+        const int i2 = (ir - i3 * ne02 * ne01) / ne01;
+        const int i1 = (ir - i3 * ne02 * ne01 - i2 * ne01);
 
-        ggml_vec_gelu_f32(nc,
-                (float *) ((char *) dst->data  + i3*nb3  + i2*nb2  + i1*nb1),
-                (float *) ((char *) src0->data + i3*nb03 + i2*nb02 + i1*nb01));
+        ggml_vec_gelu_f32(nc, (float*)((char*)dst->data + i3 * nb3 + i2 * nb2 + i1 * nb1),
+                          (float*)((char*)src0->data + i3 * nb03 + i2 * nb02 + i1 * nb01));
 
 #ifndef NDEBUG
         for (int k = 0; k < nc; k++) {
-            const float x = ((float *) ((char *) dst->data + i3*nb3 + i2*nb2 + i1*(dst->nb[1])))[k];
+            const float x = ((float*)((char*)dst->data + i3 * nb3 + i2 * nb2 + i1 * (dst->nb[1])))[k];
             GGML_UNUSED(x);
             assert(!isnan(x));
             assert(!isinf(x));
@@ -2145,19 +1968,16 @@ static void ggml_compute_forward_gelu_f32(
     }
 }
 
-static void ggml_compute_forward_gelu_f16(
-    const ggml_compute_params * params,
-    ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
+static void ggml_compute_forward_gelu_f16(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
 
     assert(ggml_is_contiguous_rows(src0));
     assert(ggml_are_same_shape(src0, dst));
 
     GGML_TENSOR_LOCALS(int64_t, ne0, src0, ne)
-    GGML_TENSOR_LOCALS(size_t,  nb0, src0, nb)
-    GGML_TENSOR_LOCALS(int64_t, ne,  dst,  ne)
-    GGML_TENSOR_LOCALS(size_t,  nb,  dst,  nb)
+    GGML_TENSOR_LOCALS(size_t, nb0, src0, nb)
+    GGML_TENSOR_LOCALS(int64_t, ne, dst, ne)
+    GGML_TENSOR_LOCALS(size_t, nb, dst, nb)
 
     const int ith = params->ith;
     const int nth = params->nth;
@@ -2166,24 +1986,23 @@ static void ggml_compute_forward_gelu_f16(
     const int nr = ggml_nrows(src0);
 
     // rows per thread
-    const int dr = (nr + nth - 1)/nth;
+    const int dr = (nr + nth - 1) / nth;
 
     // row range for this thread
-    const int ir0 = dr*ith;
+    const int ir0 = dr * ith;
     const int ir1 = MIN(ir0 + dr, nr);
 
     for (int ir = ir0; ir < ir1; ++ir) {
-        const int i3 = ir/(ne02*ne01);
-        const int i2 = (ir - i3*ne02*ne01)/ne01;
-        const int i1 = (ir - i3*ne02*ne01 - i2*ne01);
+        const int i3 = ir / (ne02 * ne01);
+        const int i2 = (ir - i3 * ne02 * ne01) / ne01;
+        const int i1 = (ir - i3 * ne02 * ne01 - i2 * ne01);
 
-        ggml_vec_gelu_f16(nc,
-                (ggml_fp16_t *) ((char *) dst->data  + i3*nb3  + i2*nb2  + i1*nb1),
-                (ggml_fp16_t *) ((char *) src0->data + i3*nb03 + i2*nb02 + i1*nb01));
+        ggml_vec_gelu_f16(nc, (ggml_fp16_t*)((char*)dst->data + i3 * nb3 + i2 * nb2 + i1 * nb1),
+                          (ggml_fp16_t*)((char*)src0->data + i3 * nb03 + i2 * nb02 + i1 * nb01));
 
 #ifndef NDEBUG
         for (int k = 0; k < nc; k++) {
-            const ggml_fp16_t x = ((ggml_fp16_t *) ((char *) dst->data + i3*nb3 + i2*nb2 + i1*( dst->nb[1])))[k];
+            const ggml_fp16_t x = ((ggml_fp16_t*)((char*)dst->data + i3 * nb3 + i2 * nb2 + i1 * (dst->nb[1])))[k];
             const float v = GGML_CPU_FP16_TO_FP32(x);
             GGML_UNUSED(v);
             assert(!isnan(v));
@@ -2193,59 +2012,53 @@ static void ggml_compute_forward_gelu_f16(
     }
 }
 
-static void ggml_compute_forward_gelu(
-        const ggml_compute_params * params,
-        ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
+static void ggml_compute_forward_gelu(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
 
     switch (src0->type) {
-        case GGML_TYPE_F32:
-            {
-                ggml_compute_forward_gelu_f32(params, dst);
-            } break;
-        case GGML_TYPE_F16:
-            {
-                ggml_compute_forward_gelu_f16(params, dst);
-            } break;
-        default:
-            {
-                GGML_ABORT("fatal error");
-            }
+    case GGML_TYPE_F32: {
+        ggml_compute_forward_gelu_f32(params, dst);
+    } break;
+    case GGML_TYPE_F16: {
+        ggml_compute_forward_gelu_f16(params, dst);
+    } break;
+    default: {
+        GGML_ABORT("fatal error");
+    }
     }
 }
 
 // ggml_compute_fill
 
-static void ggml_compute_forward_fill_f32(const ggml_compute_params * params, ggml_tensor * dst) {
+static void ggml_compute_forward_fill_f32(const ggml_compute_params* params, ggml_tensor* dst) {
     const float c = ggml_get_op_params_f32(dst, 0);
 
     GGML_TENSOR_LOCALS(int64_t, ne, dst, ne);
-    GGML_TENSOR_LOCALS(size_t,  nb, dst, nb);
+    GGML_TENSOR_LOCALS(size_t, nb, dst, nb);
 
     const auto [ir0, ir1] = get_thread_range(params, dst);
 
     for (int64_t ir = ir0; ir < ir1; ++ir) {
-        const int64_t i03 = ir/(ne2*ne1);
-        const int64_t i02 = (ir - i03*ne2*ne1)/ne1;
-        const int64_t i01 = (ir - i03*ne2*ne1 - i02*ne1);
+        const int64_t i03 = ir / (ne2 * ne1);
+        const int64_t i02 = (ir - i03 * ne2 * ne1) / ne1;
+        const int64_t i01 = (ir - i03 * ne2 * ne1 - i02 * ne1);
 
-        float * dst_ptr  = (float *) ((char *) dst->data + i03*nb3 + i02*nb2 + i01*nb1);
+        float* dst_ptr = (float*)((char*)dst->data + i03 * nb3 + i02 * nb2 + i01 * nb1);
 
         ggml_vec_set_f32(ne0, dst_ptr, c);
     }
 }
 
-void ggml_compute_forward_fill(const ggml_compute_params * params, ggml_tensor * dst) {
+void ggml_compute_forward_fill(const ggml_compute_params* params, ggml_tensor* dst) {
     ggml_compute_forward_fill_f32(params, dst);
 }
 
 // ggml_compute_tri
 
-static void ggml_compute_forward_tri_f32(const ggml_compute_params * params, ggml_tensor * dst) {
-    const ggml_tensor * src0 = dst->src[0];
+static void ggml_compute_forward_tri_f32(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
 
-    const ggml_tri_type ttype = (ggml_tri_type) ggml_get_op_params_i32(dst, 0);
+    const ggml_tri_type ttype = (ggml_tri_type)ggml_get_op_params_i32(dst, 0);
 
     GGML_ASSERT(ggml_is_contiguous(src0));
 
@@ -2256,20 +2069,29 @@ static void ggml_compute_forward_tri_f32(const ggml_compute_params * params, ggm
     bool (*bipred)(int, int);
 
     switch (ttype) {
-        case GGML_TRI_TYPE_LOWER:      bipred = [](int i, int r) { return i <  r; }; break;
-        case GGML_TRI_TYPE_LOWER_DIAG: bipred = [](int i, int r) { return i <= r; }; break;
-        case GGML_TRI_TYPE_UPPER:      bipred = [](int i, int r) { return i >  r; }; break;
-        case GGML_TRI_TYPE_UPPER_DIAG: bipred = [](int i, int r) { return i >= r; }; break;
-        default: GGML_ABORT("invalid tri type");
+    case GGML_TRI_TYPE_LOWER:
+        bipred = [](int i, int r) { return i < r; };
+        break;
+    case GGML_TRI_TYPE_LOWER_DIAG:
+        bipred = [](int i, int r) { return i <= r; };
+        break;
+    case GGML_TRI_TYPE_UPPER:
+        bipred = [](int i, int r) { return i > r; };
+        break;
+    case GGML_TRI_TYPE_UPPER_DIAG:
+        bipred = [](int i, int r) { return i >= r; };
+        break;
+    default:
+        GGML_ABORT("invalid tri type");
     }
 
     for (int64_t ir = ir0; ir < ir1; ++ir) {
-        const int64_t i03 = ir/(ne02*ne01);
-        const int64_t i02 = (ir - i03*ne02*ne01)/ne01;
-        const int64_t i01 = (ir - i03*ne02*ne01 - i02*ne01);
+        const int64_t i03 = ir / (ne02 * ne01);
+        const int64_t i02 = (ir - i03 * ne02 * ne01) / ne01;
+        const int64_t i01 = (ir - i03 * ne02 * ne01 - i02 * ne01);
 
-        const float * src_ptr = (const float  *) ((const char *) src0->data + i03*nb03 + i02*nb02 + i01*nb01);
-              float * dst_ptr = (      float  *) ((      char *) dst->data  + i03*nb3  + i02*nb2  + i01*nb1);
+        const float* src_ptr = (const float*)((const char*)src0->data + i03 * nb03 + i02 * nb02 + i01 * nb01);
+        float* dst_ptr = (float*)((char*)dst->data + i03 * nb3 + i02 * nb2 + i01 * nb1);
 
         for (int i0 = 0; i0 < ne0; ++i0) {
             dst_ptr[i0] = bipred(i0, i01) ? src_ptr[i0] : 0.0f;
@@ -2277,36 +2099,31 @@ static void ggml_compute_forward_tri_f32(const ggml_compute_params * params, ggm
     }
 }
 
-void ggml_compute_forward_tri(const ggml_compute_params * params, ggml_tensor * dst) {
-    const ggml_tensor * src0 = dst->src[0];
+void ggml_compute_forward_tri(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
 
     switch (src0->type) {
-        case GGML_TYPE_F32:
-            {
-                ggml_compute_forward_tri_f32(params, dst);
-            } break;
-        default:
-            {
-                GGML_ABORT("fatal error");
-            }
+    case GGML_TYPE_F32: {
+        ggml_compute_forward_tri_f32(params, dst);
+    } break;
+    default: {
+        GGML_ABORT("fatal error");
+    }
     }
 }
 
 // ggml_compute_forward_gelu_erf
 
-static void ggml_compute_forward_gelu_erf_f32(
-        const ggml_compute_params * params,
-        ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
+static void ggml_compute_forward_gelu_erf_f32(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
 
     assert(ggml_is_contiguous_rows(src0));
     assert(ggml_are_same_shape(src0, dst));
 
     GGML_TENSOR_LOCALS(int64_t, ne0, src0, ne)
-    GGML_TENSOR_LOCALS(size_t,  nb0, src0, nb)
-    GGML_TENSOR_LOCALS(int64_t, ne,  dst,  ne)
-    GGML_TENSOR_LOCALS(size_t,  nb,  dst,  nb)
+    GGML_TENSOR_LOCALS(size_t, nb0, src0, nb)
+    GGML_TENSOR_LOCALS(int64_t, ne, dst, ne)
+    GGML_TENSOR_LOCALS(size_t, nb, dst, nb)
 
     const int ith = params->ith;
     const int nth = params->nth;
@@ -2315,24 +2132,23 @@ static void ggml_compute_forward_gelu_erf_f32(
     const int nr = ggml_nrows(src0);
 
     // rows per thread
-    const int dr = (nr + nth - 1)/nth;
+    const int dr = (nr + nth - 1) / nth;
 
     // row range for this thread
-    const int ir0 = dr*ith;
+    const int ir0 = dr * ith;
     const int ir1 = MIN(ir0 + dr, nr);
 
     for (int ir = ir0; ir < ir1; ++ir) {
-        const int i3 = ir/(ne02*ne01);
-        const int i2 = (ir - i3*ne02*ne01)/ne01;
-        const int i1 = (ir - i3*ne02*ne01 - i2*ne01);
+        const int i3 = ir / (ne02 * ne01);
+        const int i2 = (ir - i3 * ne02 * ne01) / ne01;
+        const int i1 = (ir - i3 * ne02 * ne01 - i2 * ne01);
 
-        ggml_vec_gelu_erf_f32(nc,
-                (float *) ((char *) dst->data  + i3*nb3  + i2*nb2  + i1*nb1),
-                (float *) ((char *) src0->data + i3*nb03 + i2*nb02 + i1*nb01));
+        ggml_vec_gelu_erf_f32(nc, (float*)((char*)dst->data + i3 * nb3 + i2 * nb2 + i1 * nb1),
+                              (float*)((char*)src0->data + i3 * nb03 + i2 * nb02 + i1 * nb01));
 
 #ifndef NDEBUG
         for (int k = 0; k < nc; k++) {
-            const float x = ((float *) ((char *) dst->data + i3*nb3 + i2*nb2 + i1*(dst->nb[1])))[k];
+            const float x = ((float*)((char*)dst->data + i3 * nb3 + i2 * nb2 + i1 * (dst->nb[1])))[k];
             GGML_UNUSED(x);
             assert(!isnan(x));
             assert(!isinf(x));
@@ -2341,19 +2157,16 @@ static void ggml_compute_forward_gelu_erf_f32(
     }
 }
 
-static void ggml_compute_forward_gelu_erf_f16(
-    const ggml_compute_params * params,
-    ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
+static void ggml_compute_forward_gelu_erf_f16(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
 
     assert(ggml_is_contiguous_rows(src0));
     assert(ggml_are_same_shape(src0, dst));
 
     GGML_TENSOR_LOCALS(int64_t, ne0, src0, ne)
-    GGML_TENSOR_LOCALS(size_t,  nb0, src0, nb)
-    GGML_TENSOR_LOCALS(int64_t, ne,  dst,  ne)
-    GGML_TENSOR_LOCALS(size_t,  nb,  dst,  nb)
+    GGML_TENSOR_LOCALS(size_t, nb0, src0, nb)
+    GGML_TENSOR_LOCALS(int64_t, ne, dst, ne)
+    GGML_TENSOR_LOCALS(size_t, nb, dst, nb)
 
     const int ith = params->ith;
     const int nth = params->nth;
@@ -2362,24 +2175,23 @@ static void ggml_compute_forward_gelu_erf_f16(
     const int nr = ggml_nrows(src0);
 
     // rows per thread
-    const int dr = (nr + nth - 1)/nth;
+    const int dr = (nr + nth - 1) / nth;
 
     // row range for this thread
-    const int ir0 = dr*ith;
+    const int ir0 = dr * ith;
     const int ir1 = MIN(ir0 + dr, nr);
 
     for (int ir = ir0; ir < ir1; ++ir) {
-        const int i3 = ir/(ne02*ne01);
-        const int i2 = (ir - i3*ne02*ne01)/ne01;
-        const int i1 = (ir - i3*ne02*ne01 - i2*ne01);
+        const int i3 = ir / (ne02 * ne01);
+        const int i2 = (ir - i3 * ne02 * ne01) / ne01;
+        const int i1 = (ir - i3 * ne02 * ne01 - i2 * ne01);
 
-        ggml_vec_gelu_erf_f16(nc,
-                (ggml_fp16_t *) ((char *) dst->data  + i3*nb3  + i2*nb2  + i1*nb1),
-                (ggml_fp16_t *) ((char *) src0->data + i3*nb03 + i2*nb02 + i1*nb01));
+        ggml_vec_gelu_erf_f16(nc, (ggml_fp16_t*)((char*)dst->data + i3 * nb3 + i2 * nb2 + i1 * nb1),
+                              (ggml_fp16_t*)((char*)src0->data + i3 * nb03 + i2 * nb02 + i1 * nb01));
 
 #ifndef NDEBUG
         for (int k = 0; k < nc; k++) {
-            const ggml_fp16_t x = ((ggml_fp16_t *) ((char *) dst->data + i3*nb3 + i2*nb2 + i1*( dst->nb[1])))[k];
+            const ggml_fp16_t x = ((ggml_fp16_t*)((char*)dst->data + i3 * nb3 + i2 * nb2 + i1 * (dst->nb[1])))[k];
             const float v = GGML_CPU_FP16_TO_FP32(x);
             GGML_UNUSED(v);
             assert(!isnan(v));
@@ -2389,43 +2201,34 @@ static void ggml_compute_forward_gelu_erf_f16(
     }
 }
 
-static void ggml_compute_forward_gelu_erf(
-        const ggml_compute_params * params,
-        ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
+static void ggml_compute_forward_gelu_erf(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
 
     switch (src0->type) {
-        case GGML_TYPE_F32:
-            {
-                ggml_compute_forward_gelu_erf_f32(params, dst);
-            } break;
-        case GGML_TYPE_F16:
-            {
-                ggml_compute_forward_gelu_erf_f16(params, dst);
-            } break;
-        default:
-            {
-                GGML_ABORT("fatal error");
-            }
+    case GGML_TYPE_F32: {
+        ggml_compute_forward_gelu_erf_f32(params, dst);
+    } break;
+    case GGML_TYPE_F16: {
+        ggml_compute_forward_gelu_erf_f16(params, dst);
+    } break;
+    default: {
+        GGML_ABORT("fatal error");
+    }
     }
 }
 
 // ggml_compute_forward_gelu_quick
 
-static void ggml_compute_forward_gelu_quick_f32(
-        const ggml_compute_params * params,
-        ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
+static void ggml_compute_forward_gelu_quick_f32(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
 
     assert(ggml_is_contiguous_rows(src0));
     assert(ggml_are_same_shape(src0, dst));
 
     GGML_TENSOR_LOCALS(int64_t, ne0, src0, ne)
-    GGML_TENSOR_LOCALS(size_t,  nb0, src0, nb)
-    GGML_TENSOR_LOCALS(int64_t, ne,  dst,  ne)
-    GGML_TENSOR_LOCALS(size_t,  nb,  dst,  nb)
+    GGML_TENSOR_LOCALS(size_t, nb0, src0, nb)
+    GGML_TENSOR_LOCALS(int64_t, ne, dst, ne)
+    GGML_TENSOR_LOCALS(size_t, nb, dst, nb)
 
     const int ith = params->ith;
     const int nth = params->nth;
@@ -2434,24 +2237,23 @@ static void ggml_compute_forward_gelu_quick_f32(
     const int nr = ggml_nrows(src0);
 
     // rows per thread
-    const int dr = (nr + nth - 1)/nth;
+    const int dr = (nr + nth - 1) / nth;
 
     // row range for this thread
-    const int ir0 = dr*ith;
+    const int ir0 = dr * ith;
     const int ir1 = MIN(ir0 + dr, nr);
 
     for (int ir = ir0; ir < ir1; ++ir) {
-        const int i3 = ir/(ne02*ne01);
-        const int i2 = (ir - i3*ne02*ne01)/ne01;
-        const int i1 = (ir - i3*ne02*ne01 - i2*ne01);
+        const int i3 = ir / (ne02 * ne01);
+        const int i2 = (ir - i3 * ne02 * ne01) / ne01;
+        const int i1 = (ir - i3 * ne02 * ne01 - i2 * ne01);
 
-        ggml_vec_gelu_quick_f32(nc,
-                (float *) ((char *) dst->data  + i3*nb3  + i2*nb2  + i1*nb1),
-                (float *) ((char *) src0->data + i3*nb03 + i2*nb02 + i1*nb01));
+        ggml_vec_gelu_quick_f32(nc, (float*)((char*)dst->data + i3 * nb3 + i2 * nb2 + i1 * nb1),
+                                (float*)((char*)src0->data + i3 * nb03 + i2 * nb02 + i1 * nb01));
 
 #ifndef NDEBUG
         for (int k = 0; k < nc; k++) {
-            const float x = ((float *) ((char *) dst->data + i3*nb3 + i2*nb2 + i1*(dst->nb[1])))[k];
+            const float x = ((float*)((char*)dst->data + i3 * nb3 + i2 * nb2 + i1 * (dst->nb[1])))[k];
             GGML_UNUSED(x);
             assert(!isnan(x));
             assert(!isinf(x));
@@ -2460,19 +2262,16 @@ static void ggml_compute_forward_gelu_quick_f32(
     }
 }
 
-static void ggml_compute_forward_gelu_quick_f16(
-    const ggml_compute_params * params,
-    ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
+static void ggml_compute_forward_gelu_quick_f16(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
 
     assert(ggml_is_contiguous_rows(src0));
     assert(ggml_are_same_shape(src0, dst));
 
     GGML_TENSOR_LOCALS(int64_t, ne0, src0, ne)
-    GGML_TENSOR_LOCALS(size_t,  nb0, src0, nb)
-    GGML_TENSOR_LOCALS(int64_t, ne,  dst,  ne)
-    GGML_TENSOR_LOCALS(size_t,  nb,  dst,  nb)
+    GGML_TENSOR_LOCALS(size_t, nb0, src0, nb)
+    GGML_TENSOR_LOCALS(int64_t, ne, dst, ne)
+    GGML_TENSOR_LOCALS(size_t, nb, dst, nb)
 
     const int ith = params->ith;
     const int nth = params->nth;
@@ -2481,24 +2280,23 @@ static void ggml_compute_forward_gelu_quick_f16(
     const int nr = ggml_nrows(src0);
 
     // rows per thread
-    const int dr = (nr + nth - 1)/nth;
+    const int dr = (nr + nth - 1) / nth;
 
     // row range for this thread
-    const int ir0 = dr*ith;
+    const int ir0 = dr * ith;
     const int ir1 = MIN(ir0 + dr, nr);
 
     for (int ir = ir0; ir < ir1; ++ir) {
-        const int i3 = ir/(ne02*ne01);
-        const int i2 = (ir - i3*ne02*ne01)/ne01;
-        const int i1 = (ir - i3*ne02*ne01 - i2*ne01);
+        const int i3 = ir / (ne02 * ne01);
+        const int i2 = (ir - i3 * ne02 * ne01) / ne01;
+        const int i1 = (ir - i3 * ne02 * ne01 - i2 * ne01);
 
-        ggml_vec_gelu_quick_f16(nc,
-                (ggml_fp16_t *) ((char *) dst->data  + i3*nb3  + i2*nb2  + i1*nb1),
-                (ggml_fp16_t *) ((char *) src0->data + i3*nb03 + i2*nb02 + i1*nb01));
+        ggml_vec_gelu_quick_f16(nc, (ggml_fp16_t*)((char*)dst->data + i3 * nb3 + i2 * nb2 + i1 * nb1),
+                                (ggml_fp16_t*)((char*)src0->data + i3 * nb03 + i2 * nb02 + i1 * nb01));
 
 #ifndef NDEBUG
         for (int k = 0; k < nc; k++) {
-            const ggml_fp16_t x = ((ggml_fp16_t *) ((char *) dst->data + i3*nb3 + i2*nb2 + i1*( dst->nb[1])))[k];
+            const ggml_fp16_t x = ((ggml_fp16_t*)((char*)dst->data + i3 * nb3 + i2 * nb2 + i1 * (dst->nb[1])))[k];
             const float v = GGML_CPU_FP16_TO_FP32(x);
             GGML_UNUSED(v);
             assert(!isnan(v));
@@ -2508,43 +2306,34 @@ static void ggml_compute_forward_gelu_quick_f16(
     }
 }
 
-static void ggml_compute_forward_gelu_quick(
-        const ggml_compute_params * params,
-        ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
+static void ggml_compute_forward_gelu_quick(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
 
     switch (src0->type) {
-        case GGML_TYPE_F32:
-            {
-                ggml_compute_forward_gelu_quick_f32(params, dst);
-            } break;
-        case GGML_TYPE_F16:
-            {
-                ggml_compute_forward_gelu_quick_f16(params, dst);
-            } break;
-        default:
-            {
-                GGML_ABORT("fatal error");
-            }
+    case GGML_TYPE_F32: {
+        ggml_compute_forward_gelu_quick_f32(params, dst);
+    } break;
+    case GGML_TYPE_F16: {
+        ggml_compute_forward_gelu_quick_f16(params, dst);
+    } break;
+    default: {
+        GGML_ABORT("fatal error");
+    }
     }
 }
 
 // ggml_compute_forward_silu
 
-static void ggml_compute_forward_silu_f32(
-        const ggml_compute_params * params,
-        ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
+static void ggml_compute_forward_silu_f32(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
 
     assert(ggml_is_contiguous_rows(src0));
     assert(ggml_are_same_shape(src0, dst));
 
     GGML_TENSOR_LOCALS(int64_t, ne0, src0, ne)
-    GGML_TENSOR_LOCALS(size_t,  nb0, src0, nb)
-    GGML_TENSOR_LOCALS(int64_t, ne,  dst,  ne)
-    GGML_TENSOR_LOCALS(size_t,  nb,  dst,  nb)
+    GGML_TENSOR_LOCALS(size_t, nb0, src0, nb)
+    GGML_TENSOR_LOCALS(int64_t, ne, dst, ne)
+    GGML_TENSOR_LOCALS(size_t, nb, dst, nb)
 
     const int ith = params->ith;
     const int nth = params->nth;
@@ -2553,24 +2342,23 @@ static void ggml_compute_forward_silu_f32(
     const int nr = ggml_nrows(src0);
 
     // rows per thread
-    const int dr = (nr + nth - 1)/nth;
+    const int dr = (nr + nth - 1) / nth;
 
     // row range for this thread
-    const int ir0 = dr*ith;
+    const int ir0 = dr * ith;
     const int ir1 = MIN(ir0 + dr, nr);
 
     for (int ir = ir0; ir < ir1; ++ir) {
-        const int i3 = ir/(ne02*ne01);
-        const int i2 = (ir - i3*ne02*ne01)/ne01;
-        const int i1 = (ir - i3*ne02*ne01 - i2*ne01);
+        const int i3 = ir / (ne02 * ne01);
+        const int i2 = (ir - i3 * ne02 * ne01) / ne01;
+        const int i1 = (ir - i3 * ne02 * ne01 - i2 * ne01);
 
-        ggml_vec_silu_f32(nc,
-                (float *) ((char *) dst->data  + i3*nb3  + i2*nb2  + i1*nb1),
-                (float *) ((char *) src0->data + i3*nb03 + i2*nb02 + i1*nb01));
+        ggml_vec_silu_f32(nc, (float*)((char*)dst->data + i3 * nb3 + i2 * nb2 + i1 * nb1),
+                          (float*)((char*)src0->data + i3 * nb03 + i2 * nb02 + i1 * nb01));
 
 #ifndef NDEBUG
         for (int k = 0; k < nc; k++) {
-            const float x = ((float *) ((char *) dst->data + i3*nb3 + i2*nb2 + i1*(dst->nb[1])))[k];
+            const float x = ((float*)((char*)dst->data + i3 * nb3 + i2 * nb2 + i1 * (dst->nb[1])))[k];
             GGML_UNUSED(x);
             assert(!isnan(x));
             assert(!isinf(x));
@@ -2579,19 +2367,16 @@ static void ggml_compute_forward_silu_f32(
     }
 }
 
-static void ggml_compute_forward_silu_f16(
-    const ggml_compute_params * params,
-    ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
+static void ggml_compute_forward_silu_f16(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
 
     assert(ggml_is_contiguous_rows(src0));
     assert(ggml_are_same_shape(src0, dst));
 
     GGML_TENSOR_LOCALS(int64_t, ne0, src0, ne)
-    GGML_TENSOR_LOCALS(size_t,  nb0, src0, nb)
-    GGML_TENSOR_LOCALS(int64_t, ne,  dst,  ne)
-    GGML_TENSOR_LOCALS(size_t,  nb,  dst,  nb)
+    GGML_TENSOR_LOCALS(size_t, nb0, src0, nb)
+    GGML_TENSOR_LOCALS(int64_t, ne, dst, ne)
+    GGML_TENSOR_LOCALS(size_t, nb, dst, nb)
 
     const int ith = params->ith;
     const int nth = params->nth;
@@ -2600,24 +2385,23 @@ static void ggml_compute_forward_silu_f16(
     const int nr = ggml_nrows(src0);
 
     // rows per thread
-    const int dr = (nr + nth - 1)/nth;
+    const int dr = (nr + nth - 1) / nth;
 
     // row range for this thread
-    const int ir0 = dr*ith;
+    const int ir0 = dr * ith;
     const int ir1 = MIN(ir0 + dr, nr);
 
     for (int ir = ir0; ir < ir1; ++ir) {
-        const int i3 = ir/(ne02*ne01);
-        const int i2 = (ir - i3*ne02*ne01)/ne01;
-        const int i1 = (ir - i3*ne02*ne01 - i2*ne01);
+        const int i3 = ir / (ne02 * ne01);
+        const int i2 = (ir - i3 * ne02 * ne01) / ne01;
+        const int i1 = (ir - i3 * ne02 * ne01 - i2 * ne01);
 
-        ggml_vec_silu_f16(nc,
-                (ggml_fp16_t *) ((char *) dst->data  + i3*nb3  + i2*nb2  + i1*nb1),
-                (ggml_fp16_t *) ((char *) src0->data + i3*nb03 + i2*nb02 + i1*nb01));
+        ggml_vec_silu_f16(nc, (ggml_fp16_t*)((char*)dst->data + i3 * nb3 + i2 * nb2 + i1 * nb1),
+                          (ggml_fp16_t*)((char*)src0->data + i3 * nb03 + i2 * nb02 + i1 * nb01));
 
 #ifndef NDEBUG
         for (int k = 0; k < nc; k++) {
-            const ggml_fp16_t x = ((ggml_fp16_t *) ((char *) dst->data + i3*nb3 + i2*nb2 + i1*( dst->nb[1])))[k];
+            const ggml_fp16_t x = ((ggml_fp16_t*)((char*)dst->data + i3 * nb3 + i2 * nb2 + i1 * (dst->nb[1])))[k];
             const float v = GGML_CPU_FP16_TO_FP32(x);
             GGML_UNUSED(v);
             assert(!isnan(v));
@@ -2627,34 +2411,25 @@ static void ggml_compute_forward_silu_f16(
     }
 }
 
-static void ggml_compute_forward_silu(
-        const ggml_compute_params * params,
-        ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
+static void ggml_compute_forward_silu(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
 
     switch (src0->type) {
-        case GGML_TYPE_F32:
-            {
-                ggml_compute_forward_silu_f32(params, dst);
-            } break;
-        case GGML_TYPE_F16:
-            {
-                ggml_compute_forward_silu_f16(params, dst);
-            } break;
-        default:
-            {
-                GGML_ABORT("fatal error");
-            }
+    case GGML_TYPE_F32: {
+        ggml_compute_forward_silu_f32(params, dst);
+    } break;
+    case GGML_TYPE_F16: {
+        ggml_compute_forward_silu_f16(params, dst);
+    } break;
+    default: {
+        GGML_ABORT("fatal error");
+    }
     }
 }
 // ggml_compute_forward_leaky_relu
 
-static void ggml_compute_forward_leaky_relu_f32(
-        const ggml_compute_params * params,
-        ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
+static void ggml_compute_forward_leaky_relu_f32(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
 
     if (params->ith != 0) {
         return;
@@ -2664,27 +2439,23 @@ static void ggml_compute_forward_leaky_relu_f32(
     assert(ggml_is_contiguous_1(dst));
     assert(ggml_are_same_shape(src0, dst));
 
-    const int n  = ggml_nrows(src0);
+    const int n = ggml_nrows(src0);
     const int nc = src0->ne[0];
 
     float negative_slope;
     memcpy(&negative_slope, dst->op_params, sizeof(float));
 
-    assert(dst->nb[0]  == sizeof(float));
+    assert(dst->nb[0] == sizeof(float));
     assert(src0->nb[0] == sizeof(float));
 
     for (int i = 0; i < n; i++) {
-        ggml_vec_leaky_relu_f32(nc,
-                (float *) ((char *) dst->data  + i*( dst->nb[1])),
-                (float *) ((char *) src0->data + i*(src0->nb[1])), negative_slope);
+        ggml_vec_leaky_relu_f32(nc, (float*)((char*)dst->data + i * (dst->nb[1])),
+                                (float*)((char*)src0->data + i * (src0->nb[1])), negative_slope);
     }
 }
 
-static void ggml_compute_forward_leaky_relu_f16(
-    const ggml_compute_params * params,
-    ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
+static void ggml_compute_forward_leaky_relu_f16(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
 
     if (params->ith != 0) {
         return;
@@ -2694,52 +2465,42 @@ static void ggml_compute_forward_leaky_relu_f16(
     assert(ggml_is_contiguous_1(dst));
     assert(ggml_are_same_shape(src0, dst));
 
-    const int n  = ggml_nrows(src0);
+    const int n = ggml_nrows(src0);
     const int nc = src0->ne[0];
 
     float negative_slope;
     memcpy(&negative_slope, dst->op_params, sizeof(float));
 
-    assert(dst->nb[0]  == sizeof(ggml_fp16_t));
+    assert(dst->nb[0] == sizeof(ggml_fp16_t));
     assert(src0->nb[0] == sizeof(ggml_fp16_t));
 
     for (int i = 0; i < n; i++) {
-        ggml_vec_leaky_relu_f16(nc,
-                (ggml_fp16_t *) ((char *) dst->data  + i*( dst->nb[1])),
-                (ggml_fp16_t *) ((char *) src0->data + i*(src0->nb[1])), negative_slope);
+        ggml_vec_leaky_relu_f16(nc, (ggml_fp16_t*)((char*)dst->data + i * (dst->nb[1])),
+                                (ggml_fp16_t*)((char*)src0->data + i * (src0->nb[1])), negative_slope);
     }
 }
 
-void ggml_compute_forward_leaky_relu(
-        const ggml_compute_params * params,
-        ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
+void ggml_compute_forward_leaky_relu(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
 
     switch (src0->type) {
-        case GGML_TYPE_F32:
-            {
-                ggml_compute_forward_leaky_relu_f32(params, dst);
-            } break;
-        case GGML_TYPE_F16:
-            {
-                ggml_compute_forward_leaky_relu_f16(params, dst);
-            } break;
-        default:
-            {
-                GGML_ABORT("fatal error");
-            }
+    case GGML_TYPE_F32: {
+        ggml_compute_forward_leaky_relu_f32(params, dst);
+    } break;
+    case GGML_TYPE_F16: {
+        ggml_compute_forward_leaky_relu_f16(params, dst);
+    } break;
+    default: {
+        GGML_ABORT("fatal error");
+    }
     }
 }
 
 // ggml_compute_forward_silu_back
 
-static void ggml_compute_forward_silu_back_f32(
-        const ggml_compute_params * params,
-        ggml_tensor * dst) {
-
-    const ggml_tensor * grad = dst->src[0];
-    const ggml_tensor * src1 = dst->src[1];
+static void ggml_compute_forward_silu_back_f32(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* grad = dst->src[0];
+    const ggml_tensor* src1 = dst->src[1];
 
     assert(ggml_is_contiguous_1(grad));
     assert(ggml_is_contiguous_1(src1));
@@ -2754,21 +2515,20 @@ static void ggml_compute_forward_silu_back_f32(
     const int nr = ggml_nrows(src1);
 
     // rows per thread
-    const int dr = (nr + nth - 1)/nth;
+    const int dr = (nr + nth - 1) / nth;
 
     // row range for this thread
-    const int ir0 = dr*ith;
+    const int ir0 = dr * ith;
     const int ir1 = MIN(ir0 + dr, nr);
 
     for (int i1 = ir0; i1 < ir1; i1++) {
-        ggml_vec_silu_backward_f32(nc,
-                (float *) ((char *) dst->data  + i1*( dst->nb[1])),
-                (float *) ((char *) src1->data + i1*(src1->nb[1])),
-                (float *) ((char *) grad->data + i1*(grad->nb[1])));
+        ggml_vec_silu_backward_f32(nc, (float*)((char*)dst->data + i1 * (dst->nb[1])),
+                                   (float*)((char*)src1->data + i1 * (src1->nb[1])),
+                                   (float*)((char*)grad->data + i1 * (grad->nb[1])));
 
 #ifndef NDEBUG
         for (int k = 0; k < nc; k++) {
-            const float x = ((float *) ((char *) dst->data + i1*( dst->nb[1])))[k];
+            const float x = ((float*)((char*)dst->data + i1 * (dst->nb[1])))[k];
             GGML_UNUSED(x);
             assert(!isnan(x));
             assert(!isinf(x));
@@ -2777,12 +2537,9 @@ static void ggml_compute_forward_silu_back_f32(
     }
 }
 
-static void ggml_compute_forward_silu_back_f16(
-    const ggml_compute_params * params,
-    ggml_tensor * dst) {
-
-    const ggml_tensor * grad = dst->src[0];
-    const ggml_tensor * src1 = dst->src[1];
+static void ggml_compute_forward_silu_back_f16(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* grad = dst->src[0];
+    const ggml_tensor* src1 = dst->src[1];
 
     assert(ggml_is_contiguous_1(grad));
     assert(ggml_is_contiguous_1(src1));
@@ -2797,21 +2554,20 @@ static void ggml_compute_forward_silu_back_f16(
     const int nr = ggml_nrows(src1);
 
     // rows per thread
-    const int dr = (nr + nth - 1)/nth;
+    const int dr = (nr + nth - 1) / nth;
 
     // row range for this thread
-    const int ir0 = dr*ith;
+    const int ir0 = dr * ith;
     const int ir1 = MIN(ir0 + dr, nr);
 
     for (int i1 = ir0; i1 < ir1; i1++) {
-        ggml_vec_silu_backward_f16(nc,
-                (ggml_fp16_t *) ((char *) dst->data  + i1*( dst->nb[1])),
-                (ggml_fp16_t *) ((char *) src1->data + i1*(src1->nb[1])),
-                (ggml_fp16_t *) ((char *) grad->data + i1*(grad->nb[1])));
+        ggml_vec_silu_backward_f16(nc, (ggml_fp16_t*)((char*)dst->data + i1 * (dst->nb[1])),
+                                   (ggml_fp16_t*)((char*)src1->data + i1 * (src1->nb[1])),
+                                   (ggml_fp16_t*)((char*)grad->data + i1 * (grad->nb[1])));
 
 #ifndef NDEBUG
         for (int k = 0; k < nc; k++) {
-            const float x = ((ggml_fp16_t *) ((char *) dst->data + i1*( dst->nb[1])))[k];
+            const float x = ((ggml_fp16_t*)((char*)dst->data + i1 * (dst->nb[1])))[k];
             const float v = GGML_CPU_FP16_TO_FP32(x);
             GGML_UNUSED(v);
             assert(!isnan(v));
@@ -2821,38 +2577,29 @@ static void ggml_compute_forward_silu_back_f16(
     }
 }
 
-void ggml_compute_forward_silu_back(
-        const ggml_compute_params * params,
-        ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
+void ggml_compute_forward_silu_back(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
 
     switch (src0->type) {
-        case GGML_TYPE_F32:
-            {
-                ggml_compute_forward_silu_back_f32(params, dst);
-            } break;
-        case GGML_TYPE_F16:
-            {
-                ggml_compute_forward_silu_back_f16(params, dst);
-            } break;
-        default:
-            {
-                GGML_ABORT("fatal error");
-            }
+    case GGML_TYPE_F32: {
+        ggml_compute_forward_silu_back_f32(params, dst);
+    } break;
+    case GGML_TYPE_F16: {
+        ggml_compute_forward_silu_back_f16(params, dst);
+    } break;
+    default: {
+        GGML_ABORT("fatal error");
+    }
     }
 }
 
 // ggml_compute_forward_reglu
 
-static void ggml_compute_forward_reglu_f32(
-        const ggml_compute_params * params,
-        ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
-    const ggml_tensor * src1 = dst->src[1];
-    char * src0_d = (char *) src0->data;
-    char * src1_d = (char *) (src1 ? src1->data : src0->data);
+static void ggml_compute_forward_reglu_f32(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
+    const ggml_tensor* src1 = dst->src[1];
+    char* src0_d = (char*)src0->data;
+    char* src1_d = (char*)(src1 ? src1->data : src0->data);
     const size_t src0_o = src0->nb[1];
     const size_t src1_o = src1 ? src1->nb[1] : src0->nb[1];
 
@@ -2876,26 +2623,26 @@ static void ggml_compute_forward_reglu_f32(
     const int32_t swapped = ggml_get_op_params_i32(dst, 1);
 
     // rows per thread
-    const int dr = (nr + nth - 1)/nth;
+    const int dr = (nr + nth - 1) / nth;
 
     // row range for this thread
-    const int ir0 = dr*ith;
+    const int ir0 = dr * ith;
     const int ir1 = MIN(ir0 + dr, nr);
 
     for (int i1 = ir0; i1 < ir1; i1++) {
-        float * src0_p = (float *) (src0_d + i1*src0_o);
-        float * src1_p = (float *) (src1_d + i1*src1_o);
+        float* src0_p = (float*)(src0_d + i1 * src0_o);
+        float* src1_p = (float*)(src1_d + i1 * src1_o);
 
         if (!src1) {
             src0_p += swapped ? nc : 0;
             src1_p += swapped ? 0 : nc;
         }
 
-        ggml_vec_reglu_f32(nc, (float *) ((char *) dst->data + i1*(dst->nb[1])), src0_p, src1_p);
+        ggml_vec_reglu_f32(nc, (float*)((char*)dst->data + i1 * (dst->nb[1])), src0_p, src1_p);
 
 #ifndef NDEBUG
         for (int k = 0; k < nc; k++) {
-            const float x = ((float *) ((char *) dst->data + i1*( dst->nb[1])))[k];
+            const float x = ((float*)((char*)dst->data + i1 * (dst->nb[1])))[k];
             GGML_UNUSED(x);
             assert(!isnan(x));
             assert(!isinf(x));
@@ -2904,14 +2651,11 @@ static void ggml_compute_forward_reglu_f32(
     }
 }
 
-static void ggml_compute_forward_reglu_f16(
-    const ggml_compute_params * params,
-    ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
-    const ggml_tensor * src1 = dst->src[1];
-    char * src0_d = (char *) src0->data;
-    char * src1_d = (char *) (src1 ? src1->data : src0->data);
+static void ggml_compute_forward_reglu_f16(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
+    const ggml_tensor* src1 = dst->src[1];
+    char* src0_d = (char*)src0->data;
+    char* src1_d = (char*)(src1 ? src1->data : src0->data);
     const size_t src0_o = src0->nb[1];
     const size_t src1_o = src1 ? src1->nb[1] : src0->nb[1];
 
@@ -2935,26 +2679,26 @@ static void ggml_compute_forward_reglu_f16(
     const int32_t swapped = ggml_get_op_params_i32(dst, 1);
 
     // rows per thread
-    const int dr = (nr + nth - 1)/nth;
+    const int dr = (nr + nth - 1) / nth;
 
     // row range for this thread
-    const int ir0 = dr*ith;
+    const int ir0 = dr * ith;
     const int ir1 = MIN(ir0 + dr, nr);
 
     for (int i1 = ir0; i1 < ir1; i1++) {
-        ggml_fp16_t * src0_p = (ggml_fp16_t *) (src0_d + i1*src0_o);
-        ggml_fp16_t * src1_p = (ggml_fp16_t *) (src1_d + i1*src1_o);
+        ggml_fp16_t* src0_p = (ggml_fp16_t*)(src0_d + i1 * src0_o);
+        ggml_fp16_t* src1_p = (ggml_fp16_t*)(src1_d + i1 * src1_o);
 
         if (!src1) {
             src0_p += swapped ? nc : 0;
             src1_p += swapped ? 0 : nc;
         }
 
-        ggml_vec_reglu_f16(nc, (ggml_fp16_t *) ((char *) dst->data + i1*(dst->nb[1])), src0_p, src1_p);
+        ggml_vec_reglu_f16(nc, (ggml_fp16_t*)((char*)dst->data + i1 * (dst->nb[1])), src0_p, src1_p);
 
 #ifndef NDEBUG
         for (int k = 0; k < nc; k++) {
-            const ggml_fp16_t x = ((ggml_fp16_t *) ((char *) dst->data + i1*( dst->nb[1])))[k];
+            const ggml_fp16_t x = ((ggml_fp16_t*)((char*)dst->data + i1 * (dst->nb[1])))[k];
             const float v = GGML_FP16_TO_FP32(x);
             GGML_UNUSED(v);
             assert(!isnan(v));
@@ -2964,38 +2708,29 @@ static void ggml_compute_forward_reglu_f16(
     }
 }
 
-static void ggml_compute_forward_reglu(
-        const ggml_compute_params * params,
-        ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
+static void ggml_compute_forward_reglu(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
 
     switch (src0->type) {
-        case GGML_TYPE_F32:
-            {
-                ggml_compute_forward_reglu_f32(params, dst);
-            } break;
-        case GGML_TYPE_F16:
-            {
-                ggml_compute_forward_reglu_f16(params, dst);
-            } break;
-        default:
-            {
-                GGML_ABORT("fatal error");
-            }
+    case GGML_TYPE_F32: {
+        ggml_compute_forward_reglu_f32(params, dst);
+    } break;
+    case GGML_TYPE_F16: {
+        ggml_compute_forward_reglu_f16(params, dst);
+    } break;
+    default: {
+        GGML_ABORT("fatal error");
+    }
     }
 }
 
 // ggml_compute_forward_geglu
 
-static void ggml_compute_forward_geglu_f32(
-        const ggml_compute_params * params,
-        ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
-    const ggml_tensor * src1 = dst->src[1];
-    char * src0_d = (char *) src0->data;
-    char * src1_d = (char *) (src1 ? src1->data : src0->data);
+static void ggml_compute_forward_geglu_f32(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
+    const ggml_tensor* src1 = dst->src[1];
+    char* src0_d = (char*)src0->data;
+    char* src1_d = (char*)(src1 ? src1->data : src0->data);
     const size_t src0_o = src0->nb[1];
     const size_t src1_o = src1 ? src1->nb[1] : src0->nb[1];
 
@@ -3019,26 +2754,26 @@ static void ggml_compute_forward_geglu_f32(
     const int32_t swapped = ggml_get_op_params_i32(dst, 1);
 
     // rows per thread
-    const int dr = (nr + nth - 1)/nth;
+    const int dr = (nr + nth - 1) / nth;
 
     // row range for this thread
-    const int ir0 = dr*ith;
+    const int ir0 = dr * ith;
     const int ir1 = MIN(ir0 + dr, nr);
 
     for (int i1 = ir0; i1 < ir1; i1++) {
-        float * src0_p = (float *) (src0_d + i1*src0_o);
-        float * src1_p = (float *) (src1_d + i1*src1_o);
+        float* src0_p = (float*)(src0_d + i1 * src0_o);
+        float* src1_p = (float*)(src1_d + i1 * src1_o);
 
         if (!src1) {
             src0_p += swapped ? nc : 0;
             src1_p += swapped ? 0 : nc;
         }
 
-        ggml_vec_geglu_f32(nc, (float *) ((char *) dst->data + i1*(dst->nb[1])), src0_p, src1_p);
+        ggml_vec_geglu_f32(nc, (float*)((char*)dst->data + i1 * (dst->nb[1])), src0_p, src1_p);
 
 #ifndef NDEBUG
         for (int k = 0; k < nc; k++) {
-            const float x = ((float *) ((char *) dst->data + i1*( dst->nb[1])))[k];
+            const float x = ((float*)((char*)dst->data + i1 * (dst->nb[1])))[k];
             GGML_UNUSED(x);
             assert(!isnan(x));
             assert(!isinf(x));
@@ -3047,14 +2782,11 @@ static void ggml_compute_forward_geglu_f32(
     }
 }
 
-static void ggml_compute_forward_geglu_f16(
-    const ggml_compute_params * params,
-    ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
-    const ggml_tensor * src1 = dst->src[1];
-    char * src0_d = (char *) src0->data;
-    char * src1_d = (char *) (src1 ? src1->data : src0->data);
+static void ggml_compute_forward_geglu_f16(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
+    const ggml_tensor* src1 = dst->src[1];
+    char* src0_d = (char*)src0->data;
+    char* src1_d = (char*)(src1 ? src1->data : src0->data);
     const size_t src0_o = src0->nb[1];
     const size_t src1_o = src1 ? src1->nb[1] : src0->nb[1];
 
@@ -3078,26 +2810,26 @@ static void ggml_compute_forward_geglu_f16(
     const int32_t swapped = ggml_get_op_params_i32(dst, 1);
 
     // rows per thread
-    const int dr = (nr + nth - 1)/nth;
+    const int dr = (nr + nth - 1) / nth;
 
     // row range for this thread
-    const int ir0 = dr*ith;
+    const int ir0 = dr * ith;
     const int ir1 = MIN(ir0 + dr, nr);
 
     for (int i1 = ir0; i1 < ir1; i1++) {
-        ggml_fp16_t * src0_p = (ggml_fp16_t *) (src0_d + i1*src0_o);
-        ggml_fp16_t * src1_p = (ggml_fp16_t *) (src1_d + i1*src1_o);
+        ggml_fp16_t* src0_p = (ggml_fp16_t*)(src0_d + i1 * src0_o);
+        ggml_fp16_t* src1_p = (ggml_fp16_t*)(src1_d + i1 * src1_o);
 
         if (!src1) {
             src0_p += swapped ? nc : 0;
             src1_p += swapped ? 0 : nc;
         }
 
-        ggml_vec_geglu_f16(nc, (ggml_fp16_t *) ((char *) dst->data + i1*(dst->nb[1])), src0_p, src1_p);
+        ggml_vec_geglu_f16(nc, (ggml_fp16_t*)((char*)dst->data + i1 * (dst->nb[1])), src0_p, src1_p);
 
 #ifndef NDEBUG
         for (int k = 0; k < nc; k++) {
-            const ggml_fp16_t x = ((ggml_fp16_t *) ((char *) dst->data + i1*( dst->nb[1])))[k];
+            const ggml_fp16_t x = ((ggml_fp16_t*)((char*)dst->data + i1 * (dst->nb[1])))[k];
             const float v = GGML_FP16_TO_FP32(x);
             GGML_UNUSED(v);
             assert(!isnan(v));
@@ -3107,38 +2839,29 @@ static void ggml_compute_forward_geglu_f16(
     }
 }
 
-static void ggml_compute_forward_geglu(
-        const ggml_compute_params * params,
-        ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
+static void ggml_compute_forward_geglu(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
 
     switch (src0->type) {
-        case GGML_TYPE_F32:
-            {
-                ggml_compute_forward_geglu_f32(params, dst);
-            } break;
-        case GGML_TYPE_F16:
-            {
-                ggml_compute_forward_geglu_f16(params, dst);
-            } break;
-        default:
-            {
-                GGML_ABORT("fatal error");
-            }
+    case GGML_TYPE_F32: {
+        ggml_compute_forward_geglu_f32(params, dst);
+    } break;
+    case GGML_TYPE_F16: {
+        ggml_compute_forward_geglu_f16(params, dst);
+    } break;
+    default: {
+        GGML_ABORT("fatal error");
+    }
     }
 }
 
 // ggml_compute_forward_swiglu
 
-static void ggml_compute_forward_swiglu_f32(
-        const ggml_compute_params * params,
-        ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
-    const ggml_tensor * src1 = dst->src[1];
-    char * src0_d = (char *) src0->data;
-    char * src1_d = (char *) (src1 ? src1->data : src0->data);
+static void ggml_compute_forward_swiglu_f32(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
+    const ggml_tensor* src1 = dst->src[1];
+    char* src0_d = (char*)src0->data;
+    char* src1_d = (char*)(src1 ? src1->data : src0->data);
     const size_t src0_o = src0->nb[1];
     const size_t src1_o = src1 ? src1->nb[1] : src0->nb[1];
 
@@ -3162,26 +2885,26 @@ static void ggml_compute_forward_swiglu_f32(
     const int32_t swapped = ggml_get_op_params_i32(dst, 1);
 
     // rows per thread
-    const int dr = (nr + nth - 1)/nth;
+    const int dr = (nr + nth - 1) / nth;
 
     // row range for this thread
-    const int ir0 = dr*ith;
+    const int ir0 = dr * ith;
     const int ir1 = MIN(ir0 + dr, nr);
 
     for (int i1 = ir0; i1 < ir1; i1++) {
-        float * src0_p = (float *) (src0_d + i1*src0_o);
-        float * src1_p = (float *) (src1_d + i1*src1_o);
+        float* src0_p = (float*)(src0_d + i1 * src0_o);
+        float* src1_p = (float*)(src1_d + i1 * src1_o);
 
         if (!src1) {
             src0_p += swapped ? nc : 0;
             src1_p += swapped ? 0 : nc;
         }
 
-        ggml_vec_swiglu_f32(nc, (float *) ((char *) dst->data + i1*(dst->nb[1])), src0_p, src1_p);
+        ggml_vec_swiglu_f32(nc, (float*)((char*)dst->data + i1 * (dst->nb[1])), src0_p, src1_p);
 
 #ifndef NDEBUG
         for (int k = 0; k < nc; k++) {
-            const float x = ((float *) ((char *) dst->data + i1*( dst->nb[1])))[k];
+            const float x = ((float*)((char*)dst->data + i1 * (dst->nb[1])))[k];
             GGML_UNUSED(x);
             assert(!isnan(x));
             assert(!isinf(x));
@@ -3190,14 +2913,11 @@ static void ggml_compute_forward_swiglu_f32(
     }
 }
 
-static void ggml_compute_forward_swiglu_f16(
-    const ggml_compute_params * params,
-    ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
-    const ggml_tensor * src1 = dst->src[1];
-    char * src0_d = (char *) src0->data;
-    char * src1_d = (char *) (src1 ? src1->data : src0->data);
+static void ggml_compute_forward_swiglu_f16(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
+    const ggml_tensor* src1 = dst->src[1];
+    char* src0_d = (char*)src0->data;
+    char* src1_d = (char*)(src1 ? src1->data : src0->data);
     const size_t src0_o = src0->nb[1];
     const size_t src1_o = src1 ? src1->nb[1] : src0->nb[1];
 
@@ -3221,26 +2941,26 @@ static void ggml_compute_forward_swiglu_f16(
     const int32_t swapped = ggml_get_op_params_i32(dst, 1);
 
     // rows per thread
-    const int dr = (nr + nth - 1)/nth;
+    const int dr = (nr + nth - 1) / nth;
 
     // row range for this thread
-    const int ir0 = dr*ith;
+    const int ir0 = dr * ith;
     const int ir1 = MIN(ir0 + dr, nr);
 
     for (int i1 = ir0; i1 < ir1; i1++) {
-        ggml_fp16_t * src0_p = (ggml_fp16_t *) (src0_d + i1*src0_o);
-        ggml_fp16_t * src1_p = (ggml_fp16_t *) (src1_d + i1*src1_o);
+        ggml_fp16_t* src0_p = (ggml_fp16_t*)(src0_d + i1 * src0_o);
+        ggml_fp16_t* src1_p = (ggml_fp16_t*)(src1_d + i1 * src1_o);
 
         if (!src1) {
             src0_p += swapped ? nc : 0;
             src1_p += swapped ? 0 : nc;
         }
 
-        ggml_vec_swiglu_f16(nc, (ggml_fp16_t *) ((char *) dst->data + i1*(dst->nb[1])), src0_p, src1_p);
+        ggml_vec_swiglu_f16(nc, (ggml_fp16_t*)((char*)dst->data + i1 * (dst->nb[1])), src0_p, src1_p);
 
 #ifndef NDEBUG
         for (int k = 0; k < nc; k++) {
-            const ggml_fp16_t x = ((ggml_fp16_t *) ((char *) dst->data + i1*( dst->nb[1])))[k];
+            const ggml_fp16_t x = ((ggml_fp16_t*)((char*)dst->data + i1 * (dst->nb[1])))[k];
             const float v = GGML_FP16_TO_FP32(x);
             GGML_UNUSED(v);
             assert(!isnan(v));
@@ -3250,38 +2970,29 @@ static void ggml_compute_forward_swiglu_f16(
     }
 }
 
-static void ggml_compute_forward_swiglu(
-        const ggml_compute_params * params,
-        ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
+static void ggml_compute_forward_swiglu(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
 
     switch (src0->type) {
-        case GGML_TYPE_F32:
-            {
-                ggml_compute_forward_swiglu_f32(params, dst);
-            } break;
-        case GGML_TYPE_F16:
-            {
-                ggml_compute_forward_swiglu_f16(params, dst);
-            } break;
-        default:
-            {
-                GGML_ABORT("fatal error");
-            }
+    case GGML_TYPE_F32: {
+        ggml_compute_forward_swiglu_f32(params, dst);
+    } break;
+    case GGML_TYPE_F16: {
+        ggml_compute_forward_swiglu_f16(params, dst);
+    } break;
+    default: {
+        GGML_ABORT("fatal error");
+    }
     }
 }
 
 // ggml_compute_forward_swiglu_oai
 
-static void ggml_compute_forward_swiglu_oai_f32(
-        const ggml_compute_params * params,
-        ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
-    const ggml_tensor * src1 = dst->src[1];
-    char * src0_d = (char *) src0->data;
-    char * src1_d = (char *) (src1 ? src1->data : src0->data);
+static void ggml_compute_forward_swiglu_oai_f32(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
+    const ggml_tensor* src1 = dst->src[1];
+    char* src0_d = (char*)src0->data;
+    char* src1_d = (char*)(src1 ? src1->data : src0->data);
     const size_t src0_o = src0->nb[1];
     const size_t src1_o = src1 ? src1->nb[1] : src0->nb[1];
 
@@ -3307,16 +3018,16 @@ static void ggml_compute_forward_swiglu_oai_f32(
     const float limit = ggml_get_op_params_f32(dst, 3);
 
     // rows per thread
-    const int dr = (nr + nth - 1)/nth;
+    const int dr = (nr + nth - 1) / nth;
 
     // row range for this thread
-    const int ir0 = dr*ith;
+    const int ir0 = dr * ith;
     const int ir1 = MIN(ir0 + dr, nr);
 
     for (int i1 = ir0; i1 < ir1; i1++) {
-        float * src0_p = (float *) (src0_d + i1*src0_o);
-        float * src1_p = (float *) (src1_d + i1*src1_o);
-        float * dst_p  = (float *) ((char *) dst->data + i1*(dst->nb[1]));
+        float* src0_p = (float*)(src0_d + i1 * src0_o);
+        float* src1_p = (float*)(src1_d + i1 * src1_o);
+        float* dst_p = (float*)((char*)dst->data + i1 * (dst->nb[1]));
 
         if (!src1) {
             src0_p += swapped ? nc : 0;
@@ -3341,34 +3052,26 @@ static void ggml_compute_forward_swiglu_oai_f32(
     }
 }
 
-static void ggml_compute_forward_swiglu_oai(
-        const ggml_compute_params * params,
-        ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
+static void ggml_compute_forward_swiglu_oai(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
 
     switch (src0->type) {
-        case GGML_TYPE_F32:
-            {
-                ggml_compute_forward_swiglu_oai_f32(params, dst);
-            } break;
-        default:
-            {
-                GGML_ABORT("fatal error");
-            }
+    case GGML_TYPE_F32: {
+        ggml_compute_forward_swiglu_oai_f32(params, dst);
+    } break;
+    default: {
+        GGML_ABORT("fatal error");
+    }
     }
 }
 
 // ggml_compute_forward_geglu_erf
 
-static void ggml_compute_forward_geglu_erf_f32(
-        const ggml_compute_params * params,
-        ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
-    const ggml_tensor * src1 = dst->src[1];
-    char * src0_d = (char *) src0->data;
-    char * src1_d = (char *) (src1 ? src1->data : src0->data);
+static void ggml_compute_forward_geglu_erf_f32(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
+    const ggml_tensor* src1 = dst->src[1];
+    char* src0_d = (char*)src0->data;
+    char* src1_d = (char*)(src1 ? src1->data : src0->data);
     const size_t src0_o = src0->nb[1];
     const size_t src1_o = src1 ? src1->nb[1] : src0->nb[1];
 
@@ -3392,26 +3095,26 @@ static void ggml_compute_forward_geglu_erf_f32(
     const int32_t swapped = ggml_get_op_params_i32(dst, 1);
 
     // rows per thread
-    const int dr = (nr + nth - 1)/nth;
+    const int dr = (nr + nth - 1) / nth;
 
     // row range for this thread
-    const int ir0 = dr*ith;
+    const int ir0 = dr * ith;
     const int ir1 = MIN(ir0 + dr, nr);
 
     for (int i1 = ir0; i1 < ir1; i1++) {
-        float * src0_p = (float *) (src0_d + i1*src0_o);
-        float * src1_p = (float *) (src1_d + i1*src1_o);
+        float* src0_p = (float*)(src0_d + i1 * src0_o);
+        float* src1_p = (float*)(src1_d + i1 * src1_o);
 
         if (!src1) {
             src0_p += swapped ? nc : 0;
             src1_p += swapped ? 0 : nc;
         }
 
-        ggml_vec_geglu_erf_f32(nc, (float *) ((char *) dst->data + i1*(dst->nb[1])), src0_p, src1_p);
+        ggml_vec_geglu_erf_f32(nc, (float*)((char*)dst->data + i1 * (dst->nb[1])), src0_p, src1_p);
 
 #ifndef NDEBUG
         for (int k = 0; k < nc; k++) {
-            const float x = ((float *) ((char *) dst->data + i1*( dst->nb[1])))[k];
+            const float x = ((float*)((char*)dst->data + i1 * (dst->nb[1])))[k];
             GGML_UNUSED(x);
             assert(!isnan(x));
             assert(!isinf(x));
@@ -3420,14 +3123,11 @@ static void ggml_compute_forward_geglu_erf_f32(
     }
 }
 
-static void ggml_compute_forward_geglu_erf_f16(
-    const ggml_compute_params * params,
-    ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
-    const ggml_tensor * src1 = dst->src[1];
-    char * src0_d = (char *) src0->data;
-    char * src1_d = (char *) (src1 ? src1->data : src0->data);
+static void ggml_compute_forward_geglu_erf_f16(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
+    const ggml_tensor* src1 = dst->src[1];
+    char* src0_d = (char*)src0->data;
+    char* src1_d = (char*)(src1 ? src1->data : src0->data);
     const size_t src0_o = src0->nb[1];
     const size_t src1_o = src1 ? src1->nb[1] : src0->nb[1];
 
@@ -3451,26 +3151,26 @@ static void ggml_compute_forward_geglu_erf_f16(
     const int32_t swapped = ggml_get_op_params_i32(dst, 1);
 
     // rows per thread
-    const int dr = (nr + nth - 1)/nth;
+    const int dr = (nr + nth - 1) / nth;
 
     // row range for this thread
-    const int ir0 = dr*ith;
+    const int ir0 = dr * ith;
     const int ir1 = MIN(ir0 + dr, nr);
 
     for (int i1 = ir0; i1 < ir1; i1++) {
-        ggml_fp16_t * src0_p = (ggml_fp16_t *) (src0_d + i1*src0_o);
-        ggml_fp16_t * src1_p = (ggml_fp16_t *) (src1_d + i1*src1_o);
+        ggml_fp16_t* src0_p = (ggml_fp16_t*)(src0_d + i1 * src0_o);
+        ggml_fp16_t* src1_p = (ggml_fp16_t*)(src1_d + i1 * src1_o);
 
         if (!src1) {
             src0_p += swapped ? nc : 0;
             src1_p += swapped ? 0 : nc;
         }
 
-        ggml_vec_geglu_erf_f16(nc, (ggml_fp16_t *) ((char *) dst->data + i1*(dst->nb[1])), src0_p, src1_p);
+        ggml_vec_geglu_erf_f16(nc, (ggml_fp16_t*)((char*)dst->data + i1 * (dst->nb[1])), src0_p, src1_p);
 
 #ifndef NDEBUG
         for (int k = 0; k < nc; k++) {
-            const ggml_fp16_t x = ((ggml_fp16_t *) ((char *) dst->data + i1*( dst->nb[1])))[k];
+            const ggml_fp16_t x = ((ggml_fp16_t*)((char*)dst->data + i1 * (dst->nb[1])))[k];
             const float v = GGML_FP16_TO_FP32(x);
             GGML_UNUSED(v);
             assert(!isnan(v));
@@ -3480,38 +3180,29 @@ static void ggml_compute_forward_geglu_erf_f16(
     }
 }
 
-static void ggml_compute_forward_geglu_erf(
-        const ggml_compute_params * params,
-        ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
+static void ggml_compute_forward_geglu_erf(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
 
     switch (src0->type) {
-        case GGML_TYPE_F32:
-            {
-                ggml_compute_forward_geglu_erf_f32(params, dst);
-            } break;
-        case GGML_TYPE_F16:
-            {
-                ggml_compute_forward_geglu_erf_f16(params, dst);
-            } break;
-        default:
-            {
-                GGML_ABORT("fatal error");
-            }
+    case GGML_TYPE_F32: {
+        ggml_compute_forward_geglu_erf_f32(params, dst);
+    } break;
+    case GGML_TYPE_F16: {
+        ggml_compute_forward_geglu_erf_f16(params, dst);
+    } break;
+    default: {
+        GGML_ABORT("fatal error");
+    }
     }
 }
 
 // ggml_compute_forward_geglu_quick
 
-static void ggml_compute_forward_geglu_quick_f32(
-        const ggml_compute_params * params,
-        ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
-    const ggml_tensor * src1 = dst->src[1];
-    char * src0_d = (char *) src0->data;
-    char * src1_d = (char *) (src1 ? src1->data : src0->data);
+static void ggml_compute_forward_geglu_quick_f32(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
+    const ggml_tensor* src1 = dst->src[1];
+    char* src0_d = (char*)src0->data;
+    char* src1_d = (char*)(src1 ? src1->data : src0->data);
     const size_t src0_o = src0->nb[1];
     const size_t src1_o = src1 ? src1->nb[1] : src0->nb[1];
 
@@ -3535,26 +3226,26 @@ static void ggml_compute_forward_geglu_quick_f32(
     const int32_t swapped = ggml_get_op_params_i32(dst, 1);
 
     // rows per thread
-    const int dr = (nr + nth - 1)/nth;
+    const int dr = (nr + nth - 1) / nth;
 
     // row range for this thread
-    const int ir0 = dr*ith;
+    const int ir0 = dr * ith;
     const int ir1 = MIN(ir0 + dr, nr);
 
     for (int i1 = ir0; i1 < ir1; i1++) {
-        float * src0_p = (float *) (src0_d + i1*src0_o);
-        float * src1_p = (float *) (src1_d + i1*src1_o);
+        float* src0_p = (float*)(src0_d + i1 * src0_o);
+        float* src1_p = (float*)(src1_d + i1 * src1_o);
 
         if (!src1) {
             src0_p += swapped ? nc : 0;
             src1_p += swapped ? 0 : nc;
         }
 
-        ggml_vec_geglu_quick_f32(nc, (float *) ((char *) dst->data + i1*(dst->nb[1])), src0_p, src1_p);
+        ggml_vec_geglu_quick_f32(nc, (float*)((char*)dst->data + i1 * (dst->nb[1])), src0_p, src1_p);
 
 #ifndef NDEBUG
         for (int k = 0; k < nc; k++) {
-            const float x = ((float *) ((char *) dst->data + i1*( dst->nb[1])))[k];
+            const float x = ((float*)((char*)dst->data + i1 * (dst->nb[1])))[k];
             GGML_UNUSED(x);
             assert(!isnan(x));
             assert(!isinf(x));
@@ -3563,14 +3254,11 @@ static void ggml_compute_forward_geglu_quick_f32(
     }
 }
 
-static void ggml_compute_forward_geglu_quick_f16(
-    const ggml_compute_params * params,
-    ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
-    const ggml_tensor * src1 = dst->src[1];
-    char * src0_d = (char *) src0->data;
-    char * src1_d = (char *) (src1 ? src1->data : src0->data);
+static void ggml_compute_forward_geglu_quick_f16(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
+    const ggml_tensor* src1 = dst->src[1];
+    char* src0_d = (char*)src0->data;
+    char* src1_d = (char*)(src1 ? src1->data : src0->data);
     const size_t src0_o = src0->nb[1];
     const size_t src1_o = src1 ? src1->nb[1] : src0->nb[1];
 
@@ -3594,26 +3282,26 @@ static void ggml_compute_forward_geglu_quick_f16(
     const int32_t swapped = ggml_get_op_params_i32(dst, 1);
 
     // rows per thread
-    const int dr = (nr + nth - 1)/nth;
+    const int dr = (nr + nth - 1) / nth;
 
     // row range for this thread
-    const int ir0 = dr*ith;
+    const int ir0 = dr * ith;
     const int ir1 = MIN(ir0 + dr, nr);
 
     for (int i1 = ir0; i1 < ir1; i1++) {
-        ggml_fp16_t * src0_p = (ggml_fp16_t *) (src0_d + i1*src0_o);
-        ggml_fp16_t * src1_p = (ggml_fp16_t *) (src1_d + i1*src1_o);
+        ggml_fp16_t* src0_p = (ggml_fp16_t*)(src0_d + i1 * src0_o);
+        ggml_fp16_t* src1_p = (ggml_fp16_t*)(src1_d + i1 * src1_o);
 
         if (!src1) {
             src0_p += swapped ? nc : 0;
             src1_p += swapped ? 0 : nc;
         }
 
-        ggml_vec_geglu_quick_f16(nc, (ggml_fp16_t *) ((char *) dst->data + i1*(dst->nb[1])), src0_p, src1_p);
+        ggml_vec_geglu_quick_f16(nc, (ggml_fp16_t*)((char*)dst->data + i1 * (dst->nb[1])), src0_p, src1_p);
 
 #ifndef NDEBUG
         for (int k = 0; k < nc; k++) {
-            const ggml_fp16_t x = ((ggml_fp16_t *) ((char *) dst->data + i1*( dst->nb[1])))[k];
+            const ggml_fp16_t x = ((ggml_fp16_t*)((char*)dst->data + i1 * (dst->nb[1])))[k];
             const float v = GGML_FP16_TO_FP32(x);
             GGML_UNUSED(v);
             assert(!isnan(v));
@@ -3623,38 +3311,29 @@ static void ggml_compute_forward_geglu_quick_f16(
     }
 }
 
-static void ggml_compute_forward_geglu_quick(
-        const ggml_compute_params * params,
-        ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
+static void ggml_compute_forward_geglu_quick(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
 
     switch (src0->type) {
-        case GGML_TYPE_F32:
-            {
-                ggml_compute_forward_geglu_quick_f32(params, dst);
-            } break;
-        case GGML_TYPE_F16:
-            {
-                ggml_compute_forward_geglu_quick_f16(params, dst);
-            } break;
-        default:
-            {
-                GGML_ABORT("fatal error");
-            }
+    case GGML_TYPE_F32: {
+        ggml_compute_forward_geglu_quick_f32(params, dst);
+    } break;
+    case GGML_TYPE_F16: {
+        ggml_compute_forward_geglu_quick_f16(params, dst);
+    } break;
+    default: {
+        GGML_ABORT("fatal error");
+    }
     }
 }
 
 // ggml_compute_forward_siglu
 
-static void ggml_compute_forward_siglu_f32(
-        const ggml_compute_params * params,
-        ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
-    const ggml_tensor * src1 = dst->src[1];
-    char * src0_d = (char *) src0->data;
-    char * src1_d = (char *) (src1 ? src1->data : src0->data);
+static void ggml_compute_forward_siglu_f32(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
+    const ggml_tensor* src1 = dst->src[1];
+    char* src0_d = (char*)src0->data;
+    char* src1_d = (char*)(src1 ? src1->data : src0->data);
     const size_t src0_o = src0->nb[1];
     const size_t src1_o = src1 ? src1->nb[1] : src0->nb[1];
 
@@ -3678,26 +3357,26 @@ static void ggml_compute_forward_siglu_f32(
     const int32_t swapped = ggml_get_op_params_i32(dst, 1);
 
     // rows per thread
-    const int dr = (nr + nth - 1)/nth;
+    const int dr = (nr + nth - 1) / nth;
 
     // row range for this thread
-    const int ir0 = dr*ith;
+    const int ir0 = dr * ith;
     const int ir1 = MIN(ir0 + dr, nr);
 
     for (int i1 = ir0; i1 < ir1; i1++) {
-        float * src0_p = (float *) (src0_d + i1*src0_o);
-        float * src1_p = (float *) (src1_d + i1*src1_o);
+        float* src0_p = (float*)(src0_d + i1 * src0_o);
+        float* src1_p = (float*)(src1_d + i1 * src1_o);
 
         if (!src1) {
             src0_p += swapped ? nc : 0;
             src1_p += swapped ? 0 : nc;
         }
 
-        ggml_vec_siglu_f32(nc, (float *) ((char *) dst->data + i1*(dst->nb[1])), src0_p, src1_p);
+        ggml_vec_siglu_f32(nc, (float*)((char*)dst->data + i1 * (dst->nb[1])), src0_p, src1_p);
 
 #ifndef NDEBUG
         for (int k = 0; k < nc; k++) {
-            const float x = ((float *) ((char *) dst->data + i1*( dst->nb[1])))[k];
+            const float x = ((float*)((char*)dst->data + i1 * (dst->nb[1])))[k];
             GGML_UNUSED(x);
             assert(!isnan(x));
             assert(!isinf(x));
@@ -3706,14 +3385,11 @@ static void ggml_compute_forward_siglu_f32(
     }
 }
 
-static void ggml_compute_forward_siglu_f16(
-    const ggml_compute_params * params,
-    ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
-    const ggml_tensor * src1 = dst->src[1];
-    char * src0_d = (char *) src0->data;
-    char * src1_d = (char *) (src1 ? src1->data : src0->data);
+static void ggml_compute_forward_siglu_f16(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
+    const ggml_tensor* src1 = dst->src[1];
+    char* src0_d = (char*)src0->data;
+    char* src1_d = (char*)(src1 ? src1->data : src0->data);
     const size_t src0_o = src0->nb[1];
     const size_t src1_o = src1 ? src1->nb[1] : src0->nb[1];
 
@@ -3737,26 +3413,26 @@ static void ggml_compute_forward_siglu_f16(
     const int32_t swapped = ggml_get_op_params_i32(dst, 1);
 
     // rows per thread
-    const int dr = (nr + nth - 1)/nth;
+    const int dr = (nr + nth - 1) / nth;
 
     // row range for this thread
-    const int ir0 = dr*ith;
+    const int ir0 = dr * ith;
     const int ir1 = MIN(ir0 + dr, nr);
 
     for (int i1 = ir0; i1 < ir1; i1++) {
-        ggml_fp16_t * src0_p = (ggml_fp16_t *) (src0_d + i1*src0_o);
-        ggml_fp16_t * src1_p = (ggml_fp16_t *) (src1_d + i1*src1_o);
+        ggml_fp16_t* src0_p = (ggml_fp16_t*)(src0_d + i1 * src0_o);
+        ggml_fp16_t* src1_p = (ggml_fp16_t*)(src1_d + i1 * src1_o);
 
         if (!src1) {
             src0_p += swapped ? nc : 0;
             src1_p += swapped ? 0 : nc;
         }
 
-        ggml_vec_siglu_f16(nc, (ggml_fp16_t *) ((char *) dst->data + i1*(dst->nb[1])), src0_p, src1_p);
+        ggml_vec_siglu_f16(nc, (ggml_fp16_t*)((char*)dst->data + i1 * (dst->nb[1])), src0_p, src1_p);
 
 #ifndef NDEBUG
         for (int k = 0; k < nc; k++) {
-            const ggml_fp16_t x = ((ggml_fp16_t *) ((char *) dst->data + i1*( dst->nb[1])))[k];
+            const ggml_fp16_t x = ((ggml_fp16_t*)((char*)dst->data + i1 * (dst->nb[1])))[k];
             const float v = GGML_FP16_TO_FP32(x);
             GGML_UNUSED(v);
             assert(!isnan(v));
@@ -3766,35 +3442,26 @@ static void ggml_compute_forward_siglu_f16(
     }
 }
 
-static void ggml_compute_forward_siglu(
-        const ggml_compute_params * params,
-        ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
+static void ggml_compute_forward_siglu(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
 
     switch (src0->type) {
-        case GGML_TYPE_F32:
-            {
-                ggml_compute_forward_siglu_f32(params, dst);
-            } break;
-        case GGML_TYPE_F16:
-            {
-                ggml_compute_forward_siglu_f16(params, dst);
-            } break;
-        default:
-            {
-                GGML_ABORT("fatal error");
-            }
+    case GGML_TYPE_F32: {
+        ggml_compute_forward_siglu_f32(params, dst);
+    } break;
+    case GGML_TYPE_F16: {
+        ggml_compute_forward_siglu_f16(params, dst);
+    } break;
+    default: {
+        GGML_ABORT("fatal error");
+    }
     }
 }
 
 // ggml_compute_forward_norm
 
-static void ggml_compute_forward_norm_f32(
-        const ggml_compute_params * params,
-        ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
+static void ggml_compute_forward_norm_f32(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
 
     GGML_ASSERT(ggml_are_same_shape(src0, dst));
 
@@ -3813,13 +3480,13 @@ static void ggml_compute_forward_norm_f32(
     for (int64_t i03 = 0; i03 < ne03; i03++) {
         for (int64_t i02 = 0; i02 < ne02; i02++) {
             for (int64_t i01 = ith; i01 < ne01; i01 += nth) {
-                const float * x = (float *) ((char *) src0->data + i01*nb01 + i02*nb02 + i03*nb03);
+                const float* x = (float*)((char*)src0->data + i01 * nb01 + i02 * nb02 + i03 * nb03);
 
                 float sum = 0.0;
                 ggml_vec_sum_f32(ne00, &sum, x);
-                float mean = sum/ne00;
+                float mean = sum / ne00;
 
-                float * y = (float *) ((char *) dst->data + i01*nb1 + i02*nb2 + i03*nb3);
+                float* y = (float*)((char*)dst->data + i01 * nb1 + i02 * nb2 + i03 * nb3);
                 float variance = 0;
 
 #ifdef GGML_USE_ACCELERATE
@@ -3830,40 +3497,32 @@ static void ggml_compute_forward_norm_f32(
                 variance = ggml_vec_cvar_f32(ne00, y, x, mean);
 #endif //GGML_USE_ACCELERATE
 
-                const float scale = 1.0f/sqrtf(variance + eps);
+                const float scale = 1.0f / sqrtf(variance + eps);
                 ggml_vec_scale_f32(ne00, y, scale);
             }
         }
     }
 }
 
-void ggml_compute_forward_norm(
-        const ggml_compute_params * params,
-        ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
+void ggml_compute_forward_norm(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
 
     switch (src0->type) {
-        case GGML_TYPE_F32:
-            {
-                ggml_compute_forward_norm_f32(params, dst);
-            } break;
-        default:
-            {
-                GGML_ABORT("fatal error");
-            }
+    case GGML_TYPE_F32: {
+        ggml_compute_forward_norm_f32(params, dst);
+    } break;
+    default: {
+        GGML_ABORT("fatal error");
+    }
     }
 }
 
 // ggml_compute_forward_norm_affine
 
-static void ggml_compute_forward_norm_affine_f32(
-        const ggml_compute_params * params,
-        ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0]; // input
-    const ggml_tensor * src1 = dst->src[1]; // weight (scale)
-    const ggml_tensor * src2 = dst->src[2]; // bias
+static void ggml_compute_forward_norm_affine_f32(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0]; // input
+    const ggml_tensor* src1 = dst->src[1]; // weight (scale)
+    const ggml_tensor* src2 = dst->src[2]; // bias
 
     GGML_ASSERT(ggml_are_same_shape(src0, dst));
     GGML_ASSERT(src0->nb[0] == sizeof(float));
@@ -3878,14 +3537,14 @@ static void ggml_compute_forward_norm_affine_f32(
 
     GGML_ASSERT(eps >= 0.0f);
 
-    const float * w = (const float *) src1->data;
-    const float * b = (const float *) src2->data;
+    const float* w = (const float*)src1->data;
+    const float* b = (const float*)src2->data;
 
     for (int64_t i03 = 0; i03 < ne03; i03++) {
         for (int64_t i02 = 0; i02 < ne02; i02++) {
             for (int64_t i01 = ith; i01 < ne01; i01 += nth) {
-                const float * x = (float *) ((char *) src0->data + i01*nb01 + i02*nb02 + i03*nb03);
-                float       * y = (float *) ((char *) dst->data  + i01*nb1  + i02*nb2  + i03*nb3);
+                const float* x = (float*)((char*)src0->data + i01 * nb01 + i02 * nb02 + i03 * nb03);
+                float* y = (float*)((char*)dst->data + i01 * nb1 + i02 * nb2 + i03 * nb3);
 
                 float sum = 0.0f;
                 ggml_vec_sum_f32(ne00, &sum, x);
@@ -3911,31 +3570,23 @@ static void ggml_compute_forward_norm_affine_f32(
     }
 }
 
-void ggml_compute_forward_norm_affine(
-        const ggml_compute_params * params,
-        ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
+void ggml_compute_forward_norm_affine(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
 
     switch (src0->type) {
-        case GGML_TYPE_F32:
-            {
-                ggml_compute_forward_norm_affine_f32(params, dst);
-            } break;
-        default:
-            {
-                GGML_ABORT("fatal error");
-            }
+    case GGML_TYPE_F32: {
+        ggml_compute_forward_norm_affine_f32(params, dst);
+    } break;
+    default: {
+        GGML_ABORT("fatal error");
+    }
     }
 }
 
 // ggml_compute_forward_group_rms_norm
 
-static void ggml_compute_forward_rms_norm_f32(
-        const ggml_compute_params * params,
-        ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
+static void ggml_compute_forward_rms_norm_f32(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
 
     GGML_ASSERT(ggml_are_same_shape(src0, dst));
 
@@ -3955,23 +3606,23 @@ static void ggml_compute_forward_rms_norm_f32(
     for (int64_t i03 = 0; i03 < ne03; i03++) {
         for (int64_t i02 = 0; i02 < ne02; i02++) {
             for (int64_t i01 = ith; i01 < ne01; i01 += nth) {
-                const float * x = (float *) ((char *) src0->data + i01*nb01 + i02*nb02 + i03*nb03);
+                const float* x = (float*)((char*)src0->data + i01 * nb01 + i02 * nb02 + i03 * nb03);
 
                 ggml_float sum = 0.0;
                 for (int64_t i00 = 0; i00 < ne00; i00++) {
                     sum += (ggml_float)(x[i00] * x[i00]);
                 }
 
-                const float mean = sum/ne00;
+                const float mean = sum / ne00;
 
-                float * y = (float *) ((char *) dst->data + i01*nb1 + i02*nb2 + i03*nb3);
+                float* y = (float*)((char*)dst->data + i01 * nb1 + i02 * nb2 + i03 * nb3);
 
                 memcpy(y, x, ne00 * sizeof(float));
                 // for (int i00 = 0; i00 < ne00; i00++) {
                 //     y[i00] = x[i00];
                 // }
 
-                const float scale = 1.0f/sqrtf(mean + eps);
+                const float scale = 1.0f / sqrtf(mean + eps);
 
                 // if you hit this, likely you got an inf somewhere earlier
                 assert(scale > 0.0f);
@@ -3982,30 +3633,22 @@ static void ggml_compute_forward_rms_norm_f32(
     }
 }
 
-void ggml_compute_forward_rms_norm(
-        const ggml_compute_params * params,
-        ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
+void ggml_compute_forward_rms_norm(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
 
     switch (src0->type) {
-        case GGML_TYPE_F32:
-            {
-                ggml_compute_forward_rms_norm_f32(params, dst);
-            } break;
-        default:
-            {
-                GGML_ABORT("fatal error");
-            }
+    case GGML_TYPE_F32: {
+        ggml_compute_forward_rms_norm_f32(params, dst);
+    } break;
+    default: {
+        GGML_ABORT("fatal error");
+    }
     }
 }
 
-static void ggml_compute_forward_rms_norm_back_f32(
-        const ggml_compute_params * params,
-        ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0]; // gradients from forward pass output
-    const ggml_tensor * src1 = dst->src[1]; // src1 from forward pass
+static void ggml_compute_forward_rms_norm_back_f32(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0]; // gradients from forward pass output
+    const ggml_tensor* src1 = dst->src[1]; // src1 from forward pass
 
     GGML_ASSERT(ggml_are_same_shape(src0, dst) && ggml_are_same_shape(src0, src1));
 
@@ -4029,25 +3672,25 @@ static void ggml_compute_forward_rms_norm_back_f32(
                 const int64_t i12 = i02;
                 const int64_t i13 = i03;
 
-                const float * dz = (float *) ((char *) src0->data + i01*nb01 + i02*nb02 + i03*nb03);
-                const float * x  = (float *) ((char *) src1->data + i11*nb11 + i12*nb12 + i13*nb13);
+                const float* dz = (float*)((char*)src0->data + i01 * nb01 + i02 * nb02 + i03 * nb03);
+                const float* x = (float*)((char*)src1->data + i11 * nb11 + i12 * nb12 + i13 * nb13);
 
-                ggml_float sum_xx  = 0.0;
+                ggml_float sum_xx = 0.0;
                 ggml_float sum_xdz = 0.0;
 
                 for (int64_t i00 = 0; i00 < ne00; i00++) {
-                    sum_xx  += (ggml_float)(x[i00] * x[i00]);
+                    sum_xx += (ggml_float)(x[i00] * x[i00]);
                     sum_xdz += (ggml_float)(x[i00] * dz[i00]);
                 }
 
                 //const float mean     = (float)(sum_xx)/ne00;
-                const float mean_eps = (float)(sum_xx)/ne00 + eps;
-                const float sum_eps  = (float)(sum_xx) + eps*ne00;
+                const float mean_eps = (float)(sum_xx) / ne00 + eps;
+                const float sum_eps = (float)(sum_xx) + eps * ne00;
                 //const float mean_xdz = (float)(sum_xdz)/ne00;
                 // we could cache rms from forward pass to improve performance.
                 // to do this implement ggml_rms and compose ggml_rms_norm using ggml_rms.
                 //const float rms      = sqrtf(mean_eps);
-                const float rrms     = 1.0f / sqrtf(mean_eps);
+                const float rrms = 1.0f / sqrtf(mean_eps);
                 //const float scale    = -rrms/(ne00 * mean_eps); // -1/(n*rms**3)
 
                 {
@@ -4144,44 +3787,36 @@ static void ggml_compute_forward_rms_norm_back_f32(
                 // dx := scale(dx,-mean_xdz/mean_eps)
                 // dx := add(dx, dz)
                 // dx := scale(dx, rrms)
-                float * dx = (float *) ((char *) dst->data + i01*nb1 + i02*nb2 + i03*nb3);
+                float* dx = (float*)((char*)dst->data + i01 * nb1 + i02 * nb2 + i03 * nb3);
 
                 // dx[i00] = (x*(-sum_xdz/sum_eps) + dz) / sqrtf(mean_eps)
-                ggml_vec_cpy_f32  (ne00, dx, x);
+                ggml_vec_cpy_f32(ne00, dx, x);
                 // ggml_vec_scale_f32(ne00, dx, -mean_xdz/mean_eps);
-                ggml_vec_scale_f32(ne00, dx, (float)(-sum_xdz)/sum_eps);
-                ggml_vec_acc_f32  (ne00, dx, dz);
+                ggml_vec_scale_f32(ne00, dx, (float)(-sum_xdz) / sum_eps);
+                ggml_vec_acc_f32(ne00, dx, dz);
                 ggml_vec_scale_f32(ne00, dx, rrms);
             }
         }
     }
 }
 
-void ggml_compute_forward_rms_norm_back(
-        const ggml_compute_params * params,
-        ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
+void ggml_compute_forward_rms_norm_back(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
 
     switch (src0->type) {
-        case GGML_TYPE_F32:
-            {
-                ggml_compute_forward_rms_norm_back_f32(params, dst);
-            } break;
-        default:
-            {
-                GGML_ABORT("fatal error");
-            }
+    case GGML_TYPE_F32: {
+        ggml_compute_forward_rms_norm_back_f32(params, dst);
+    } break;
+    default: {
+        GGML_ABORT("fatal error");
+    }
     }
 }
 
 // ggml_compute_forward_group_norm
 
-static void ggml_compute_forward_group_norm_f32(
-    const ggml_compute_params * params,
-    ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
+static void ggml_compute_forward_group_norm_f32(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
 
     GGML_ASSERT(ggml_are_same_shape(src0, dst));
 
@@ -4212,7 +3847,7 @@ static void ggml_compute_forward_group_norm_f32(
             ggml_float sum = 0.0;
             for (int64_t i02 = start; i02 < end; i02++) {
                 for (int64_t i01 = 0; i01 < ne01; i01++) {
-                    const float * x = (float *)((char *) src0->data + i01 * nb01 + i02 * nb02 + i03 * nb03);
+                    const float* x = (float*)((char*)src0->data + i01 * nb01 + i02 * nb02 + i03 * nb03);
 
                     ggml_float sumr = 0.0;
                     for (int64_t i00 = 0; i00 < ne00; i00++) {
@@ -4226,9 +3861,9 @@ static void ggml_compute_forward_group_norm_f32(
             ggml_float sum2 = 0.0;
             for (int64_t i02 = start; i02 < end; i02++) {
                 for (int64_t i01 = 0; i01 < ne01; i01++) {
-                    const float * x = (float *)((char *) src0->data + i01 * nb01 + i02 * nb02 + i03 * nb03);
+                    const float* x = (float*)((char*)src0->data + i01 * nb01 + i02 * nb02 + i03 * nb03);
 
-                    float * y = (float *)((char *) dst->data + i01 * nb1 + i02 * nb2 + i03 * nb3);
+                    float* y = (float*)((char*)dst->data + i01 * nb1 + i02 * nb2 + i03 * nb3);
 
                     ggml_float sumr = 0.0;
                     for (int64_t i00 = 0; i00 < ne00; i00++) {
@@ -4244,7 +3879,7 @@ static void ggml_compute_forward_group_norm_f32(
 
             for (int64_t i02 = start; i02 < end; i02++) {
                 for (int64_t i01 = 0; i01 < ne01; i01++) {
-                    float * y = (float *)((char *) dst->data + i01 * nb1 + i02 * nb2 + i03 * nb3);
+                    float* y = (float*)((char*)dst->data + i01 * nb1 + i02 * nb2 + i03 * nb3);
                     ggml_vec_scale_f32(ne00, y, scale);
                 }
             }
@@ -4252,31 +3887,23 @@ static void ggml_compute_forward_group_norm_f32(
     }
 }
 
-void ggml_compute_forward_group_norm(
-    const ggml_compute_params * params,
-    ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
+void ggml_compute_forward_group_norm(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
 
     switch (src0->type) {
-        case GGML_TYPE_F32:
-            {
-                ggml_compute_forward_group_norm_f32(params, dst);
-            } break;
-        default:
-            {
-                GGML_ABORT("fatal error");
-            }
+    case GGML_TYPE_F32: {
+        ggml_compute_forward_group_norm_f32(params, dst);
+    } break;
+    default: {
+        GGML_ABORT("fatal error");
+    }
     }
 }
 
 // ggml_compute_forward_l2_norm
 
-static void ggml_compute_forward_l2_norm_f32(
-    const ggml_compute_params * params,
-    ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
+static void ggml_compute_forward_l2_norm_f32(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
 
     GGML_ASSERT(ggml_are_same_shape(src0, dst));
 
@@ -4296,18 +3923,18 @@ static void ggml_compute_forward_l2_norm_f32(
     for (int64_t i03 = 0; i03 < ne03; i03++) {
         for (int64_t i02 = 0; i02 < ne02; i02++) {
             for (int64_t i01 = ith; i01 < ne01; i01 += nth) {
-                const float * x = (float *) ((char *) src0->data + i01*nb01 + i02*nb02 + i03*nb03);
+                const float* x = (float*)((char*)src0->data + i01 * nb01 + i02 * nb02 + i03 * nb03);
 
                 ggml_float sum = 0.0;
                 for (int64_t i00 = 0; i00 < ne00; i00++) {
                     sum += (ggml_float)(x[i00] * x[i00]);
                 }
 
-                float * y = (float *) ((char *) dst->data + i01*nb1 + i02*nb2 + i03*nb3);
+                float* y = (float*)((char*)dst->data + i01 * nb1 + i02 * nb2 + i03 * nb3);
 
                 memcpy(y, x, ne00 * sizeof(float));
 
-                const float scale = 1.0f/fmaxf(sqrtf(sum), eps);
+                const float scale = 1.0f / fmaxf(sqrtf(sum), eps);
 
                 ggml_vec_scale_f32(ne00, y, scale);
             }
@@ -4315,32 +3942,24 @@ static void ggml_compute_forward_l2_norm_f32(
     }
 }
 
-void ggml_compute_forward_l2_norm(
-    const ggml_compute_params * params,
-    ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
+void ggml_compute_forward_l2_norm(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
 
     switch (src0->type) {
-        case GGML_TYPE_F32:
-            {
-                ggml_compute_forward_l2_norm_f32(params, dst);
-            } break;
-        default:
-            {
-                GGML_ABORT("fatal error");
-            }
+    case GGML_TYPE_F32: {
+        ggml_compute_forward_l2_norm_f32(params, dst);
+    } break;
+    default: {
+        GGML_ABORT("fatal error");
+    }
     }
 }
 
 // ggml_compute_forward_out_prod
 
-static void ggml_compute_forward_out_prod_f32(
-        const ggml_compute_params * params,
-              ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
-    const ggml_tensor * src1 = dst->src[1];
+static void ggml_compute_forward_out_prod_f32(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
+    const ggml_tensor* src1 = dst->src[1];
 
     GGML_TENSOR_BINARY_OP_LOCALS
 
@@ -4372,7 +3991,7 @@ static void ggml_compute_forward_out_prod_f32(
     //   compute by src0 rows
 
     if (ith == 0) {
-        ggml_vec_set_f32(ne0*ne1*ne2*ne3, (float *)dst->data, 0);
+        ggml_vec_set_f32(ne0 * ne1 * ne2 * ne3, (float*)dst->data, 0);
     }
     ggml_barrier(params->threadpool);
 
@@ -4386,13 +4005,13 @@ static void ggml_compute_forward_out_prod_f32(
     // parallelize by last three dimensions
 
     // total rows in dst
-    const int64_t nr = ne1*ne2*ne3;
+    const int64_t nr = ne1 * ne2 * ne3;
 
     // rows per thread
-    const int64_t dr = (nr + nth - 1)/nth;
+    const int64_t dr = (nr + nth - 1) / nth;
 
     // row range for this thread
-    const int64_t ir0 = dr*ith;
+    const int64_t ir0 = dr * ith;
     const int64_t ir1 = MIN(ir0 + dr, nr);
 
     // block-tiling attempt
@@ -4409,9 +4028,9 @@ static void ggml_compute_forward_out_prod_f32(
             const int64_t bne01 = MIN(bi01 + blck_0, ne01);
             for (int64_t ir = bir; ir < bir1; ++ir) {
                 // dst indices
-                const int64_t i3 = ir/(ne2*ne1);
-                const int64_t i2 = (ir - i3*ne2*ne1)/ne1;
-                const int64_t i1 = (ir - i3*ne2*ne1 - i2*ne1);
+                const int64_t i3 = ir / (ne2 * ne1);
+                const int64_t i2 = (ir - i3 * ne2 * ne1) / ne1;
+                const int64_t i1 = (ir - i3 * ne2 * ne1 - i2 * ne1);
 
                 const int64_t i02 = i2 / dps2;
                 const int64_t i03 = i3 / dps3;
@@ -4425,18 +4044,18 @@ static void ggml_compute_forward_out_prod_f32(
                 for (int64_t i01 = bi01; i01 < bne01_unroll; i01 += GGML_VEC_MAD_UNROLL) {
                     const int64_t i11 = i01;
 
-                    float * s0 = (float *) ((char *) src0->data + (          i01*nb01 + i02*nb02 + i03*nb03));
-                    float * s1 = (float *) ((char *) src1->data + (i1*nb10 + i11*nb11 + i12*nb12 + i13*nb13));
-                    float * d  = (float *) ((char *)  dst->data + (          i1*nb1   + i2*nb2   + i3*nb3));
+                    float* s0 = (float*)((char*)src0->data + (i01 * nb01 + i02 * nb02 + i03 * nb03));
+                    float* s1 = (float*)((char*)src1->data + (i1 * nb10 + i11 * nb11 + i12 * nb12 + i13 * nb13));
+                    float* d = (float*)((char*)dst->data + (i1 * nb1 + i2 * nb2 + i3 * nb3));
 
                     ggml_vec_mad_f32_unroll(ne0, nb01, nb11, d, s0, s1);
                 }
                 for (int64_t i01 = bne01_unroll; i01 < bne01; ++i01) {
                     const int64_t i11 = i01;
 
-                    float * s0 = (float *) ((char *) src0->data + (          i01*nb01 + i02*nb02 + i03*nb03));
-                    float * s1 = (float *) ((char *) src1->data + (i1*nb10 + i11*nb11 + i12*nb12 + i13*nb13));
-                    float * d  = (float *) ((char *)  dst->data + (          i1*nb1   + i2*nb2   + i3*nb3));
+                    float* s0 = (float*)((char*)src0->data + (i01 * nb01 + i02 * nb02 + i03 * nb03));
+                    float* s1 = (float*)((char*)src1->data + (i1 * nb10 + i11 * nb11 + i12 * nb12 + i13 * nb13));
+                    float* d = (float*)((char*)dst->data + (i1 * nb1 + i2 * nb2 + i3 * nb3));
 
                     ggml_vec_mad_f32(ne0, d, s0, *s1);
                 }
@@ -4444,9 +4063,9 @@ static void ggml_compute_forward_out_prod_f32(
                 for (int64_t i01 = bi01; i01 < bne01; ++i01) {
                     const int64_t i11 = i01;
 
-                    float * s0 = (float *) ((char *) src0->data + (          i01*nb01 + i02*nb02 + i03*nb03));
-                    float * s1 = (float *) ((char *) src1->data + (i1*nb10 + i11*nb11 + i12*nb12 + i13*nb13));
-                    float * d  = (float *) ((char *)  dst->data + (          i1*nb1 + i2*nb2 + i3*nb3));
+                    float* s0 = (float*)((char*)src0->data + (i01 * nb01 + i02 * nb02 + i03 * nb03));
+                    float* s1 = (float*)((char*)src1->data + (i1 * nb10 + i11 * nb11 + i12 * nb12 + i13 * nb13));
+                    float* d = (float*)((char*)dst->data + (i1 * nb1 + i2 * nb2 + i3 * nb3));
 
                     ggml_vec_mad_f32(ne0, d, s0, *s1);
                 }
@@ -4456,12 +4075,9 @@ static void ggml_compute_forward_out_prod_f32(
     }
 }
 
-static void ggml_compute_forward_out_prod_q_f32(
-        const ggml_compute_params * params,
-              ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
-    const ggml_tensor * src1 = dst->src[1];
+static void ggml_compute_forward_out_prod_q_f32(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
+    const ggml_tensor* src1 = dst->src[1];
 
     GGML_TENSOR_BINARY_OP_LOCALS;
 
@@ -4473,8 +4089,8 @@ static void ggml_compute_forward_out_prod_q_f32(
 
     GGML_ASSERT(ne02 == ne12);
     GGML_ASSERT(ne03 == ne13);
-    GGML_ASSERT(ne2  == ne12);
-    GGML_ASSERT(ne3  == ne13);
+    GGML_ASSERT(ne2 == ne12);
+    GGML_ASSERT(ne3 == ne13);
 
     // we don't support permuted src0 dim0
     GGML_ASSERT(nb00 == ggml_type_size(type));
@@ -4494,20 +4110,20 @@ static void ggml_compute_forward_out_prod_q_f32(
     //   compute by src0 rows
 
     if (ith == 0) {
-        ggml_vec_set_f32(ne0*ne1*ne2*ne3, (float *)dst->data, 0);
+        ggml_vec_set_f32(ne0 * ne1 * ne2 * ne3, (float*)dst->data, 0);
     }
     ggml_barrier(params->threadpool);
 
     // parallelize by last three dimensions
 
     // total rows in dst
-    const int64_t nr = ne1*ne2*ne3;
+    const int64_t nr = ne1 * ne2 * ne3;
 
     // rows per thread
-    const int64_t dr = (nr + nth - 1)/nth;
+    const int64_t dr = (nr + nth - 1) / nth;
 
     // row range for this thread
-    const int64_t ir0 = dr*ith;
+    const int64_t ir0 = dr * ith;
     const int64_t ir1 = MIN(ir0 + dr, nr);
 
     // dst[:,:,:,:] = 0
@@ -4517,13 +4133,13 @@ static void ggml_compute_forward_out_prod_q_f32(
     //       for i0:
     //         dst[i0,i1,i2,i3] += src0[i0,i01,i2,i3] * src1[i1,i01,i2,i3]
 
-    float * wdata = (float *) params->wdata + (ne0 + CACHE_LINE_SIZE_F32) * ith;
+    float* wdata = (float*)params->wdata + (ne0 + CACHE_LINE_SIZE_F32) * ith;
 
     for (int64_t ir = ir0; ir < ir1; ++ir) {
         // dst indices
-        const int64_t i3 = ir/(ne2*ne1);
-        const int64_t i2 = (ir - i3*ne2*ne1)/ne1;
-        const int64_t i1 = (ir - i3*ne2*ne1 - i2*ne1);
+        const int64_t i3 = ir / (ne2 * ne1);
+        const int64_t i2 = (ir - i3 * ne2 * ne1) / ne1;
+        const int64_t i1 = (ir - i3 * ne2 * ne1 - i2 * ne1);
 
         const int64_t i02 = i2;
         const int64_t i03 = i3;
@@ -4535,9 +4151,9 @@ static void ggml_compute_forward_out_prod_q_f32(
         for (int64_t i01 = 0; i01 < ne01; ++i01) {
             const int64_t i11 = i01;
 
-            float * s0 = (float *) ((char *) src0->data + (          i01*nb01 + i02*nb02 + i03*nb03));
-            float * s1 = (float *) ((char *) src1->data + (i1*nb10 + i11*nb11 + i12*nb12 + i13*nb13));
-            float * d  = (float *) ((char *)  dst->data + (          i1*nb1 + i2*nb2 + i3*nb3));
+            float* s0 = (float*)((char*)src0->data + (i01 * nb01 + i02 * nb02 + i03 * nb03));
+            float* s1 = (float*)((char*)src1->data + (i1 * nb10 + i11 * nb11 + i12 * nb12 + i13 * nb13));
+            float* d = (float*)((char*)dst->data + (i1 * nb1 + i2 * nb2 + i3 * nb3));
 
             dequantize_row_q(s0, wdata, ne0);
             ggml_vec_mad_f32(ne0, d, wdata, *s1);
@@ -4545,63 +4161,53 @@ static void ggml_compute_forward_out_prod_q_f32(
     }
 }
 
-void ggml_compute_forward_out_prod(
-        const ggml_compute_params * params,
-        ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
+void ggml_compute_forward_out_prod(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
 
     switch (src0->type) {
-        case GGML_TYPE_Q1_0:
-        case GGML_TYPE_Q4_0:
-        case GGML_TYPE_Q4_1:
-        case GGML_TYPE_Q5_0:
-        case GGML_TYPE_Q5_1:
-        case GGML_TYPE_Q8_0:
-        case GGML_TYPE_MXFP4:
-        case GGML_TYPE_NVFP4:
-        case GGML_TYPE_Q2_K:
-        case GGML_TYPE_Q3_K:
-        case GGML_TYPE_Q4_K:
-        case GGML_TYPE_Q5_K:
-        case GGML_TYPE_Q6_K:
-        case GGML_TYPE_TQ1_0:
-        case GGML_TYPE_TQ2_0:
-        case GGML_TYPE_IQ2_XXS:
-        case GGML_TYPE_IQ2_XS:
-        case GGML_TYPE_IQ3_XXS:
-        case GGML_TYPE_IQ1_S:
-        case GGML_TYPE_IQ1_M:
-        case GGML_TYPE_IQ4_NL:
-        case GGML_TYPE_IQ4_XS:
-        case GGML_TYPE_IQ3_S:
-        case GGML_TYPE_IQ2_S:
-            {
-                ggml_compute_forward_out_prod_q_f32(params, dst);
-            } break;
-        case GGML_TYPE_F16:
-            {
-                GGML_ABORT("fatal error"); // todo
-                // ggml_compute_forward_out_prod_f16_f32(params, dst);
-            }
-        case GGML_TYPE_F32:
-            {
-                ggml_compute_forward_out_prod_f32(params, dst);
-            } break;
-        default:
-            {
-                GGML_ABORT("fatal error");
-            }
+    case GGML_TYPE_Q1_0:
+    case GGML_TYPE_Q4_0:
+    case GGML_TYPE_Q4_1:
+    case GGML_TYPE_Q5_0:
+    case GGML_TYPE_Q5_1:
+    case GGML_TYPE_Q8_0:
+    case GGML_TYPE_MXFP4:
+    case GGML_TYPE_NVFP4:
+    case GGML_TYPE_Q2_K:
+    case GGML_TYPE_Q3_K:
+    case GGML_TYPE_Q4_K:
+    case GGML_TYPE_Q5_K:
+    case GGML_TYPE_Q6_K:
+    case GGML_TYPE_TQ1_0:
+    case GGML_TYPE_TQ2_0:
+    case GGML_TYPE_IQ2_XXS:
+    case GGML_TYPE_IQ2_XS:
+    case GGML_TYPE_IQ3_XXS:
+    case GGML_TYPE_IQ1_S:
+    case GGML_TYPE_IQ1_M:
+    case GGML_TYPE_IQ4_NL:
+    case GGML_TYPE_IQ4_XS:
+    case GGML_TYPE_IQ3_S:
+    case GGML_TYPE_IQ2_S: {
+        ggml_compute_forward_out_prod_q_f32(params, dst);
+    } break;
+    case GGML_TYPE_F16: {
+        GGML_ABORT("fatal error"); // todo
+        // ggml_compute_forward_out_prod_f16_f32(params, dst);
+    }
+    case GGML_TYPE_F32: {
+        ggml_compute_forward_out_prod_f32(params, dst);
+    } break;
+    default: {
+        GGML_ABORT("fatal error");
+    }
     }
 }
 
 // ggml_compute_forward_scale
 
-static void ggml_compute_forward_scale_f32(
-        const ggml_compute_params * params,
-        ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
+static void ggml_compute_forward_scale_f32(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
 
     GGML_ASSERT(ggml_is_contiguous(src0));
     GGML_ASSERT(ggml_is_contiguous(dst));
@@ -4610,8 +4216,8 @@ static void ggml_compute_forward_scale_f32(
     float s; // scale factor
     float b; // bias
 
-    memcpy(&s, (float *) dst->op_params + 0, sizeof(float));
-    memcpy(&b, (float *) dst->op_params + 1, sizeof(float));
+    memcpy(&s, (float*)dst->op_params + 0, sizeof(float));
+    memcpy(&b, (float*)dst->op_params + 1, sizeof(float));
 
     const int ith = params->ith;
     const int nth = params->nth;
@@ -4620,10 +4226,10 @@ static void ggml_compute_forward_scale_f32(
     const int nr = ggml_nrows(src0);
 
     // rows per thread
-    const int dr = (nr + nth - 1)/nth;
+    const int dr = (nr + nth - 1) / nth;
 
     // row range for this thread
-    const int ir0 = dr*ith;
+    const int ir0 = dr * ith;
     const int ir1 = MIN(ir0 + dr, nr);
 
     const size_t nb01 = src0->nb[1];
@@ -4635,66 +4241,52 @@ static void ggml_compute_forward_scale_f32(
             if (dst->data != src0->data) {
                 // src0 is same shape as dst => same indices
                 // TODO: add x parameter to ggml_vec_scale_f32 and remove this memcpy
-                memcpy((char *)dst->data + i1*nb1, (char *)src0->data + i1*nb01, nc * sizeof(float));
+                memcpy((char*)dst->data + i1 * nb1, (char*)src0->data + i1 * nb01, nc * sizeof(float));
             }
-            ggml_vec_scale_f32(nc, (float *) ((char *) dst->data + i1*nb1), s);
+            ggml_vec_scale_f32(nc, (float*)((char*)dst->data + i1 * nb1), s);
         }
     } else {
         for (int i1 = ir0; i1 < ir1; i1++) {
-            ggml_vec_mad1_f32(nc,
-                (float *) ((char *) dst->data  + i1*nb1),
-                (float *) ((char *) src0->data + i1*nb1),
-                s, b);
+            ggml_vec_mad1_f32(nc, (float*)((char*)dst->data + i1 * nb1), (float*)((char*)src0->data + i1 * nb1), s, b);
         }
     }
 }
 
-void ggml_compute_forward_scale(
-        const ggml_compute_params * params,
-        ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
+void ggml_compute_forward_scale(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
 
     switch (src0->type) {
-        case GGML_TYPE_F32:
-            {
-                ggml_compute_forward_scale_f32(params, dst);
-            } break;
-        default:
-            {
-                GGML_ABORT("fatal error");
-            }
+    case GGML_TYPE_F32: {
+        ggml_compute_forward_scale_f32(params, dst);
+    } break;
+    default: {
+        GGML_ABORT("fatal error");
+    }
     }
 }
 
 // ggml_compute_forward_set
 
-static void ggml_compute_forward_set_f32(
-        const ggml_compute_params * params,
-        ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
-    const ggml_tensor * src1 = dst->src[1];
+static void ggml_compute_forward_set_f32(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
+    const ggml_tensor* src1 = dst->src[1];
 
     GGML_ASSERT(ggml_are_same_shape(src0, dst));
     GGML_ASSERT(ggml_is_contiguous(dst) && ggml_is_contiguous(src0));
 
     // view src0 and dst with these strides and data offset inbytes during set
     // nb0 is implicitly element_size because src0 and dst are contiguous
-    size_t nb1     = ((int32_t *) dst->op_params)[0];
-    size_t nb2     = ((int32_t *) dst->op_params)[1];
-    size_t nb3     = ((int32_t *) dst->op_params)[2];
-    size_t offset  = ((int32_t *) dst->op_params)[3];
-    bool   inplace = (bool) ((int32_t *) dst->op_params)[4];
+    size_t nb1 = ((int32_t*)dst->op_params)[0];
+    size_t nb2 = ((int32_t*)dst->op_params)[1];
+    size_t nb3 = ((int32_t*)dst->op_params)[2];
+    size_t offset = ((int32_t*)dst->op_params)[3];
+    bool inplace = (bool)((int32_t*)dst->op_params)[4];
 
     if (!inplace) {
         if (params->ith == 0) {
             // memcpy needs to be synchronized across threads to avoid race conditions.
             // => do it in INIT phase
-            memcpy(
-                ((char *)  dst->data),
-                ((char *) src0->data),
-                ggml_nbytes(dst));
+            memcpy(((char*)dst->data), ((char*)src0->data), ggml_nbytes(dst));
         }
         ggml_barrier(params->threadpool);
     }
@@ -4706,66 +4298,59 @@ static void ggml_compute_forward_set_f32(
     const int nc = src1->ne[0];
 
     GGML_TENSOR_LOCALS(int64_t, ne1, src1, ne)
-    GGML_TENSOR_LOCALS(size_t,  nb1, src1, nb)
+    GGML_TENSOR_LOCALS(size_t, nb1, src1, nb)
 
     // src0 and dst as viewed during set
     const size_t nb0 = ggml_element_size(src0);
 
-    const int im0 = (ne10 == 0 ? 0 : ne10-1);
-    const int im1 = (ne11 == 0 ? 0 : ne11-1);
-    const int im2 = (ne12 == 0 ? 0 : ne12-1);
-    const int im3 = (ne13 == 0 ? 0 : ne13-1);
+    const int im0 = (ne10 == 0 ? 0 : ne10 - 1);
+    const int im1 = (ne11 == 0 ? 0 : ne11 - 1);
+    const int im2 = (ne12 == 0 ? 0 : ne12 - 1);
+    const int im3 = (ne13 == 0 ? 0 : ne13 - 1);
 
-    GGML_ASSERT(offset + im0*nb0  + im1*nb1  + im2*nb2  + im3*nb3  <= ggml_nbytes(dst));
+    GGML_ASSERT(offset + im0 * nb0 + im1 * nb1 + im2 * nb2 + im3 * nb3 <= ggml_nbytes(dst));
 
     GGML_ASSERT(nb10 == sizeof(float));
 
     // rows per thread
-    const int dr = (nr + nth - 1)/nth;
+    const int dr = (nr + nth - 1) / nth;
 
     // row range for this thread
-    const int ir0 = dr*ith;
+    const int ir0 = dr * ith;
     const int ir1 = MIN(ir0 + dr, nr);
 
     for (int ir = ir0; ir < ir1; ++ir) {
         // src0 and dst are viewed with shape of src1 and offset
         // => same indices
-        const int i3 = ir/(ne12*ne11);
-        const int i2 = (ir - i3*ne12*ne11)/ne11;
-        const int i1 = (ir - i3*ne12*ne11 - i2*ne11);
+        const int i3 = ir / (ne12 * ne11);
+        const int i2 = (ir - i3 * ne12 * ne11) / ne11;
+        const int i1 = (ir - i3 * ne12 * ne11 - i2 * ne11);
 
-        ggml_vec_cpy_f32(nc,
-                (float *) ((char *)  dst->data + i3*nb3  + i2*nb2  + i1*nb1  + offset),
-                (float *) ((char *) src1->data + i3*nb13 + i2*nb12 + i1*nb11));
+        ggml_vec_cpy_f32(nc, (float*)((char*)dst->data + i3 * nb3 + i2 * nb2 + i1 * nb1 + offset),
+                         (float*)((char*)src1->data + i3 * nb13 + i2 * nb12 + i1 * nb11));
     }
 }
 
-static void ggml_compute_forward_set_i32(
-        const ggml_compute_params * params,
-        ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
-    const ggml_tensor * src1 = dst->src[1];
+static void ggml_compute_forward_set_i32(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
+    const ggml_tensor* src1 = dst->src[1];
 
     GGML_ASSERT(ggml_are_same_shape(src0, dst));
     GGML_ASSERT(ggml_is_contiguous(dst) && ggml_is_contiguous(src0));
 
     // view src0 and dst with these strides and data offset inbytes during set
     // nb0 is implicitly element_size because src0 and dst are contiguous
-    size_t nb1     = ((int32_t *) dst->op_params)[0];
-    size_t nb2     = ((int32_t *) dst->op_params)[1];
-    size_t nb3     = ((int32_t *) dst->op_params)[2];
-    size_t offset  = ((int32_t *) dst->op_params)[3];
-    bool   inplace = (bool) ((int32_t *) dst->op_params)[4];
+    size_t nb1 = ((int32_t*)dst->op_params)[0];
+    size_t nb2 = ((int32_t*)dst->op_params)[1];
+    size_t nb3 = ((int32_t*)dst->op_params)[2];
+    size_t offset = ((int32_t*)dst->op_params)[3];
+    bool inplace = (bool)((int32_t*)dst->op_params)[4];
 
     if (!inplace) {
         if (params->ith == 0) {
             // memcpy needs to be synchronized across threads to avoid race conditions.
             // => do it in INIT phase
-            memcpy(
-                ((char *)  dst->data),
-                ((char *) src0->data),
-                ggml_nbytes(dst));
+            memcpy(((char*)dst->data), ((char*)src0->data), ggml_nbytes(dst));
         }
         ggml_barrier(params->threadpool);
     }
@@ -4777,113 +4362,99 @@ static void ggml_compute_forward_set_i32(
     const int nc = src1->ne[0];
 
     GGML_TENSOR_LOCALS(int64_t, ne1, src1, ne)
-    GGML_TENSOR_LOCALS(size_t,  nb1, src1, nb)
+    GGML_TENSOR_LOCALS(size_t, nb1, src1, nb)
 
     // src0 and dst as viewed during set
     const size_t nb0 = ggml_element_size(src0);
 
-    const int im0 = (ne10 == 0 ? 0 : ne10-1);
-    const int im1 = (ne11 == 0 ? 0 : ne11-1);
-    const int im2 = (ne12 == 0 ? 0 : ne12-1);
-    const int im3 = (ne13 == 0 ? 0 : ne13-1);
+    const int im0 = (ne10 == 0 ? 0 : ne10 - 1);
+    const int im1 = (ne11 == 0 ? 0 : ne11 - 1);
+    const int im2 = (ne12 == 0 ? 0 : ne12 - 1);
+    const int im3 = (ne13 == 0 ? 0 : ne13 - 1);
 
-    GGML_ASSERT(offset + im0*nb0  + im1*nb1  + im2*nb2  + im3*nb3  <= ggml_nbytes(dst));
+    GGML_ASSERT(offset + im0 * nb0 + im1 * nb1 + im2 * nb2 + im3 * nb3 <= ggml_nbytes(dst));
 
     GGML_ASSERT(nb10 == sizeof(int32_t));
 
     // rows per thread
-    const int dr = (nr + nth - 1)/nth;
+    const int dr = (nr + nth - 1) / nth;
 
     // row range for this thread
-    const int ir0 = dr*ith;
+    const int ir0 = dr * ith;
     const int ir1 = MIN(ir0 + dr, nr);
 
     for (int ir = ir0; ir < ir1; ++ir) {
         // src0 and dst are viewed with shape of src1 and offset
         // => same indices
-        const int i3 = ir/(ne12*ne11);
-        const int i2 = (ir - i3*ne12*ne11)/ne11;
-        const int i1 = (ir - i3*ne12*ne11 - i2*ne11);
+        const int i3 = ir / (ne12 * ne11);
+        const int i2 = (ir - i3 * ne12 * ne11) / ne11;
+        const int i1 = (ir - i3 * ne12 * ne11 - i2 * ne11);
 
-        ggml_vec_cpy_i32(nc,
-                (int32_t *) ((char *)  dst->data + i3*nb3  + i2*nb2  + i1*nb1  + offset),
-                (int32_t *) ((char *) src1->data + i3*nb13 + i2*nb12 + i1*nb11));
+        ggml_vec_cpy_i32(nc, (int32_t*)((char*)dst->data + i3 * nb3 + i2 * nb2 + i1 * nb1 + offset),
+                         (int32_t*)((char*)src1->data + i3 * nb13 + i2 * nb12 + i1 * nb11));
     }
 }
 
-void ggml_compute_forward_set(
-        const ggml_compute_params * params,
-        ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
+void ggml_compute_forward_set(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
 
     switch (src0->type) {
-        case GGML_TYPE_F32:
-            {
-                ggml_compute_forward_set_f32(params, dst);
-            } break;
-        case GGML_TYPE_I32:
-            {
-                ggml_compute_forward_set_i32(params, dst);
-            } break;
-        case GGML_TYPE_F16:
-        case GGML_TYPE_BF16:
-        case GGML_TYPE_Q1_0:
-        case GGML_TYPE_Q4_0:
-        case GGML_TYPE_Q4_1:
-        case GGML_TYPE_Q5_0:
-        case GGML_TYPE_Q5_1:
-        case GGML_TYPE_Q8_0:
-        case GGML_TYPE_Q8_1:
-        case GGML_TYPE_MXFP4:
-        case GGML_TYPE_NVFP4:
-        case GGML_TYPE_Q2_K:
-        case GGML_TYPE_Q3_K:
-        case GGML_TYPE_Q4_K:
-        case GGML_TYPE_Q5_K:
-        case GGML_TYPE_Q6_K:
-        case GGML_TYPE_TQ1_0:
-        case GGML_TYPE_TQ2_0:
-        case GGML_TYPE_IQ2_XXS:
-        case GGML_TYPE_IQ2_XS:
-        case GGML_TYPE_IQ3_XXS:
-        case GGML_TYPE_IQ1_S:
-        case GGML_TYPE_IQ1_M:
-        case GGML_TYPE_IQ4_NL:
-        case GGML_TYPE_IQ4_XS:
-        case GGML_TYPE_IQ3_S:
-        case GGML_TYPE_IQ2_S:
-        default:
-            {
-                GGML_ABORT("fatal error");
-            }
+    case GGML_TYPE_F32: {
+        ggml_compute_forward_set_f32(params, dst);
+    } break;
+    case GGML_TYPE_I32: {
+        ggml_compute_forward_set_i32(params, dst);
+    } break;
+    case GGML_TYPE_F16:
+    case GGML_TYPE_BF16:
+    case GGML_TYPE_Q1_0:
+    case GGML_TYPE_Q4_0:
+    case GGML_TYPE_Q4_1:
+    case GGML_TYPE_Q5_0:
+    case GGML_TYPE_Q5_1:
+    case GGML_TYPE_Q8_0:
+    case GGML_TYPE_Q8_1:
+    case GGML_TYPE_MXFP4:
+    case GGML_TYPE_NVFP4:
+    case GGML_TYPE_Q2_K:
+    case GGML_TYPE_Q3_K:
+    case GGML_TYPE_Q4_K:
+    case GGML_TYPE_Q5_K:
+    case GGML_TYPE_Q6_K:
+    case GGML_TYPE_TQ1_0:
+    case GGML_TYPE_TQ2_0:
+    case GGML_TYPE_IQ2_XXS:
+    case GGML_TYPE_IQ2_XS:
+    case GGML_TYPE_IQ3_XXS:
+    case GGML_TYPE_IQ1_S:
+    case GGML_TYPE_IQ1_M:
+    case GGML_TYPE_IQ4_NL:
+    case GGML_TYPE_IQ4_XS:
+    case GGML_TYPE_IQ3_S:
+    case GGML_TYPE_IQ2_S:
+    default: {
+        GGML_ABORT("fatal error");
+    }
     }
 }
 
 // ggml_compute_forward_cpy
 
-void ggml_compute_forward_cpy(
-        const ggml_compute_params * params,
-        ggml_tensor * dst) {
+void ggml_compute_forward_cpy(const ggml_compute_params* params, ggml_tensor* dst) {
     ggml_compute_forward_dup(params, dst);
 }
 
 // ggml_compute_forward_cont
 
-void ggml_compute_forward_cont(
-        const ggml_compute_params * params,
-        ggml_tensor * dst) {
+void ggml_compute_forward_cont(const ggml_compute_params* params, ggml_tensor* dst) {
     ggml_compute_forward_dup(params, dst);
 }
 
 // ggml_compute_forward_get_rows
 
-static void ggml_compute_forward_get_rows_q(
-        const ggml_compute_params * params,
-              ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
-    const ggml_tensor * src1 = dst->src[1];
+static void ggml_compute_forward_get_rows_q(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
+    const ggml_tensor* src1 = dst->src[1];
 
     GGML_TENSOR_BINARY_OP_LOCALS
 
@@ -4893,7 +4464,7 @@ static void ggml_compute_forward_get_rows_q(
     const ggml_type type = src0->type;
     ggml_to_float_t const dequantize_row_q = ggml_get_type_traits(type)->to_float;
 
-    assert(ne0  == nc);
+    assert(ne0 == nc);
     assert(ne02 == ne11);
     assert(nb00 == ggml_type_size(type));
     assert(ggml_nrows(dst) == nr);
@@ -4902,39 +4473,35 @@ static void ggml_compute_forward_get_rows_q(
     const int nth = params->nth;
 
     // rows per thread
-    const int dr = (nr + nth - 1)/nth;
+    const int dr = (nr + nth - 1) / nth;
 
     // row range for this thread
-    const int ir0 = dr*ith;
+    const int ir0 = dr * ith;
     const int ir1 = MIN(ir0 + dr, nr);
 
     for (int64_t i = ir0; i < ir1; ++i) {
-        const int64_t i12 = i/(ne11*ne10);
-        const int64_t i11 = (i - i12*ne11*ne10)/ne10;
-        const int64_t i10 = (i - i12*ne11*ne10 - i11*ne10);
-        const int64_t i01 = *(int32_t *) ((char *) src1->data + i10*nb10 + i11*nb11 + i12*nb12);
+        const int64_t i12 = i / (ne11 * ne10);
+        const int64_t i11 = (i - i12 * ne11 * ne10) / ne10;
+        const int64_t i10 = (i - i12 * ne11 * ne10 - i11 * ne10);
+        const int64_t i01 = *(int32_t*)((char*)src1->data + i10 * nb10 + i11 * nb11 + i12 * nb12);
 
         GGML_ASSERT(i01 >= 0 && i01 < ne01);
 
-        dequantize_row_q(
-                (const void *) ((char *) src0->data + i01*nb01 + i11*nb02 + i12*nb03),
-                     (float *) ((char *)  dst->data + i10*nb1  + i11*nb2  + i12*nb3), nc);
+        dequantize_row_q((const void*)((char*)src0->data + i01 * nb01 + i11 * nb02 + i12 * nb03),
+                         (float*)((char*)dst->data + i10 * nb1 + i11 * nb2 + i12 * nb3), nc);
     }
 }
 
-static void ggml_compute_forward_get_rows_f16(
-        const ggml_compute_params * params,
-              ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
-    const ggml_tensor * src1 = dst->src[1];
+static void ggml_compute_forward_get_rows_f16(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
+    const ggml_tensor* src1 = dst->src[1];
 
     GGML_TENSOR_BINARY_OP_LOCALS
 
     const int64_t nc = ne00;
     const int64_t nr = ggml_nelements(src1);
 
-    assert(ne0  == nc);
+    assert(ne0 == nc);
     assert(ne02 == ne11);
     assert(nb00 == sizeof(ggml_fp16_t));
     assert(ggml_nrows(dst) == nr);
@@ -4943,39 +4510,35 @@ static void ggml_compute_forward_get_rows_f16(
     const int nth = params->nth;
 
     // rows per thread
-    const int dr = (nr + nth - 1)/nth;
+    const int dr = (nr + nth - 1) / nth;
 
     // row range for this thread
-    const int ir0 = dr*ith;
+    const int ir0 = dr * ith;
     const int ir1 = MIN(ir0 + dr, nr);
 
     for (int64_t i = ir0; i < ir1; ++i) {
-        const int64_t i12 = i/(ne11*ne10);
-        const int64_t i11 = (i - i12*ne11*ne10)/ne10;
-        const int64_t i10 = (i - i12*ne11*ne10 - i11*ne10);
-        const int64_t i01 = *(int32_t *) ((char *) src1->data + i10*nb10 + i11*nb11 + i12*nb12);
+        const int64_t i12 = i / (ne11 * ne10);
+        const int64_t i11 = (i - i12 * ne11 * ne10) / ne10;
+        const int64_t i10 = (i - i12 * ne11 * ne10 - i11 * ne10);
+        const int64_t i01 = *(int32_t*)((char*)src1->data + i10 * nb10 + i11 * nb11 + i12 * nb12);
 
         GGML_ASSERT(i01 >= 0 && i01 < ne01);
 
-        ggml_cpu_fp16_to_fp32(
-            (const ggml_fp16_t*) ((char *) src0->data + i01*nb01 + i11*nb02 + i12*nb03),
-                       (float *) ((char *)  dst->data + i10*nb1  + i11*nb2  + i12*nb3), nc);
+        ggml_cpu_fp16_to_fp32((const ggml_fp16_t*)((char*)src0->data + i01 * nb01 + i11 * nb02 + i12 * nb03),
+                              (float*)((char*)dst->data + i10 * nb1 + i11 * nb2 + i12 * nb3), nc);
     }
 }
 
-static void ggml_compute_forward_get_rows_bf16(
-        const ggml_compute_params * params,
-              ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
-    const ggml_tensor * src1 = dst->src[1];
+static void ggml_compute_forward_get_rows_bf16(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
+    const ggml_tensor* src1 = dst->src[1];
 
     GGML_TENSOR_BINARY_OP_LOCALS
 
     const int64_t nc = ne00;
     const int64_t nr = ggml_nelements(src1);
 
-    assert(ne0  == nc);
+    assert(ne0 == nc);
     assert(ne02 == ne11);
     assert(nb00 == sizeof(ggml_bf16_t));
     assert(ggml_nrows(dst) == nr);
@@ -4984,39 +4547,35 @@ static void ggml_compute_forward_get_rows_bf16(
     const int nth = params->nth;
 
     // rows per thread
-    const int dr = (nr + nth - 1)/nth;
+    const int dr = (nr + nth - 1) / nth;
 
     // row range for this thread
-    const int ir0 = dr*ith;
+    const int ir0 = dr * ith;
     const int ir1 = MIN(ir0 + dr, nr);
 
     for (int64_t i = ir0; i < ir1; ++i) {
-        const int64_t i12 = i/(ne11*ne10);
-        const int64_t i11 = (i - i12*ne11*ne10)/ne10;
-        const int64_t i10 = (i - i12*ne11*ne10 - i11*ne10);
-        const int64_t i01 = *(int32_t *) ((char *) src1->data + i10*nb10 + i11*nb11 + i12*nb12);
+        const int64_t i12 = i / (ne11 * ne10);
+        const int64_t i11 = (i - i12 * ne11 * ne10) / ne10;
+        const int64_t i10 = (i - i12 * ne11 * ne10 - i11 * ne10);
+        const int64_t i01 = *(int32_t*)((char*)src1->data + i10 * nb10 + i11 * nb11 + i12 * nb12);
 
         GGML_ASSERT(i01 >= 0 && i01 < ne01);
 
-        ggml_cpu_bf16_to_fp32(
-            (const ggml_bf16_t *) ((char *) src0->data + i01*nb01 + i11*nb02 + i12*nb03),
-                        (float *) ((char *)  dst->data + i10*nb1  + i11*nb2  + i12*nb3), nc);
+        ggml_cpu_bf16_to_fp32((const ggml_bf16_t*)((char*)src0->data + i01 * nb01 + i11 * nb02 + i12 * nb03),
+                              (float*)((char*)dst->data + i10 * nb1 + i11 * nb2 + i12 * nb3), nc);
     }
 }
 
-static void ggml_compute_forward_get_rows_f32(
-        const ggml_compute_params * params,
-              ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
-    const ggml_tensor * src1 = dst->src[1];
+static void ggml_compute_forward_get_rows_f32(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
+    const ggml_tensor* src1 = dst->src[1];
 
     GGML_TENSOR_BINARY_OP_LOCALS
 
     const int64_t nc = ne00;
     const int64_t nr = ggml_nelements(src1);
 
-    assert(ne0  == nc);
+    assert(ne0 == nc);
     assert(ne02 == ne11);
     assert(nb00 == sizeof(float));
     assert(ggml_nrows(dst) == nr);
@@ -5025,78 +4584,69 @@ static void ggml_compute_forward_get_rows_f32(
     const int nth = params->nth;
 
     // rows per thread
-    const int dr = (nr + nth - 1)/nth;
+    const int dr = (nr + nth - 1) / nth;
 
     // row range for this thread
-    const int ir0 = dr*ith;
+    const int ir0 = dr * ith;
     const int ir1 = MIN(ir0 + dr, nr);
 
     for (int64_t i = ir0; i < ir1; ++i) {
-        const int64_t i12 = i/(ne11*ne10);
-        const int64_t i11 = (i - i12*ne11*ne10)/ne10;
-        const int64_t i10 = (i - i12*ne11*ne10 - i11*ne10);
-        const int64_t i01 = *(int32_t *) ((char *) src1->data + i10*nb10 + i11*nb11 + i12*nb12);
+        const int64_t i12 = i / (ne11 * ne10);
+        const int64_t i11 = (i - i12 * ne11 * ne10) / ne10;
+        const int64_t i10 = (i - i12 * ne11 * ne10 - i11 * ne10);
+        const int64_t i01 = *(int32_t*)((char*)src1->data + i10 * nb10 + i11 * nb11 + i12 * nb12);
 
         GGML_ASSERT(i01 >= 0 && i01 < ne01);
 
-        ggml_vec_cpy_f32(nc,
-                (float *) ((char *)  dst->data + i10*nb1  + i11*nb2  + i12*nb3),
-                (float *) ((char *) src0->data + i01*nb01 + i11*nb02 + i12*nb03));
+        ggml_vec_cpy_f32(nc, (float*)((char*)dst->data + i10 * nb1 + i11 * nb2 + i12 * nb3),
+                         (float*)((char*)src0->data + i01 * nb01 + i11 * nb02 + i12 * nb03));
     }
 }
 
-void ggml_compute_forward_get_rows(
-        const ggml_compute_params * params,
-        ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
+void ggml_compute_forward_get_rows(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
 
     switch (src0->type) {
-        case GGML_TYPE_Q1_0:
-        case GGML_TYPE_Q4_0:
-        case GGML_TYPE_Q4_1:
-        case GGML_TYPE_Q5_0:
-        case GGML_TYPE_Q5_1:
-        case GGML_TYPE_Q8_0:
-        case GGML_TYPE_Q8_1:
-        case GGML_TYPE_MXFP4:
-        case GGML_TYPE_NVFP4:
-        case GGML_TYPE_Q2_K:
-        case GGML_TYPE_Q3_K:
-        case GGML_TYPE_Q4_K:
-        case GGML_TYPE_Q5_K:
-        case GGML_TYPE_Q6_K:
-        case GGML_TYPE_TQ1_0:
-        case GGML_TYPE_TQ2_0:
-        case GGML_TYPE_IQ2_XXS:
-        case GGML_TYPE_IQ2_XS:
-        case GGML_TYPE_IQ3_XXS:
-        case GGML_TYPE_IQ1_S:
-        case GGML_TYPE_IQ1_M:
-        case GGML_TYPE_IQ4_NL:
-        case GGML_TYPE_IQ4_XS:
-        case GGML_TYPE_IQ3_S:
-        case GGML_TYPE_IQ2_S:
-            {
-                ggml_compute_forward_get_rows_q(params, dst);
-            } break;
-        case GGML_TYPE_F16:
-            {
-                ggml_compute_forward_get_rows_f16(params, dst);
-            } break;
-        case GGML_TYPE_BF16:
-            {
-                ggml_compute_forward_get_rows_bf16(params, dst);
-            } break;
-        case GGML_TYPE_F32:
-        case GGML_TYPE_I32:
-            {
-                ggml_compute_forward_get_rows_f32(params, dst);
-            } break;
-        default:
-            {
-                GGML_ABORT("fatal error");
-            }
+    case GGML_TYPE_Q1_0:
+    case GGML_TYPE_Q4_0:
+    case GGML_TYPE_Q4_1:
+    case GGML_TYPE_Q5_0:
+    case GGML_TYPE_Q5_1:
+    case GGML_TYPE_Q8_0:
+    case GGML_TYPE_Q8_1:
+    case GGML_TYPE_MXFP4:
+    case GGML_TYPE_NVFP4:
+    case GGML_TYPE_Q2_K:
+    case GGML_TYPE_Q3_K:
+    case GGML_TYPE_Q4_K:
+    case GGML_TYPE_Q5_K:
+    case GGML_TYPE_Q6_K:
+    case GGML_TYPE_TQ1_0:
+    case GGML_TYPE_TQ2_0:
+    case GGML_TYPE_IQ2_XXS:
+    case GGML_TYPE_IQ2_XS:
+    case GGML_TYPE_IQ3_XXS:
+    case GGML_TYPE_IQ1_S:
+    case GGML_TYPE_IQ1_M:
+    case GGML_TYPE_IQ4_NL:
+    case GGML_TYPE_IQ4_XS:
+    case GGML_TYPE_IQ3_S:
+    case GGML_TYPE_IQ2_S: {
+        ggml_compute_forward_get_rows_q(params, dst);
+    } break;
+    case GGML_TYPE_F16: {
+        ggml_compute_forward_get_rows_f16(params, dst);
+    } break;
+    case GGML_TYPE_BF16: {
+        ggml_compute_forward_get_rows_bf16(params, dst);
+    } break;
+    case GGML_TYPE_F32:
+    case GGML_TYPE_I32: {
+        ggml_compute_forward_get_rows_f32(params, dst);
+    } break;
+    default: {
+        GGML_ABORT("fatal error");
+    }
     }
 
     //static bool first = true;
@@ -5118,22 +4668,19 @@ void ggml_compute_forward_get_rows(
     //}
 }
 
-template<typename idx_t>
-static void ggml_compute_forward_set_rows_f32(
-        const ggml_compute_params * params,
-              ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
-    const ggml_tensor * src1 = dst->src[1];
+template <typename idx_t>
+static void ggml_compute_forward_set_rows_f32(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
+    const ggml_tensor* src1 = dst->src[1];
 
     GGML_TENSOR_BINARY_OP_LOCALS
 
     const int64_t nc = ne00;
     const int64_t nr = ne01;
 
-    assert(ne0  == nc);
-    assert(ne2  == ne02);
-    assert(ne3  == ne03);
+    assert(ne0 == nc);
+    assert(ne2 == ne02);
+    assert(ne3 == ne03);
     assert(src0->type == GGML_TYPE_F32);
     assert(ne02 % ne11 == 0);
     assert(ne03 % ne12 == 0);
@@ -5142,10 +4689,10 @@ static void ggml_compute_forward_set_rows_f32(
     const int nth = params->nth;
 
     // rows per thread
-    const int64_t dr = (nr + nth - 1)/nth;
+    const int64_t dr = (nr + nth - 1) / nth;
 
     // row range for this thread
-    const int64_t ir0 = dr*ith;
+    const int64_t ir0 = dr * ith;
     const int64_t ir1 = std::min(ir0 + dr, nr);
 
     ggml_from_float_t const from_float = ggml_get_type_traits_cpu(dst->type)->from_float;
@@ -5153,55 +4700,46 @@ static void ggml_compute_forward_set_rows_f32(
     for (int64_t i03 = 0; i03 < ne03; ++i03) {
         for (int64_t i02 = 0; i02 < ne02; ++i02) {
             for (int64_t i = ir0; i < ir1; ++i) {
-                const int64_t i12 = i03%ne12;
-                const int64_t i11 = i02%ne11;
+                const int64_t i12 = i03 % ne12;
+                const int64_t i11 = i02 % ne11;
                 const int64_t i10 = i;
 
-                const int64_t i1 = *(idx_t *) ((char *) src1->data + i10*nb10 + i11*nb11 + i12*nb12);
+                const int64_t i1 = *(idx_t*)((char*)src1->data + i10 * nb10 + i11 * nb11 + i12 * nb12);
 
                 GGML_ASSERT(i1 >= 0 && i1 < ne1);
 
-                from_float(
-                        (const float *) ((char *) src0->data +  i*nb01 + i02*nb02 + i03*nb03),
-                                        ((char *)  dst->data + i1*nb1  + i02*nb2  + i03*nb3), nc);
+                from_float((const float*)((char*)src0->data + i * nb01 + i02 * nb02 + i03 * nb03),
+                           ((char*)dst->data + i1 * nb1 + i02 * nb2 + i03 * nb3), nc);
             }
         }
     }
 }
 
-void ggml_compute_forward_set_rows(
-        const ggml_compute_params * params,
-        ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
-    const ggml_tensor * src1 = dst->src[1];
+void ggml_compute_forward_set_rows(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
+    const ggml_tensor* src1 = dst->src[1];
 
     switch (src0->type) {
-        case GGML_TYPE_F32:
-            {
-                if (src1->type == GGML_TYPE_I64) {
-                    ggml_compute_forward_set_rows_f32<int64_t>(params, dst);
-                } else if (src1->type == GGML_TYPE_I32) {
-                    ggml_compute_forward_set_rows_f32<int32_t>(params, dst);
-                } else {
-                    GGML_ABORT("src1->type = %d (%s) not supported", src1->type, ggml_type_name(src1->type));
-                }
-            } break;
-        default:
-            {
-                GGML_ABORT("src0->type = %d (%s) not supported", src0->type, ggml_type_name(src0->type));
-            }
+    case GGML_TYPE_F32: {
+        if (src1->type == GGML_TYPE_I64) {
+            ggml_compute_forward_set_rows_f32<int64_t>(params, dst);
+        } else if (src1->type == GGML_TYPE_I32) {
+            ggml_compute_forward_set_rows_f32<int32_t>(params, dst);
+        } else {
+            GGML_ABORT("src1->type = %d (%s) not supported", src1->type, ggml_type_name(src1->type));
+        }
+    } break;
+    default: {
+        GGML_ABORT("src0->type = %d (%s) not supported", src0->type, ggml_type_name(src0->type));
+    }
     }
 }
 
 // ggml_compute_forward_get_rows_back
 
-static void ggml_compute_forward_get_rows_back_f32_f16(
-        const ggml_compute_params * params,
-              ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
-    const ggml_tensor * src1 = dst->src[1];
+static void ggml_compute_forward_get_rows_back_f32_f16(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
+    const ggml_tensor* src1 = dst->src[1];
 
     if (params->ith != 0) {
         return;
@@ -5216,25 +4754,22 @@ static void ggml_compute_forward_get_rows_back_f32_f16(
     const int nc = src0->ne[0];
     const int nr = ggml_nelements(src1);
 
-    GGML_ASSERT( dst->ne[0] == nc);
+    GGML_ASSERT(dst->ne[0] == nc);
     GGML_ASSERT(src0->nb[0] == sizeof(ggml_fp16_t));
 
     for (int i = 0; i < nr; ++i) {
-        const int r = ((int32_t *) src1->data)[i];
+        const int r = ((int32_t*)src1->data)[i];
 
         for (int j = 0; j < nc; ++j) {
-            ggml_fp16_t v = ((ggml_fp16_t *) ((char *) src0->data + i*src0->nb[1]))[j];
-            ((float *) ((char *) dst->data + r*dst->nb[1]))[j] += GGML_CPU_FP16_TO_FP32(v);
+            ggml_fp16_t v = ((ggml_fp16_t*)((char*)src0->data + i * src0->nb[1]))[j];
+            ((float*)((char*)dst->data + r * dst->nb[1]))[j] += GGML_CPU_FP16_TO_FP32(v);
         }
     }
 }
 
-static void ggml_compute_forward_get_rows_back_f32(
-        const ggml_compute_params * params,
-              ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
-    const ggml_tensor * src1 = dst->src[1];
+static void ggml_compute_forward_get_rows_back_f32(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
+    const ggml_tensor* src1 = dst->src[1];
 
     if (params->ith != 0) {
         return;
@@ -5249,38 +4784,30 @@ static void ggml_compute_forward_get_rows_back_f32(
     const int nc = src0->ne[0];
     const int nr = ggml_nelements(src1);
 
-    GGML_ASSERT( dst->ne[0] == nc);
+    GGML_ASSERT(dst->ne[0] == nc);
     GGML_ASSERT(src0->nb[0] == sizeof(float));
 
     for (int i = 0; i < nr; ++i) {
-        const int r = ((int32_t *) src1->data)[i];
+        const int r = ((int32_t*)src1->data)[i];
 
-        ggml_vec_add_f32(nc,
-                (float *) ((char *)  dst->data + r*dst->nb[1]),
-                (float *) ((char *)  dst->data + r*dst->nb[1]),
-                (float *) ((char *) src0->data + i*src0->nb[1]));
+        ggml_vec_add_f32(nc, (float*)((char*)dst->data + r * dst->nb[1]), (float*)((char*)dst->data + r * dst->nb[1]),
+                         (float*)((char*)src0->data + i * src0->nb[1]));
     }
 }
 
-void ggml_compute_forward_get_rows_back(
-        const ggml_compute_params * params,
-        ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
+void ggml_compute_forward_get_rows_back(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
 
     switch (src0->type) {
-        case GGML_TYPE_F16:
-            {
-                ggml_compute_forward_get_rows_back_f32_f16(params, dst);
-            } break;
-        case GGML_TYPE_F32:
-            {
-                ggml_compute_forward_get_rows_back_f32(params, dst);
-            } break;
-        default:
-            {
-                GGML_ABORT("fatal error");
-            }
+    case GGML_TYPE_F16: {
+        ggml_compute_forward_get_rows_back_f32_f16(params, dst);
+    } break;
+    case GGML_TYPE_F32: {
+        ggml_compute_forward_get_rows_back_f32(params, dst);
+    } break;
+    default: {
+        GGML_ABORT("fatal error");
+    }
     }
 
     //static bool first = true;
@@ -5304,11 +4831,8 @@ void ggml_compute_forward_get_rows_back(
 
 // ggml_compute_forward_diag
 
-static void ggml_compute_forward_diag_f32(
-        const ggml_compute_params * params,
-        ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
+static void ggml_compute_forward_diag_f32(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
 
     if (params->ith != 0) {
         return;
@@ -5325,18 +4849,18 @@ static void ggml_compute_forward_diag_f32(
     GGML_ASSERT(ne03 == ne3);
 
     GGML_ASSERT(nb00 == sizeof(float));
-    GGML_ASSERT(nb0  == sizeof(float));
+    GGML_ASSERT(nb0 == sizeof(float));
 
     for (int i3 = 0; i3 < ne3; i3++) {
         for (int i2 = 0; i2 < ne2; i2++) {
             for (int i1 = 0; i1 < ne1; i1++) {
-                float * d = (float *)((char *)  dst->data + i3*nb3  + i2*nb2 + i1*nb1);
-                float * s = (float *)((char *) src0->data + i3*nb03 + i2*nb02);
+                float* d = (float*)((char*)dst->data + i3 * nb3 + i2 * nb2 + i1 * nb1);
+                float* s = (float*)((char*)src0->data + i3 * nb03 + i2 * nb02);
                 for (int i0 = 0; i0 < i1; i0++) {
                     d[i0] = 0;
                 }
                 d[i1] = s[i1];
-                for (int i0 = i1+1; i0 < ne0; i0++) {
+                for (int i0 = i1 + 1; i0 < ne0; i0++) {
                     d[i0] = 0;
                 }
             }
@@ -5344,37 +4868,28 @@ static void ggml_compute_forward_diag_f32(
     }
 }
 
-void ggml_compute_forward_diag(
-        const ggml_compute_params * params,
-        ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
+void ggml_compute_forward_diag(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
 
     switch (src0->type) {
-        case GGML_TYPE_F32:
-            {
-                ggml_compute_forward_diag_f32(params, dst);
-            } break;
-        default:
-            {
-                GGML_ABORT("fatal error");
-            }
+    case GGML_TYPE_F32: {
+        ggml_compute_forward_diag_f32(params, dst);
+    } break;
+    default: {
+        GGML_ABORT("fatal error");
+    }
     }
 }
 
 // ggml_compute_forward_diag_mask_inf
 
-static void ggml_compute_forward_diag_mask_f32(
-        const ggml_compute_params * params,
-        ggml_tensor * dst,
-        const float value) {
-
-    const ggml_tensor * src0 = dst->src[0];
+static void ggml_compute_forward_diag_mask_f32(const ggml_compute_params* params, ggml_tensor* dst, const float value) {
+    const ggml_tensor* src0 = dst->src[0];
 
     const int ith = params->ith;
     const int nth = params->nth;
 
-    const int  n_past  = ((int32_t *) dst->op_params)[0];
+    const int n_past = ((int32_t*)dst->op_params)[0];
     const bool inplace = src0->data == dst->data;
 
     GGML_ASSERT(n_past >= 0);
@@ -5385,89 +4900,73 @@ static void ggml_compute_forward_diag_mask_f32(
             // => do it in INIT phase
             GGML_ASSERT(ggml_nelements(dst) == ggml_nelements(src0));
             GGML_ASSERT(ggml_is_contiguous(dst) && ggml_is_contiguous(src0));
-            memcpy(
-                ((char *)  dst->data),
-                ((char *) src0->data),
-                ggml_nbytes(dst));
+            memcpy(((char*)dst->data), ((char*)src0->data), ggml_nbytes(dst));
         }
         ggml_barrier(params->threadpool);
     }
 
     // TODO: handle transposed/permuted matrices
 
-    const int n  = ggml_nrows(src0);
+    const int n = ggml_nrows(src0);
     const int nc = src0->ne[0];
     const int nr = src0->ne[1];
-    const int nz = n/nr;
+    const int nz = n / nr;
 
-    GGML_ASSERT( dst->nb[0] == sizeof(float));
+    GGML_ASSERT(dst->nb[0] == sizeof(float));
     GGML_ASSERT(src0->nb[0] == sizeof(float));
 
     for (int k = 0; k < nz; k++) {
         for (int j = ith; j < nr; j += nth) {
             for (int i = n_past; i < nc; i++) {
                 if (i > n_past + j) {
-                    *(float *)((char *) dst->data + k*dst->nb[2] + j*dst->nb[1] + i*dst->nb[0]) = value;
+                    *(float*)((char*)dst->data + k * dst->nb[2] + j * dst->nb[1] + i * dst->nb[0]) = value;
                 }
             }
         }
     }
 }
 
-void ggml_compute_forward_diag_mask_inf(
-        const ggml_compute_params * params,
-        ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
+void ggml_compute_forward_diag_mask_inf(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
 
     switch (src0->type) {
-        case GGML_TYPE_F32:
-            {
-                ggml_compute_forward_diag_mask_f32(params, dst, -INFINITY);
-            } break;
-        default:
-            {
-                GGML_ABORT("fatal error");
-            }
+    case GGML_TYPE_F32: {
+        ggml_compute_forward_diag_mask_f32(params, dst, -INFINITY);
+    } break;
+    default: {
+        GGML_ABORT("fatal error");
+    }
     }
 }
 
-void ggml_compute_forward_diag_mask_zero(
-        const ggml_compute_params * params,
-        ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
+void ggml_compute_forward_diag_mask_zero(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
 
     switch (src0->type) {
-        case GGML_TYPE_F32:
-            {
-                ggml_compute_forward_diag_mask_f32(params, dst, 0);
-            } break;
-        default:
-            {
-                GGML_ABORT("fatal error");
-            }
+    case GGML_TYPE_F32: {
+        ggml_compute_forward_diag_mask_f32(params, dst, 0);
+    } break;
+    default: {
+        GGML_ABORT("fatal error");
+    }
     }
 }
 
 // ggml_compute_forward_soft_max
 
-static void ggml_compute_forward_soft_max_f32(
-        const ggml_compute_params * params,
-              ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
-    const ggml_tensor * src1 = dst->src[1];
-    const ggml_tensor * src2 = dst->src[2];
+static void ggml_compute_forward_soft_max_f32(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
+    const ggml_tensor* src1 = dst->src[1];
+    const ggml_tensor* src2 = dst->src[2];
 
     assert(ggml_is_contiguous(dst));
     assert(ggml_are_same_shape(src0, dst));
 
-    float scale    = 1.0f;
+    float scale = 1.0f;
     float max_bias = 0.0f;
 
-    memcpy(&scale,    (float *) dst->op_params + 0, sizeof(float));
-    memcpy(&max_bias, (float *) dst->op_params + 1, sizeof(float));
+    memcpy(&scale, (float*)dst->op_params + 0, sizeof(float));
+    memcpy(&max_bias, (float*)dst->op_params + 1, sizeof(float));
 
     const int ith = params->ith;
     const int nth = params->nth;
@@ -5483,47 +4982,49 @@ static void ggml_compute_forward_soft_max_f32(
 
     // TODO: is this supposed to be ceil instead of floor?
     //       https://huggingface.co/mosaicml/mpt-7b/blob/main/attention.py#L370
-    const uint32_t n_head      = ne02;
-    const uint32_t n_head_log2 = 1u << (uint32_t) floor(log2(n_head));
+    const uint32_t n_head = ne02;
+    const uint32_t n_head_log2 = 1u << (uint32_t)floor(log2(n_head));
 
-    const float m0 = powf(2.0f, -(max_bias       ) / n_head_log2);
+    const float m0 = powf(2.0f, -(max_bias) / n_head_log2);
     const float m1 = powf(2.0f, -(max_bias / 2.0f) / n_head_log2);
 
-    float * wp = (float *) params->wdata + (ne00 + CACHE_LINE_SIZE_F32) * ith;
+    float* wp = (float*)params->wdata + (ne00 + CACHE_LINE_SIZE_F32) * ith;
 
     const bool use_f16 = (src1 && src1->type == GGML_TYPE_F16);
 
     // sinks
-    const float * sk = src2 ? (float *)((char *) src2->data) : nullptr;
+    const float* sk = src2 ? (float*)((char*)src2->data) : nullptr;
 
     for (int64_t i03 = 0; i03 < ne03; i03++) {
         for (int64_t i02 = 0; i02 < ne02; i02++) {
             for (int64_t i01 = ith; i01 < ne01; i01 += nth) {
                 const int64_t i11 = i01;
-                const int64_t i12 = i02%ne12;
-                const int64_t i13 = i03%ne13;
+                const int64_t i12 = i02 % ne12;
+                const int64_t i13 = i03 % ne13;
 
                 // ALiBi
                 const uint32_t h = i02; // head
-                const float slope = (max_bias > 0.0f) ? h < n_head_log2 ? powf(m0, h + 1) : powf(m1, 2*(h - n_head_log2) + 1) : 1.0f;
+                const float slope =
+                    (max_bias > 0.0f) ? h < n_head_log2 ? powf(m0, h + 1) : powf(m1, 2 * (h - n_head_log2) + 1) : 1.0f;
 
-                float * sp = (float *)((char *) src0->data + i01*nb01 + i02*nb02 + i03*nb03);
-                float * dp = (float *)((char *)  dst->data + i01*nb1  + i02*nb2  + i03*nb3);
+                float* sp = (float*)((char*)src0->data + i01 * nb01 + i02 * nb02 + i03 * nb03);
+                float* dp = (float*)((char*)dst->data + i01 * nb1 + i02 * nb2 + i03 * nb3);
 
                 // broadcast the mask across rows
-                ggml_fp16_t * mp_f16 = src1 ? (ggml_fp16_t *)((char *) src1->data + i11*nb11 + i12*nb12 + i13*nb13) : NULL;
-                float       * mp_f32 = src1 ? (float       *)((char *) src1->data + i11*nb11 + i12*nb12 + i13*nb13) : NULL;
+                ggml_fp16_t* mp_f16 =
+                    src1 ? (ggml_fp16_t*)((char*)src1->data + i11 * nb11 + i12 * nb12 + i13 * nb13) : NULL;
+                float* mp_f32 = src1 ? (float*)((char*)src1->data + i11 * nb11 + i12 * nb12 + i13 * nb13) : NULL;
 
-                ggml_vec_cpy_f32  (ne00, wp, sp);
+                ggml_vec_cpy_f32(ne00, wp, sp);
                 ggml_vec_scale_f32(ne00, wp, scale);
                 if (mp_f32) {
                     if (use_f16) {
                         for (int i = 0; i < ne00; ++i) {
-                            wp[i] += slope*GGML_CPU_FP16_TO_FP32(mp_f16[i]);
+                            wp[i] += slope * GGML_CPU_FP16_TO_FP32(mp_f16[i]);
                         }
                     } else {
                         for (int i = 0; i < ne00; ++i) {
-                            wp[i] += slope*mp_f32[i];
+                            wp[i] += slope * mp_f32[i];
                         }
                     }
                 }
@@ -5547,10 +5048,10 @@ static void ggml_compute_forward_soft_max_f32(
                 assert(sum > 0.0);
 
                 if (sk) {
-                    sum += (ggml_float) expf(sk[i02] - max);
+                    sum += (ggml_float)expf(sk[i02] - max);
                 }
 
-                sum = 1.0/sum;
+                sum = 1.0 / sum;
                 ggml_vec_scale_f32(ne00, dp, sum);
 
 #ifndef NDEBUG
@@ -5564,33 +5065,25 @@ static void ggml_compute_forward_soft_max_f32(
     }
 }
 
-void ggml_compute_forward_soft_max(
-        const ggml_compute_params * params,
-              ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
+void ggml_compute_forward_soft_max(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
 
     switch (src0->type) {
-        case GGML_TYPE_F32:
-            {
-                ggml_compute_forward_soft_max_f32(params, dst);
-            } break;
-        default:
-            {
-                GGML_ABORT("fatal error");
-            }
+    case GGML_TYPE_F32: {
+        ggml_compute_forward_soft_max_f32(params, dst);
+    } break;
+    default: {
+        GGML_ABORT("fatal error");
+    }
     }
 }
 
 
 // ggml_compute_forward_soft_max_ext_back
 
-static void ggml_compute_forward_soft_max_ext_back_f32(
-        const ggml_compute_params * params,
-        ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
-    const ggml_tensor * src1 = dst->src[1];
+static void ggml_compute_forward_soft_max_ext_back_f32(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
+    const ggml_tensor* src1 = dst->src[1];
 
     GGML_ASSERT(ggml_is_contiguous(src0));
     GGML_ASSERT(ggml_is_contiguous(src1));
@@ -5598,11 +5091,11 @@ static void ggml_compute_forward_soft_max_ext_back_f32(
     GGML_ASSERT(ggml_are_same_shape(src0, dst));
     GGML_ASSERT(ggml_are_same_shape(src1, dst));
 
-    float scale    = 1.0f;
+    float scale = 1.0f;
     float max_bias = 0.0f;
 
-    memcpy(&scale,    (const float *) dst->op_params + 0, sizeof(float));
-    memcpy(&max_bias, (const float *) dst->op_params + 1, sizeof(float));
+    memcpy(&scale, (const float*)dst->op_params + 0, sizeof(float));
+    memcpy(&max_bias, (const float*)dst->op_params + 1, sizeof(float));
 
     GGML_ASSERT(max_bias == 0.0f);
 
@@ -5615,16 +5108,16 @@ static void ggml_compute_forward_soft_max_ext_back_f32(
     const int nr = ggml_nrows(src0);
 
     // rows per thread
-    const int dr = (nr + nth - 1)/nth;
+    const int dr = (nr + nth - 1) / nth;
 
     // row range for this thread
-    const int ir0 = dr*ith;
+    const int ir0 = dr * ith;
     const int ir1 = MIN(ir0 + dr, nr);
 
     for (int i1 = ir0; i1 < ir1; i1++) {
-        float *dy = (float *)((char *) src0->data + i1*src0->nb[1]);
-        float *y  = (float *)((char *) src1->data + i1*src1->nb[1]);
-        float *dx = (float *)((char *) dst->data  + i1*dst->nb[1]);
+        float* dy = (float*)((char*)src0->data + i1 * src0->nb[1]);
+        float* y = (float*)((char*)src1->data + i1 * src1->nb[1]);
+        float* dx = (float*)((char*)dst->data + i1 * dst->nb[1]);
 
 #ifndef NDEBUG
         for (int i = 0; i < nc; ++i) {
@@ -5632,32 +5125,32 @@ static void ggml_compute_forward_soft_max_ext_back_f32(
             assert(!isnan(dy[i]));
             assert(!isnan(y[i]));
         }
-#endif // NDEBUG
-        // Jii = yi - yi*yi
-        // Jij = -yi*yj
-        // J = diag(y)-y.T*y
-        // dx = J * dy
-        // dxk = sum_i(Jki * dyi)
-        // dxk = sum_i(-yk*yi * dyi) - (-yk*yk)*dyk + (yk - yk*yk)*dyk
-        // dxk = sum_i(-yk*yi * dyi) + yk*yk*dyk + yk*dyk - yk*yk*dyk
-        // dxk = sum_i(-yk*yi * dyi) + yk*dyk
-        // dxk = -yk * sum_i(yi * dyi) + yk*dyk
-        // dxk = -yk * dot(y, dy) + yk*dyk
-        // dxk = yk * (- dot(y, dy) + dyk)
-        // dxk = yk * (dyk - dot(y, dy))
-        //
-        // post-order:
-        // dot_y_dy := dot(y, dy)
-        // dx := dy
-        // dx := dx - dot_y_dy
-        // dx := dx * y
+#endif // NDEBUG                                                                                                       \
+    // Jii = yi - yi*yi                                                                                                \
+    // Jij = -yi*yj                                                                                                    \
+    // J = diag(y)-y.T*y                                                                                               \
+    // dx = J * dy                                                                                                     \
+    // dxk = sum_i(Jki * dyi)                                                                                          \
+    // dxk = sum_i(-yk*yi * dyi) - (-yk*yk)*dyk + (yk - yk*yk)*dyk                                                     \
+    // dxk = sum_i(-yk*yi * dyi) + yk*yk*dyk + yk*dyk - yk*yk*dyk                                                      \
+    // dxk = sum_i(-yk*yi * dyi) + yk*dyk                                                                              \
+    // dxk = -yk * sum_i(yi * dyi) + yk*dyk                                                                            \
+    // dxk = -yk * dot(y, dy) + yk*dyk                                                                                 \
+    // dxk = yk * (- dot(y, dy) + dyk)                                                                                 \
+    // dxk = yk * (dyk - dot(y, dy))                                                                                   \
+    //                                                                                                                 \
+    // post-order:                                                                                                     \
+    // dot_y_dy := dot(y, dy)                                                                                          \
+    // dx := dy                                                                                                        \
+    // dx := dx - dot_y_dy                                                                                             \
+    // dx := dx * y
 
         // linear runtime, no additional memory
         float dot_y_dy = 0;
-        ggml_vec_dot_f32  (nc, &dot_y_dy, 0, y, 0, dy, 0, 1);
-        ggml_vec_cpy_f32  (nc, dx, dy);
-        ggml_vec_acc1_f32 (nc, dx, -dot_y_dy);
-        ggml_vec_mul_f32  (nc, dx, dx, y);
+        ggml_vec_dot_f32(nc, &dot_y_dy, 0, y, 0, dy, 0, 1);
+        ggml_vec_cpy_f32(nc, dx, dy);
+        ggml_vec_acc1_f32(nc, dx, -dot_y_dy);
+        ggml_vec_mul_f32(nc, dx, dx, y);
         ggml_vec_scale_f32(nc, dx, scale);
 
 #ifndef NDEBUG
@@ -5669,41 +5162,33 @@ static void ggml_compute_forward_soft_max_ext_back_f32(
     }
 }
 
-void ggml_compute_forward_soft_max_ext_back(
-        const ggml_compute_params * params,
-        ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
+void ggml_compute_forward_soft_max_ext_back(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
 
     switch (src0->type) {
-        case GGML_TYPE_F32:
-            {
-                ggml_compute_forward_soft_max_ext_back_f32(params, dst);
-            } break;
-        default:
-            {
-                GGML_ABORT("fatal error");
-            }
+    case GGML_TYPE_F32: {
+        ggml_compute_forward_soft_max_ext_back_f32(params, dst);
+    } break;
+    default: {
+        GGML_ABORT("fatal error");
+    }
     }
 }
 
 // ggml_compute_forward_clamp
 
-static void ggml_compute_forward_clamp_f32(
-        const ggml_compute_params * params,
-        ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
+static void ggml_compute_forward_clamp_f32(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
 
     float min;
     float max;
-    memcpy(&min, (float *) dst->op_params + 0, sizeof(float));
-    memcpy(&max, (float *) dst->op_params + 1, sizeof(float));
+    memcpy(&min, (float*)dst->op_params + 0, sizeof(float));
+    memcpy(&max, (float*)dst->op_params + 1, sizeof(float));
 
     const int ith = params->ith;
     const int nth = params->nth;
 
-    const int n  = ggml_nrows(src0);
+    const int n = ggml_nrows(src0);
     const int nc = src0->ne[0];
 
     const size_t nb00 = src0->nb[0];
@@ -5712,12 +5197,12 @@ static void ggml_compute_forward_clamp_f32(
     const size_t nb0 = dst->nb[0];
     const size_t nb1 = dst->nb[1];
 
-    GGML_ASSERT( nb0 == sizeof(float));
+    GGML_ASSERT(nb0 == sizeof(float));
     GGML_ASSERT(nb00 == sizeof(float));
 
     for (int j = ith; j < n; j += nth) {
-        float * dst_ptr  = (float *) ((char *)  dst->data + j*nb1);
-        float * src0_ptr = (float *) ((char *) src0->data + j*nb01);
+        float* dst_ptr = (float*)((char*)dst->data + j * nb1);
+        float* src0_ptr = (float*)((char*)src0->data + j * nb01);
 
         for (int i = 0; i < nc; i++) {
             dst_ptr[i] = MAX(MIN(src0_ptr[i], max), min);
@@ -5725,21 +5210,18 @@ static void ggml_compute_forward_clamp_f32(
     }
 }
 
-static void ggml_compute_forward_clamp_f16(
-    const ggml_compute_params * params,
-    ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
+static void ggml_compute_forward_clamp_f16(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
 
     float min;
     float max;
-    memcpy(&min, (float *) dst->op_params + 0, sizeof(float));
-    memcpy(&max, (float *) dst->op_params + 1, sizeof(float));
+    memcpy(&min, (float*)dst->op_params + 0, sizeof(float));
+    memcpy(&max, (float*)dst->op_params + 1, sizeof(float));
 
     const int ith = params->ith;
     const int nth = params->nth;
 
-    const int n  = ggml_nrows(src0);
+    const int n = ggml_nrows(src0);
     const int nc = src0->ne[0];
 
     const size_t nb00 = src0->nb[0];
@@ -5748,12 +5230,12 @@ static void ggml_compute_forward_clamp_f16(
     const size_t nb0 = dst->nb[0];
     const size_t nb1 = dst->nb[1];
 
-    GGML_ASSERT( nb0 == sizeof(ggml_fp16_t));
+    GGML_ASSERT(nb0 == sizeof(ggml_fp16_t));
     GGML_ASSERT(nb00 == sizeof(ggml_fp16_t));
 
     for (int j = ith; j < n; j += nth) {
-        ggml_fp16_t * dst_ptr  = (ggml_fp16_t *) ((char *)  dst->data + j*nb1);
-        ggml_fp16_t * src0_ptr = (ggml_fp16_t *) ((char *) src0->data + j*nb01);
+        ggml_fp16_t* dst_ptr = (ggml_fp16_t*)((char*)dst->data + j * nb1);
+        ggml_fp16_t* src0_ptr = (ggml_fp16_t*)((char*)src0->data + j * nb01);
 
         for (int i = 0; i < nc; i++) {
             float v = GGML_CPU_FP16_TO_FP32(src0_ptr[i]);
@@ -5762,57 +5244,51 @@ static void ggml_compute_forward_clamp_f16(
     }
 }
 
-void ggml_compute_forward_clamp(
-        const ggml_compute_params * params,
-        ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
+void ggml_compute_forward_clamp(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
 
     switch (src0->type) {
-        case GGML_TYPE_F32:
-            {
-                ggml_compute_forward_clamp_f32(params, dst);
-            } break;
-        case GGML_TYPE_F16:
-            {
-                ggml_compute_forward_clamp_f16(params, dst);
-            } break;
-        case GGML_TYPE_BF16:
-        case GGML_TYPE_Q1_0:
-        case GGML_TYPE_Q4_0:
-        case GGML_TYPE_Q4_1:
-        case GGML_TYPE_Q5_0:
-        case GGML_TYPE_Q5_1:
-        case GGML_TYPE_Q8_0:
-        case GGML_TYPE_Q8_1:
-        case GGML_TYPE_MXFP4:
-        case GGML_TYPE_NVFP4:
-        case GGML_TYPE_Q2_K:
-        case GGML_TYPE_Q3_K:
-        case GGML_TYPE_Q4_K:
-        case GGML_TYPE_Q5_K:
-        case GGML_TYPE_Q6_K:
-        case GGML_TYPE_TQ1_0:
-        case GGML_TYPE_TQ2_0:
-        case GGML_TYPE_IQ2_XXS:
-        case GGML_TYPE_IQ2_XS:
-        case GGML_TYPE_IQ3_XXS:
-        case GGML_TYPE_IQ1_S:
-        case GGML_TYPE_IQ1_M:
-        case GGML_TYPE_IQ4_NL:
-        case GGML_TYPE_IQ4_XS:
-        case GGML_TYPE_IQ3_S:
-        case GGML_TYPE_IQ2_S:
-        case GGML_TYPE_Q8_K:
-        case GGML_TYPE_I8:
-        case GGML_TYPE_I16:
-        case GGML_TYPE_I32:
-        case GGML_TYPE_I64:
-        case GGML_TYPE_F64:
-        case GGML_TYPE_COUNT:
-            {
-                GGML_ABORT("fatal error");
-            }
+    case GGML_TYPE_F32: {
+        ggml_compute_forward_clamp_f32(params, dst);
+    } break;
+    case GGML_TYPE_F16: {
+        ggml_compute_forward_clamp_f16(params, dst);
+    } break;
+    case GGML_TYPE_BF16:
+    case GGML_TYPE_Q1_0:
+    case GGML_TYPE_Q4_0:
+    case GGML_TYPE_Q4_1:
+    case GGML_TYPE_Q5_0:
+    case GGML_TYPE_Q5_1:
+    case GGML_TYPE_Q8_0:
+    case GGML_TYPE_Q8_1:
+    case GGML_TYPE_MXFP4:
+    case GGML_TYPE_NVFP4:
+    case GGML_TYPE_Q2_K:
+    case GGML_TYPE_Q3_K:
+    case GGML_TYPE_Q4_K:
+    case GGML_TYPE_Q5_K:
+    case GGML_TYPE_Q6_K:
+    case GGML_TYPE_TQ1_0:
+    case GGML_TYPE_TQ2_0:
+    case GGML_TYPE_IQ2_XXS:
+    case GGML_TYPE_IQ2_XS:
+    case GGML_TYPE_IQ3_XXS:
+    case GGML_TYPE_IQ1_S:
+    case GGML_TYPE_IQ1_M:
+    case GGML_TYPE_IQ4_NL:
+    case GGML_TYPE_IQ4_XS:
+    case GGML_TYPE_IQ3_S:
+    case GGML_TYPE_IQ2_S:
+    case GGML_TYPE_Q8_K:
+    case GGML_TYPE_I8:
+    case GGML_TYPE_I16:
+    case GGML_TYPE_I32:
+    case GGML_TYPE_I64:
+    case GGML_TYPE_F64:
+    case GGML_TYPE_COUNT: {
+        GGML_ABORT("fatal error");
+    }
     }
 }
 
@@ -5825,9 +5301,8 @@ static float rope_yarn_ramp(const float low, const float high, const int i0) {
 
 // YaRN algorithm based on LlamaYaRNScaledRotaryEmbedding.py from https://github.com/jquesnelle/yarn
 // MIT licensed. Copyright (c) 2023 Jeffrey Quesnelle and Bowen Peng.
-static void rope_yarn(
-    float theta_extrap, float freq_scale, float corr_dims[2], int64_t i0, float ext_factor, float mscale,
-    float * cos_theta, float * sin_theta) {
+static void rope_yarn(float theta_extrap, float freq_scale, float corr_dims[2], int64_t i0, float ext_factor,
+                      float mscale, float* cos_theta, float* sin_theta) {
     // Get n-d rotational scaling corrected for extrapolation
     float theta_interp = freq_scale * theta_extrap;
     float theta = theta_interp;
@@ -5842,38 +5317,36 @@ static void rope_yarn(
     *sin_theta = sinf(theta) * mscale;
 }
 
-static void ggml_rope_cache_init(
-     float theta_base, float freq_scale, const float * freq_factors, float corr_dims[2], int64_t ne0, float ext_factor, float mscale,
-     float * cache, float sin_sign, float theta_scale) {
+static void ggml_rope_cache_init(float theta_base, float freq_scale, const float* freq_factors, float corr_dims[2],
+                                 int64_t ne0, float ext_factor, float mscale, float* cache, float sin_sign,
+                                 float theta_scale) {
     // ref: https://github.com/jquesnelle/yarn/blob/master/scaled_rope/LlamaYaRNScaledRotaryEmbedding.py
     float theta = theta_base;
     for (int64_t i0 = 0; i0 < ne0; i0 += 2) {
-        const float ff = freq_factors ? freq_factors[i0/2] : 1.0f;
-        rope_yarn(
-            theta/ff, freq_scale, corr_dims, i0, ext_factor, mscale, &cache[i0 + 0], &cache[i0 + 1]
-        );
+        const float ff = freq_factors ? freq_factors[i0 / 2] : 1.0f;
+        rope_yarn(theta / ff, freq_scale, corr_dims, i0, ext_factor, mscale, &cache[i0 + 0], &cache[i0 + 1]);
         cache[i0 + 1] *= sin_sign;
 
         theta *= theta_scale;
     }
 }
 
-static void ggml_mrope_cache_init(
-     float theta_base_t, float theta_base_h, float theta_base_w, float theta_base_e, int sections[4], bool is_imrope, bool indep_sects,
-     float freq_scale, const float * freq_factors, float corr_dims[2], int64_t ne0, float ext_factor, float mscale,
-     float * cache, float sin_sign, float theta_scale) {
+static void ggml_mrope_cache_init(float theta_base_t, float theta_base_h, float theta_base_w, float theta_base_e,
+                                  int sections[4], bool is_imrope, bool indep_sects, float freq_scale,
+                                  const float* freq_factors, float corr_dims[2], int64_t ne0, float ext_factor,
+                                  float mscale, float* cache, float sin_sign, float theta_scale) {
     // ref: https://github.com/jquesnelle/yarn/blob/master/scaled_rope/LlamaYaRNScaledRotaryEmbedding.py
     float theta_t = theta_base_t;
     float theta_h = theta_base_h;
     float theta_w = theta_base_w;
-    float theta_e = theta_base_e;  // extra position id for vision encoder
+    float theta_e = theta_base_e; // extra position id for vision encoder
     int sect_dims = sections[0] + sections[1] + sections[2] + sections[3];
     int sec_w = sections[1] + sections[0];
     int sec_e = sections[2] + sec_w;
     GGML_ASSERT(sect_dims <= ne0);
 
     for (int64_t i0 = 0; i0 < ne0; i0 += 2) {
-        const float ff = freq_factors ? freq_factors[i0/2] : 1.0f;
+        const float ff = freq_factors ? freq_factors[i0 / 2] : 1.0f;
 
         int sector = (i0 / 2) % sect_dims;
         if (indep_sects) {
@@ -5881,14 +5354,12 @@ static void ggml_mrope_cache_init(
             // (i.e. reset corresponding theta when `i0` go from one section to another)
             if (sector == 0) {
                 theta_t = theta_base_t;
-            }
-            else if (sector == sections[0]) {
-                theta_h = theta_base_h;;
-            }
-            else if (sector == sec_w) {
+            } else if (sector == sections[0]) {
+                theta_h = theta_base_h;
+                ;
+            } else if (sector == sec_w) {
                 theta_w = theta_base_w;
-            }
-            else if (sector == sec_e) {
+            } else if (sector == sec_e) {
                 theta_e = theta_base_e;
             }
         }
@@ -5907,18 +5378,14 @@ static void ggml_mrope_cache_init(
         } else {
             if (sector >= sections[0] && sector < sec_w) {
                 theta = theta_h;
-            }
-            else if (sector >= sec_w && sector < sec_w + sections[2]) {
+            } else if (sector >= sec_w && sector < sec_w + sections[2]) {
                 theta = theta_w;
-            }
-            else if (sector >= sec_w + sections[2]) {
+            } else if (sector >= sec_w + sections[2]) {
                 theta = theta_e;
             }
         }
 
-        rope_yarn(
-            theta/ff, freq_scale, corr_dims, i0, ext_factor, mscale, &cache[i0 + 0], &cache[i0 + 1]
-        );
+        rope_yarn(theta / ff, freq_scale, corr_dims, i0, ext_factor, mscale, &cache[i0 + 0], &cache[i0 + 1]);
         cache[i0 + 1] *= sin_sign;
 
         theta_t *= theta_scale;
@@ -5929,34 +5396,32 @@ static void ggml_mrope_cache_init(
 }
 
 
-template<typename T>
-static void rotate_pairs(const int64_t n, const int64_t n_offset, const float * cache, const T * src_data, T * dst_data, const int scale = 2) {
-  for (int64_t i0 = 0; i0 < n; i0 += 2) {
-    const int64_t ic = i0/scale; // hack for GGML_ROPE_TYPE_NORMAL, where we need ic = i0; for all other cases, ic = i0/2
+template <typename T>
+static void rotate_pairs(const int64_t n, const int64_t n_offset, const float* cache, const T* src_data, T* dst_data,
+                         const int scale = 2) {
+    for (int64_t i0 = 0; i0 < n; i0 += 2) {
+        const int64_t ic =
+            i0 / scale; // hack for GGML_ROPE_TYPE_NORMAL, where we need ic = i0; for all other cases, ic = i0/2
 
-    const float cos_theta = cache[i0 + 0];
-    const float sin_theta = cache[i0 + 1];
+        const float cos_theta = cache[i0 + 0];
+        const float sin_theta = cache[i0 + 1];
 
-    const T * const src = src_data + ic;
-    T * dst             = dst_data + ic;
+        const T* const src = src_data + ic;
+        T* dst = dst_data + ic;
 
-    const float x0 = type_conversion_table<T>::to_f32(src[0]);
-    const float x1 = type_conversion_table<T>::to_f32(src[n_offset]);
+        const float x0 = type_conversion_table<T>::to_f32(src[0]);
+        const float x1 = type_conversion_table<T>::to_f32(src[n_offset]);
 
-    dst[0]        = type_conversion_table<T>::from_f32(x0*cos_theta - x1*sin_theta);
-    dst[n_offset] = type_conversion_table<T>::from_f32(x0*sin_theta + x1*cos_theta);
-  }
+        dst[0] = type_conversion_table<T>::from_f32(x0 * cos_theta - x1 * sin_theta);
+        dst[n_offset] = type_conversion_table<T>::from_f32(x0 * sin_theta + x1 * cos_theta);
+    }
 }
 
-template<typename T> //float or ggml_fp16_t
-static void ggml_compute_forward_rope_flt(
-        const ggml_compute_params * params,
-        ggml_tensor * dst,
-        const bool forward) {
-
-    const ggml_tensor * src0 = dst->src[0];
-    const ggml_tensor * src1 = dst->src[1];
-    const ggml_tensor * src2 = dst->src[2];
+template <typename T> //float or ggml_fp16_t
+static void ggml_compute_forward_rope_flt(const ggml_compute_params* params, ggml_tensor* dst, const bool forward) {
+    const ggml_tensor* src0 = dst->src[0];
+    const ggml_tensor* src1 = dst->src[1];
+    const ggml_tensor* src2 = dst->src[2];
 
     GGML_ASSERT(src0->type == GGML_TYPE_F32 || src0->type == GGML_TYPE_F16);
     GGML_ASSERT(src1->type == GGML_TYPE_I32);
@@ -5965,18 +5430,18 @@ static void ggml_compute_forward_rope_flt(
     int sections[4];
 
     //const int n_past     = ((int32_t *) dst->op_params)[0];
-    const int n_dims     = ((int32_t *) dst->op_params)[1];
-    const int mode       = ((int32_t *) dst->op_params)[2];
+    const int n_dims = ((int32_t*)dst->op_params)[1];
+    const int mode = ((int32_t*)dst->op_params)[2];
     //const int n_ctx      = ((int32_t *) dst->op_params)[3];
-    const int n_ctx_orig = ((int32_t *) dst->op_params)[4];
+    const int n_ctx_orig = ((int32_t*)dst->op_params)[4];
 
-    memcpy(&freq_base,   (int32_t *) dst->op_params +  5, sizeof(float));
-    memcpy(&freq_scale,  (int32_t *) dst->op_params +  6, sizeof(float));
-    memcpy(&ext_factor,  (int32_t *) dst->op_params +  7, sizeof(float));
-    memcpy(&attn_factor, (int32_t *) dst->op_params +  8, sizeof(float));
-    memcpy(&beta_fast,   (int32_t *) dst->op_params +  9, sizeof(float));
-    memcpy(&beta_slow,   (int32_t *) dst->op_params + 10, sizeof(float));
-    memcpy(&sections,    (int32_t *) dst->op_params + 11, sizeof(int)*4);
+    memcpy(&freq_base, (int32_t*)dst->op_params + 5, sizeof(float));
+    memcpy(&freq_scale, (int32_t*)dst->op_params + 6, sizeof(float));
+    memcpy(&ext_factor, (int32_t*)dst->op_params + 7, sizeof(float));
+    memcpy(&attn_factor, (int32_t*)dst->op_params + 8, sizeof(float));
+    memcpy(&beta_fast, (int32_t*)dst->op_params + 9, sizeof(float));
+    memcpy(&beta_slow, (int32_t*)dst->op_params + 10, sizeof(float));
+    memcpy(&sections, (int32_t*)dst->op_params + 11, sizeof(int) * 4);
 
     GGML_TENSOR_UNARY_OP_LOCALS
 
@@ -5995,22 +5460,23 @@ static void ggml_compute_forward_rope_flt(
     GGML_ASSERT(n_dims % 2 == 0);
 
     // rows per thread
-    const int dr = (nr + nth - 1)/nth;
+    const int dr = (nr + nth - 1) / nth;
 
     // row range for this thread
-    const int ir0 = dr*ith;
+    const int ir0 = dr * ith;
     const int ir1 = MIN(ir0 + dr, nr);
 
     // row index used to determine which thread to use
     int ir = 0;
 
-    const float theta_scale = powf(freq_base, -2.0f/n_dims);
+    const float theta_scale = powf(freq_base, -2.0f / n_dims);
 
     float corr_dims[2];
     ggml_rope_yarn_corr_dims(n_dims, n_ctx_orig, freq_base, beta_fast, beta_slow, corr_dims);
 
     const bool is_imrope = mode == GGML_ROPE_TYPE_IMROPE; // qwen3vl apply interleaved mrope
-    const bool mrope_used = mode & GGML_ROPE_TYPE_MROPE;  // ggml_rope_multi, note: also true for vision (24 & 8 == true) and for imrope
+    const bool mrope_used =
+        mode & GGML_ROPE_TYPE_MROPE; // ggml_rope_multi, note: also true for vision (24 & 8 == true) and for imrope
     const bool is_vision = mode == GGML_ROPE_TYPE_VISION;
 
     if (mrope_used) {
@@ -6018,14 +5484,14 @@ static void ggml_compute_forward_rope_flt(
     }
 
     if (is_vision) {
-        GGML_ASSERT(n_dims == ne0/2);
+        GGML_ASSERT(n_dims == ne0 / 2);
     }
 
-    const float * freq_factors = NULL;
+    const float* freq_factors = NULL;
     if (src2 != NULL) {
         GGML_ASSERT(src2->type == GGML_TYPE_F32);
         GGML_ASSERT(src2->ne[0] >= n_dims / 2);
-        freq_factors = (const float *) src2->data;
+        freq_factors = (const float*)src2->data;
     }
 
     // backward process uses inverse rotation by cos and sin.
@@ -6033,59 +5499,61 @@ static void ggml_compute_forward_rope_flt(
     // this essentially just switches the sign of sin.
     const float sin_sign = forward ? 1.0f : -1.0f;
 
-    const int32_t * pos = (const int32_t *) src1->data;
+    const int32_t* pos = (const int32_t*)src1->data;
 
     int64_t last_i2 = -1;
 
-    for (int64_t i3 = 0; i3 < ne3; i3++) { // batch
-        for (int64_t i2 = 0; i2 < ne2; i2++) { // seq-len
+    for (int64_t i3 = 0; i3 < ne3; i3++) {         // batch
+        for (int64_t i2 = 0; i2 < ne2; i2++) {     // seq-len
             for (int64_t i1 = 0; i1 < ne1; i1++) { // attn-heads
-                if (ir++ < ir0) continue; // skip rows mapped to other threads
-                if (ir   > ir1) break;
+                if (ir++ < ir0)
+                    continue; // skip rows mapped to other threads
+                if (ir > ir1)
+                    break;
 
-                float * cache = (float *) params->wdata + (ne0 + CACHE_LINE_SIZE_F32)*ith;
+                float* cache = (float*)params->wdata + (ne0 + CACHE_LINE_SIZE_F32) * ith;
                 if (last_i2 != i2) {
                     if (!mrope_used) {
                         const int64_t p = pos[i2];
-                        ggml_rope_cache_init(p, freq_scale, freq_factors, corr_dims, ne0, ext_factor, attn_factor, cache, sin_sign, theta_scale);
-                    }
-                    else {
+                        ggml_rope_cache_init(p, freq_scale, freq_factors, corr_dims, ne0, ext_factor, attn_factor,
+                                             cache, sin_sign, theta_scale);
+                    } else {
                         const int64_t p_t = pos[i2];
                         const int64_t p_h = pos[i2 + ne2];
                         const int64_t p_w = pos[i2 + ne2 * 2];
                         const int64_t p_e = pos[i2 + ne2 * 3];
-                        ggml_mrope_cache_init(
-                            p_t, p_h, p_w, p_e, sections, is_imrope, is_vision,
-                            freq_scale, freq_factors, corr_dims, ne0, ext_factor, attn_factor, cache, sin_sign, theta_scale);
+                        ggml_mrope_cache_init(p_t, p_h, p_w, p_e, sections, is_imrope, is_vision, freq_scale,
+                                              freq_factors, corr_dims, ne0, ext_factor, attn_factor, cache, sin_sign,
+                                              theta_scale);
                     }
 
                     last_i2 = i2;
                 }
 
-                T * src = (T *)((char *) src0->data + i3*nb03 + i2*nb02 + i1*nb01);
-                T * dst_data  = (T *)((char *)  dst->data + i3*nb3  + i2*nb2  + i1*nb1);
+                T* src = (T*)((char*)src0->data + i3 * nb03 + i2 * nb02 + i1 * nb01);
+                T* dst_data = (T*)((char*)dst->data + i3 * nb3 + i2 * nb2 + i1 * nb1);
 
                 switch (mode) {
-                    case GGML_ROPE_TYPE_NORMAL:
-                        rotate_pairs<T>(n_dims, 1, cache, src, dst_data, 1);
-                        break;
-                    case GGML_ROPE_TYPE_NEOX:
-                    case GGML_ROPE_TYPE_MROPE:
-                    case GGML_ROPE_TYPE_IMROPE:
-                        rotate_pairs<T>(n_dims, n_dims/2, cache, src, dst_data);
-                        break;
-                    case GGML_ROPE_TYPE_VISION:
-                        rotate_pairs<T>(ne0, n_dims, cache, src, dst_data);
-                        break;
-                    default:
-                        GGML_ABORT("rope type not supported");
+                case GGML_ROPE_TYPE_NORMAL:
+                    rotate_pairs<T>(n_dims, 1, cache, src, dst_data, 1);
+                    break;
+                case GGML_ROPE_TYPE_NEOX:
+                case GGML_ROPE_TYPE_MROPE:
+                case GGML_ROPE_TYPE_IMROPE:
+                    rotate_pairs<T>(n_dims, n_dims / 2, cache, src, dst_data);
+                    break;
+                case GGML_ROPE_TYPE_VISION:
+                    rotate_pairs<T>(ne0, n_dims, cache, src, dst_data);
+                    break;
+                default:
+                    GGML_ABORT("rope type not supported");
                 }
 
                 if (!is_vision) {
                     // fill the remain channels with data from src tensor
                     for (int64_t i0 = n_dims; i0 < ne0; i0 += 2) {
-                        const T * const src = (T *)((char *) src0->data + i3*nb03 + i2*nb02 + i1*nb01 + i0*nb00);
-                        T * dst_data  = (T *)((char *)  dst->data + i3*nb3  + i2*nb2  + i1*nb1  + i0*nb0);
+                        const T* const src = (T*)((char*)src0->data + i3 * nb03 + i2 * nb02 + i1 * nb01 + i0 * nb00);
+                        T* dst_data = (T*)((char*)dst->data + i3 * nb3 + i2 * nb2 + i1 * nb1 + i0 * nb0);
 
                         dst_data[0] = src[0];
                         dst_data[1] = src[1];
@@ -6096,71 +5564,56 @@ static void ggml_compute_forward_rope_flt(
     }
 }
 
-void ggml_compute_forward_rope(
-        const ggml_compute_params * params,
-        ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
+void ggml_compute_forward_rope(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
 
     switch (src0->type) {
-        case GGML_TYPE_F16:
-            {
-                ggml_compute_forward_rope_flt<ggml_fp16_t>(params, dst, true);
-            } break;
-        case GGML_TYPE_F32:
-            {
-                ggml_compute_forward_rope_flt<float>(params, dst, true);
-            } break;
-        default:
-            {
-                GGML_ABORT("fatal error");
-            }
+    case GGML_TYPE_F16: {
+        ggml_compute_forward_rope_flt<ggml_fp16_t>(params, dst, true);
+    } break;
+    case GGML_TYPE_F32: {
+        ggml_compute_forward_rope_flt<float>(params, dst, true);
+    } break;
+    default: {
+        GGML_ABORT("fatal error");
+    }
     }
 }
 
 // ggml_compute_forward_rope_back
 
-void ggml_compute_forward_rope_back(
-        const ggml_compute_params * params,
-        ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
+void ggml_compute_forward_rope_back(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
 
     switch (src0->type) {
-        case GGML_TYPE_F16:
-            {
-                ggml_compute_forward_rope_flt<ggml_fp16_t>(params, dst, false);
-            } break;
-        case GGML_TYPE_F32:
-            {
-                ggml_compute_forward_rope_flt<float>(params, dst, false);
-            } break;
-        default:
-            {
-                GGML_ABORT("fatal error");
-            }
+    case GGML_TYPE_F16: {
+        ggml_compute_forward_rope_flt<ggml_fp16_t>(params, dst, false);
+    } break;
+    case GGML_TYPE_F32: {
+        ggml_compute_forward_rope_flt<float>(params, dst, false);
+    } break;
+    default: {
+        GGML_ABORT("fatal error");
+    }
     }
 }
 
 // ggml_compute_forward_conv_transpose_1d
 
-static void ggml_compute_forward_conv_transpose_1d_f16_f32(
-        const ggml_compute_params * params,
-              ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
-    const ggml_tensor * src1 = dst->src[1];
+static void ggml_compute_forward_conv_transpose_1d_f16_f32(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
+    const ggml_tensor* src1 = dst->src[1];
 
     GGML_ASSERT(src0->type == GGML_TYPE_F16);
     GGML_ASSERT(src1->type == GGML_TYPE_F32);
-    GGML_ASSERT( dst->type == GGML_TYPE_F32);
+    GGML_ASSERT(dst->type == GGML_TYPE_F32);
 
     GGML_TENSOR_BINARY_OP_LOCALS
 
     const int ith = params->ith;
     const int nth = params->nth;
 
-    const int nk = ne00*ne01*ne02;
+    const int nk = ne00 * ne01 * ne02;
 
     GGML_ASSERT(nb00 == sizeof(ggml_fp16_t));
     GGML_ASSERT(nb10 == sizeof(float));
@@ -6170,14 +5623,14 @@ static void ggml_compute_forward_conv_transpose_1d_f16_f32(
 
         // permute kernel data (src0) from (K x Cout x Cin) to (Cin x K x Cout)
         {
-            ggml_fp16_t * const wdata = (ggml_fp16_t *) params->wdata + 0;
+            ggml_fp16_t* const wdata = (ggml_fp16_t*)params->wdata + 0;
 
             for (int64_t i02 = 0; i02 < ne02; i02++) {
                 for (int64_t i01 = 0; i01 < ne01; i01++) {
-                    const ggml_fp16_t * const src = (ggml_fp16_t *)((char *) src0->data + i02*nb02 + i01*nb01);
-                    ggml_fp16_t * dst_data = wdata + i01*ne00*ne02;
+                    const ggml_fp16_t* const src = (ggml_fp16_t*)((char*)src0->data + i02 * nb02 + i01 * nb01);
+                    ggml_fp16_t* dst_data = wdata + i01 * ne00 * ne02;
                     for (int64_t i00 = 0; i00 < ne00; i00++) {
-                        dst_data[i00*ne02 + i02] = src[i00];
+                        dst_data[i00 * ne02 + i02] = src[i00];
                     }
                 }
             }
@@ -6185,13 +5638,13 @@ static void ggml_compute_forward_conv_transpose_1d_f16_f32(
 
         // permute source data (src1) from (L x Cin) to (Cin x L)
         {
-            ggml_fp16_t * const wdata = (ggml_fp16_t *) params->wdata + nk;
-            ggml_fp16_t * dst_data = wdata;
+            ggml_fp16_t* const wdata = (ggml_fp16_t*)params->wdata + nk;
+            ggml_fp16_t* dst_data = wdata;
 
             for (int64_t i11 = 0; i11 < ne11; i11++) {
-                const float * const src = (float *)((char *) src1->data + i11*nb11);
+                const float* const src = (float*)((char*)src1->data + i11 * nb11);
                 for (int64_t i10 = 0; i10 < ne10; i10++) {
-                    dst_data[i10*ne11 + i11] = GGML_CPU_FP32_TO_FP16(src[i10]);
+                    dst_data[i10 * ne11 + i11] = GGML_CPU_FP32_TO_FP16(src[i10]);
                 }
             }
         }
@@ -6207,48 +5660,44 @@ static void ggml_compute_forward_conv_transpose_1d_f16_f32(
     const int nr = ne1;
 
     // rows per thread
-    const int dr = (nr + nth - 1)/nth;
+    const int dr = (nr + nth - 1) / nth;
 
     // row range for this thread
-    const int ir0 = dr*ith;
+    const int ir0 = dr * ith;
     const int ir1 = MIN(ir0 + dr, nr);
 
-    ggml_fp16_t * const wdata     = (ggml_fp16_t *) params->wdata + 0;
-    ggml_fp16_t * const wdata_src = wdata + nk;
+    ggml_fp16_t* const wdata = (ggml_fp16_t*)params->wdata + 0;
+    ggml_fp16_t* const wdata_src = wdata + nk;
 
     for (int i1 = ir0; i1 < ir1; i1++) {
-        float * dst_data = (float *)((char *) dst->data + i1*nb1);
-        ggml_fp16_t * wdata_kernel = wdata + i1*ne02*ne00;
+        float* dst_data = (float*)((char*)dst->data + i1 * nb1);
+        ggml_fp16_t* wdata_kernel = wdata + i1 * ne02 * ne00;
         for (int i10 = 0; i10 < ne10; i10++) {
-            const int i1n = i10*ne11;
+            const int i1n = i10 * ne11;
             for (int i00 = 0; i00 < ne00; i00++) {
                 float v = 0;
-                ggml_vec_dot_f16(ne02, &v, 0,
-                        (ggml_fp16_t *)    wdata_src + i1n, 0,
-                        (ggml_fp16_t *) wdata_kernel + i00*ne02, 0, 1);
-                dst_data[i10*s0 + i00] += v;
+                ggml_vec_dot_f16(ne02, &v, 0, (ggml_fp16_t*)wdata_src + i1n, 0, (ggml_fp16_t*)wdata_kernel + i00 * ne02,
+                                 0, 1);
+                dst_data[i10 * s0 + i00] += v;
             }
         }
     }
 }
 
-static void ggml_compute_forward_conv_transpose_1d_f32(
-        const ggml_compute_params * params,
-              ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
-    const ggml_tensor * src1 = dst->src[1];
+static void ggml_compute_forward_conv_transpose_1d_f32(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
+    const ggml_tensor* src1 = dst->src[1];
 
     GGML_ASSERT(src0->type == GGML_TYPE_F32);
     GGML_ASSERT(src1->type == GGML_TYPE_F32);
-    GGML_ASSERT( dst->type == GGML_TYPE_F32);
+    GGML_ASSERT(dst->type == GGML_TYPE_F32);
 
     GGML_TENSOR_BINARY_OP_LOCALS
 
     const int ith = params->ith;
     const int nth = params->nth;
 
-    const int nk = ne00*ne01*ne02;
+    const int nk = ne00 * ne01 * ne02;
 
     GGML_ASSERT(nb00 == sizeof(float));
     GGML_ASSERT(nb10 == sizeof(float));
@@ -6258,14 +5707,14 @@ static void ggml_compute_forward_conv_transpose_1d_f32(
 
         // prepare kernel data (src0) from (K x Cout x Cin) to (Cin x K x Cout)
         {
-            float * const wdata = (float *) params->wdata + 0;
+            float* const wdata = (float*)params->wdata + 0;
 
             for (int64_t i02 = 0; i02 < ne02; i02++) {
                 for (int64_t i01 = 0; i01 < ne01; i01++) {
-                    const float * const src = (float *)((char *) src0->data + i02*nb02 + i01*nb01);
-                    float * dst_data = wdata + i01*ne00*ne02;
+                    const float* const src = (float*)((char*)src0->data + i02 * nb02 + i01 * nb01);
+                    float* dst_data = wdata + i01 * ne00 * ne02;
                     for (int64_t i00 = 0; i00 < ne00; i00++) {
-                        dst_data[i00*ne02 + i02] = src[i00];
+                        dst_data[i00 * ne02 + i02] = src[i00];
                     }
                 }
             }
@@ -6273,13 +5722,13 @@ static void ggml_compute_forward_conv_transpose_1d_f32(
 
         // prepare source data (src1)
         {
-            float * const wdata = (float *) params->wdata + nk;
-            float * dst_data = wdata;
+            float* const wdata = (float*)params->wdata + nk;
+            float* dst_data = wdata;
 
             for (int64_t i11 = 0; i11 < ne11; i11++) {
-                const float * const src = (float *)((char *) src1->data + i11*nb11);
+                const float* const src = (float*)((char*)src1->data + i11 * nb11);
                 for (int64_t i10 = 0; i10 < ne10; i10++) {
-                    dst_data[i10*ne11 + i11] = src[i10];
+                    dst_data[i10 * ne11 + i11] = src[i10];
                 }
             }
         }
@@ -6295,50 +5744,42 @@ static void ggml_compute_forward_conv_transpose_1d_f32(
     const int nr = ne1;
 
     // rows per thread
-    const int dr = (nr + nth - 1)/nth;
+    const int dr = (nr + nth - 1) / nth;
 
     // row range for this thread
-    const int ir0 = dr*ith;
+    const int ir0 = dr * ith;
     const int ir1 = MIN(ir0 + dr, nr);
 
-    float * const wdata     = (float *) params->wdata + 0;
-    float * const wdata_src = wdata + nk;
+    float* const wdata = (float*)params->wdata + 0;
+    float* const wdata_src = wdata + nk;
 
     for (int i1 = ir0; i1 < ir1; i1++) {
-        float * dst_data = (float *)((char *) dst->data + i1*nb1);
-        float * wdata_kernel = wdata + i1*ne02*ne00;
+        float* dst_data = (float*)((char*)dst->data + i1 * nb1);
+        float* wdata_kernel = wdata + i1 * ne02 * ne00;
         for (int i10 = 0; i10 < ne10; i10++) {
-            const int i1n = i10*ne11;
+            const int i1n = i10 * ne11;
             for (int i00 = 0; i00 < ne00; i00++) {
                 float v = 0;
-                ggml_vec_dot_f32(ne02, &v, 0,
-                        wdata_src + i1n, 0,
-                        wdata_kernel + i00*ne02, 0, 1);
-                dst_data[i10*s0 + i00] += v;
+                ggml_vec_dot_f32(ne02, &v, 0, wdata_src + i1n, 0, wdata_kernel + i00 * ne02, 0, 1);
+                dst_data[i10 * s0 + i00] += v;
             }
         }
     }
 }
 
-void ggml_compute_forward_conv_transpose_1d(
-        const ggml_compute_params * params,
-              ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
+void ggml_compute_forward_conv_transpose_1d(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
 
     switch (src0->type) {
-        case GGML_TYPE_F16:
-            {
-                ggml_compute_forward_conv_transpose_1d_f16_f32(params, dst);
-            } break;
-        case GGML_TYPE_F32:
-            {
-                ggml_compute_forward_conv_transpose_1d_f32(params, dst);
-            } break;
-        default:
-            {
-                GGML_ABORT("fatal error");
-            }
+    case GGML_TYPE_F16: {
+        ggml_compute_forward_conv_transpose_1d_f16_f32(params, dst);
+    } break;
+    case GGML_TYPE_F32: {
+        ggml_compute_forward_conv_transpose_1d_f32(params, dst);
+    } break;
+    default: {
+        GGML_ABORT("fatal error");
+    }
     }
 }
 
@@ -6348,46 +5789,46 @@ void ggml_compute_forward_conv_transpose_1d(
 // contributing input columns and sums the pre-computed (oc, k) entries.
 // Matches the CUDA kernel in col2im-1d.cu bit-for-bit so GPU/CPU results
 // are interchangeable.
-static void ggml_compute_forward_col2im_1d_f32(
-        const ggml_compute_params * params,
-              ggml_tensor * dst) {
-
-    const ggml_tensor * col = dst->src[0];
+static void ggml_compute_forward_col2im_1d_f32(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* col = dst->src[0];
 
     GGML_ASSERT(col->type == GGML_TYPE_F32);
     GGML_ASSERT(dst->type == GGML_TYPE_F32);
 
-    const int32_t s0 = ((const int32_t *)(dst->op_params))[0];
-    const int32_t OC = ((const int32_t *)(dst->op_params))[1];
-    const int32_t p0 = ((const int32_t *)(dst->op_params))[2];
+    const int32_t s0 = ((const int32_t*)(dst->op_params))[0];
+    const int32_t OC = ((const int32_t*)(dst->op_params))[1];
+    const int32_t p0 = ((const int32_t*)(dst->op_params))[2];
 
     const int K_OC = (int)col->ne[0];
     const int T_in = (int)col->ne[1];
-    const int K    = K_OC / OC;
+    const int K = K_OC / OC;
     const int T_out = (int)dst->ne[0];
 
     const int ith = params->ith;
     const int nth = params->nth;
 
-    const int total  = T_out * OC;
-    const int dr     = (total + nth - 1) / nth;
-    const int ir0    = dr * ith;
-    const int ir1    = ir0 + dr < total ? ir0 + dr : total;
+    const int total = T_out * OC;
+    const int dr = (total + nth - 1) / nth;
+    const int ir0 = dr * ith;
+    const int ir1 = ir0 + dr < total ? ir0 + dr : total;
 
-    if (ir0 >= ir1) return;
+    if (ir0 >= ir1)
+        return;
 
-    const float * GGML_RESTRICT cp = (const float *)col->data;
-    float       * GGML_RESTRICT dp = (float *)      dst->data;
+    const float* GGML_RESTRICT cp = (const float*)col->data;
+    float* GGML_RESTRICT dp = (float*)dst->data;
 
     for (int gidx = ir0; gidx < ir1; gidx++) {
         const int t_out = gidx % T_out;
-        const int oc    = gidx / T_out;
+        const int oc = gidx / T_out;
         const int t_abs = t_out + p0;
 
         int t_in_min = (t_abs - K + s0) / s0;
-        if (t_in_min < 0) t_in_min = 0;
+        if (t_in_min < 0)
+            t_in_min = 0;
         int t_in_max = t_abs / s0;
-        if (t_in_max >= T_in) t_in_max = T_in - 1;
+        if (t_in_max >= T_in)
+            t_in_max = T_in - 1;
 
         float sum = 0.0f;
         for (int t_in = t_in_min; t_in <= t_in_max; t_in++) {
@@ -6398,18 +5839,15 @@ static void ggml_compute_forward_col2im_1d_f32(
     }
 }
 
-void ggml_compute_forward_col2im_1d(
-        const ggml_compute_params * params,
-              ggml_tensor * dst) {
-
-    const ggml_tensor * col = dst->src[0];
+void ggml_compute_forward_col2im_1d(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* col = dst->src[0];
 
     switch (col->type) {
-        case GGML_TYPE_F32:
-            ggml_compute_forward_col2im_1d_f32(params, dst);
-            break;
-        default:
-            GGML_ABORT("col2im_1d: unsupported type");
+    case GGML_TYPE_F32:
+        ggml_compute_forward_col2im_1d_f32(params, dst);
+        break;
+    default:
+        GGML_ABORT("col2im_1d: unsupported type");
     }
 }
 
@@ -6421,54 +5859,51 @@ void ggml_compute_forward_col2im_1d(
 // Bit-equivalent to the existing custom-op path so it can serve as a CPU
 // oracle for the Metal kernel.
 // MUST RE-APPLY after every ggml bump.
-void ggml_compute_forward_aa_snake_beta(
-        const ggml_compute_params * params,
-              ggml_tensor * dst) {
+void ggml_compute_forward_aa_snake_beta(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src_x = dst->src[0];   // x         [T, C]
+    const ggml_tensor* src_la = dst->src[1];  // log_alpha [C]
+    const ggml_tensor* src_lb = dst->src[2];  // log_beta  [C]
+    const ggml_tensor* src_usf = dst->src[3]; // us_filter [K, 1, 1]
+    const ggml_tensor* src_dsf = dst->src[4]; // ds_filter [K, 1, 1]
 
-    const ggml_tensor * src_x   = dst->src[0]; // x         [T, C]
-    const ggml_tensor * src_la  = dst->src[1]; // log_alpha [C]
-    const ggml_tensor * src_lb  = dst->src[2]; // log_beta  [C]
-    const ggml_tensor * src_usf = dst->src[3]; // us_filter [K, 1, 1]
-    const ggml_tensor * src_dsf = dst->src[4]; // ds_filter [K, 1, 1]
-
-    GGML_ASSERT(src_x->type   == GGML_TYPE_F32);
-    GGML_ASSERT(src_la->type  == GGML_TYPE_F32);
-    GGML_ASSERT(src_lb->type  == GGML_TYPE_F32);
+    GGML_ASSERT(src_x->type == GGML_TYPE_F32);
+    GGML_ASSERT(src_la->type == GGML_TYPE_F32);
+    GGML_ASSERT(src_lb->type == GGML_TYPE_F32);
     GGML_ASSERT(src_usf->type == GGML_TYPE_F32);
     GGML_ASSERT(src_dsf->type == GGML_TYPE_F32);
-    GGML_ASSERT(dst->type     == GGML_TYPE_F32);
+    GGML_ASSERT(dst->type == GGML_TYPE_F32);
     GGML_ASSERT(ggml_is_contiguous(src_x));
     GGML_ASSERT(ggml_is_contiguous(dst));
     GGML_ASSERT(ggml_are_same_shape(src_x, dst));
 
-    const int T = (int) src_x->ne[0];
-    const int C = (int) src_x->ne[1];
-    const int K = (int) src_usf->ne[0];
+    const int T = (int)src_x->ne[0];
+    const int C = (int)src_x->ne[1];
+    const int K = (int)src_usf->ne[0];
     GGML_ASSERT(K == 12 && "aa_snake_beta currently requires K=12 taps");
-    GGML_ASSERT((int) src_la->ne[0] == C);
-    GGML_ASSERT((int) src_lb->ne[0] == C);
-    GGML_ASSERT((int) src_dsf->ne[0] == K);
+    GGML_ASSERT((int)src_la->ne[0] == C);
+    GGML_ASSERT((int)src_lb->ne[0] == C);
+    GGML_ASSERT((int)src_dsf->ne[0] == K);
 
     // Pad layout mirrors `aa_snake_params` in src/indextts_voc.cpp.
-    const int up_pad        = K / 2 - 1;                  // 5
-    const int up_pad_left   = up_pad * 2 + (K - 2) / 2;   // 15
-    const int up_pad_right  = up_pad * 2 + (K - 2 + 1)/2; // 15
-    const int ds_pad_left   = K / 2 - 1;                  // 5
-    const int ds_pad_right  = K / 2;                      // 6
+    const int up_pad = K / 2 - 1;                          // 5
+    const int up_pad_left = up_pad * 2 + (K - 2) / 2;      // 15
+    const int up_pad_right = up_pad * 2 + (K - 2 + 1) / 2; // 15
+    const int ds_pad_left = K / 2 - 1;                     // 5
+    const int ds_pad_right = K / 2;                        // 6
 
-    const int T_padded   = T + 2 * up_pad;
-    const int T_up       = (T_padded - 1) * 2 + K;
-    const int T_cropped  = T_up - up_pad_left - up_pad_right;
-    const int T_ds_pad   = T_cropped + ds_pad_left + ds_pad_right;
-    const int T_out_ds   = (T_ds_pad - K) / 2 + 1;
-    const int T_final    = T_out_ds < T ? T_out_ds : T;
+    const int T_padded = T + 2 * up_pad;
+    const int T_up = (T_padded - 1) * 2 + K;
+    const int T_cropped = T_up - up_pad_left - up_pad_right;
+    const int T_ds_pad = T_cropped + ds_pad_left + ds_pad_right;
+    const int T_out_ds = (T_ds_pad - K) / 2 + 1;
+    const int T_final = T_out_ds < T ? T_out_ds : T;
 
-    const float * x_in     = (const float *) src_x->data;
-    float       * x_out    = (float *)       dst->data;
-    const float * log_a    = (const float *) src_la->data;
-    const float * log_b    = (const float *) src_lb->data;
-    const float * us_f_raw = (const float *) src_usf->data;
-    const float * ds_f     = (const float *) src_dsf->data;
+    const float* x_in = (const float*)src_x->data;
+    float* x_out = (float*)dst->data;
+    const float* log_a = (const float*)src_la->data;
+    const float* log_b = (const float*)src_lb->data;
+    const float* us_f_raw = (const float*)src_usf->data;
+    const float* ds_f = (const float*)src_dsf->data;
 
     // Pre-bake the ×2 zero-stuff gain into the upsample filter once per call
     // into a small stack buffer (12 floats).
@@ -6484,16 +5919,20 @@ void ggml_compute_forward_aa_snake_beta(
     thread_local std::vector<float> tl_upsampled;
     thread_local std::vector<float> tl_ds_padded;
     thread_local std::vector<float> tl_snake;
-    if ((int) tl_padded.size()    < T_padded)  tl_padded.resize(T_padded);
-    if ((int) tl_upsampled.size() < T_up)      tl_upsampled.resize(T_up);
-    if ((int) tl_ds_padded.size() < T_ds_pad)  tl_ds_padded.resize(T_ds_pad);
-    if ((int) tl_snake.size()     < T_cropped) tl_snake.resize(T_cropped);
+    if ((int)tl_padded.size() < T_padded)
+        tl_padded.resize(T_padded);
+    if ((int)tl_upsampled.size() < T_up)
+        tl_upsampled.resize(T_up);
+    if ((int)tl_ds_padded.size() < T_ds_pad)
+        tl_ds_padded.resize(T_ds_pad);
+    if ((int)tl_snake.size() < T_cropped)
+        tl_snake.resize(T_cropped);
 
-    float * padded     = tl_padded.data();
-    float * upsampled  = tl_upsampled.data();
-    float * ds_padded  = tl_ds_padded.data();
+    float* padded = tl_padded.data();
+    float* upsampled = tl_upsampled.data();
+    float* ds_padded = tl_ds_padded.data();
 #ifdef GGML_USE_ACCELERATE
-    float * snake_tmp  = tl_snake.data();
+    float* snake_tmp = tl_snake.data();
 #endif
 
     // Channel-split parallelism — matches the worker layout of the legacy
@@ -6501,42 +5940,44 @@ void ggml_compute_forward_aa_snake_beta(
     const int ith = params->ith;
     const int nth = params->nth;
     const int c_start = (C * ith) / nth;
-    const int c_end   = (C * (ith + 1)) / nth;
+    const int c_end = (C * (ith + 1)) / nth;
 
     for (int c = c_start; c < c_end; c++) {
-        const float alpha_c  = expf(log_a[c]);
-        const float beta_c   = expf(log_b[c]);
+        const float alpha_c = expf(log_a[c]);
+        const float beta_c = expf(log_b[c]);
         const float inv_beta = 1.0f / beta_c;
 
-        const float * x_in_c  = x_in  + (size_t) c * T;
-        float       * x_out_c = x_out + (size_t) c * T;
+        const float* x_in_c = x_in + (size_t)c * T;
+        float* x_out_c = x_out + (size_t)c * T;
 
         // ── 1. Edge-replicate padding for upsample.
-        const float left_edge  = x_in_c[0];
+        const float left_edge = x_in_c[0];
         const float right_edge = x_in_c[T - 1];
-        for (int t = 0; t < up_pad; t++) padded[t] = left_edge;
-        std::memcpy(padded + up_pad, x_in_c, (size_t) T * sizeof(float));
-        for (int t = 0; t < up_pad; t++) padded[up_pad + T + t] = right_edge;
+        for (int t = 0; t < up_pad; t++)
+            padded[t] = left_edge;
+        std::memcpy(padded + up_pad, x_in_c, (size_t)T * sizeof(float));
+        for (int t = 0; t < up_pad; t++)
+            padded[up_pad + T + t] = right_edge;
 
         // ── 2. Zero-stuff upsample 2× + FIR (×2 gain baked in).
-        std::memset(upsampled, 0, (size_t) T_up * sizeof(float));
+        std::memset(upsampled, 0, (size_t)T_up * sizeof(float));
         for (int t = 0; t < T_padded; t++) {
             const float v = padded[t];
-            float * dst_row = upsampled + t * 2;
+            float* dst_row = upsampled + t * 2;
             for (int k = 0; k < K; k++) {
                 dst_row[k] += v * us_f_x2[k];
             }
         }
 
         // ── 3. SnakeBeta in place on the cropped upsample window.
-        float * cropped = upsampled + up_pad_left;
+        float* cropped = upsampled + up_pad_left;
 #ifdef GGML_USE_ACCELERATE
         {
             int n = T_cropped;
-            vDSP_vsmul(cropped, 1, &alpha_c, snake_tmp, 1, (vDSP_Length) n);
+            vDSP_vsmul(cropped, 1, &alpha_c, snake_tmp, 1, (vDSP_Length)n);
             vvsinf(snake_tmp, snake_tmp, &n); // sin in place; aliasing-safe
-            vDSP_vsq(snake_tmp, 1, snake_tmp, 1, (vDSP_Length) n);
-            vDSP_vsma(snake_tmp, 1, &inv_beta, cropped, 1, cropped, 1, (vDSP_Length) n);
+            vDSP_vsq(snake_tmp, 1, snake_tmp, 1, (vDSP_Length)n);
+            vDSP_vsma(snake_tmp, 1, &inv_beta, cropped, 1, cropped, 1, (vDSP_Length)n);
         }
 #else
         for (int t = 0; t < T_cropped; t++) {
@@ -6547,24 +5988,28 @@ void ggml_compute_forward_aa_snake_beta(
 #endif
 
         // ── 4. Edge-replicate padding for downsample.
-        const float c_left  = cropped[0];
+        const float c_left = cropped[0];
         const float c_right = cropped[T_cropped - 1];
-        for (int t = 0; t < ds_pad_left; t++) ds_padded[t] = c_left;
-        std::memcpy(ds_padded + ds_pad_left, cropped, (size_t) T_cropped * sizeof(float));
-        for (int t = 0; t < ds_pad_right; t++) ds_padded[ds_pad_left + T_cropped + t] = c_right;
+        for (int t = 0; t < ds_pad_left; t++)
+            ds_padded[t] = c_left;
+        std::memcpy(ds_padded + ds_pad_left, cropped, (size_t)T_cropped * sizeof(float));
+        for (int t = 0; t < ds_pad_right; t++)
+            ds_padded[ds_pad_left + T_cropped + t] = c_right;
 
-        // ── 5. Stride-2 downsample FIR.
+            // ── 5. Stride-2 downsample FIR.
 #ifdef GGML_USE_ACCELERATE
-        vDSP_desamp(ds_padded, /*decimation*/ 2, ds_f, x_out_c, (vDSP_Length) T_final, (vDSP_Length) K);
+        vDSP_desamp(ds_padded, /*decimation*/ 2, ds_f, x_out_c, (vDSP_Length)T_final, (vDSP_Length)K);
 #else
         for (int t = 0; t < T_final; t++) {
-            const float * row = ds_padded + t * 2;
+            const float* row = ds_padded + t * 2;
             float sum = 0.0f;
-            for (int k = 0; k < K; k++) sum += row[k] * ds_f[k];
+            for (int k = 0; k < K; k++)
+                sum += row[k] * ds_f[k];
             x_out_c[t] = sum;
         }
 #endif
-        for (int t = T_final; t < T; t++) x_out_c[t] = 0.0f;
+        for (int t = T_final; t < T; t++)
+            x_out_c[t] = 0.0f;
     }
 }
 
@@ -6572,30 +6017,27 @@ void ggml_compute_forward_aa_snake_beta(
 // src0: kernel [OC, IC, KH, KW]
 // src1: image [N, IC, IH, IW]
 // dst:  result [N, OH, OW, IC*KH*KW]
-static void ggml_compute_forward_im2col_f32(
-        const ggml_compute_params * params,
-              ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
-    const ggml_tensor * src1 = dst->src[1];
+static void ggml_compute_forward_im2col_f32(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
+    const ggml_tensor* src1 = dst->src[1];
 
     GGML_ASSERT(src1->type == GGML_TYPE_F32);
-    GGML_ASSERT( dst->type == GGML_TYPE_F32);
+    GGML_ASSERT(dst->type == GGML_TYPE_F32);
 
     GGML_TENSOR_BINARY_OP_LOCALS;
 
-    const int32_t s0 = ((const int32_t *)(dst->op_params))[0];
-    const int32_t s1 = ((const int32_t *)(dst->op_params))[1];
-    const int32_t p0 = ((const int32_t *)(dst->op_params))[2];
-    const int32_t p1 = ((const int32_t *)(dst->op_params))[3];
-    const int32_t d0 = ((const int32_t *)(dst->op_params))[4];
-    const int32_t d1 = ((const int32_t *)(dst->op_params))[5];
-    const bool is_2D = ((const int32_t *)(dst->op_params))[6] == 1;
+    const int32_t s0 = ((const int32_t*)(dst->op_params))[0];
+    const int32_t s1 = ((const int32_t*)(dst->op_params))[1];
+    const int32_t p0 = ((const int32_t*)(dst->op_params))[2];
+    const int32_t p1 = ((const int32_t*)(dst->op_params))[3];
+    const int32_t d0 = ((const int32_t*)(dst->op_params))[4];
+    const int32_t d1 = ((const int32_t*)(dst->op_params))[5];
+    const bool is_2D = ((const int32_t*)(dst->op_params))[6] == 1;
 
     const int ith = params->ith;
     const int nth = params->nth;
 
-    const int64_t N  = is_2D ? ne13 : ne12;
+    const int64_t N = is_2D ? ne13 : ne12;
     const int64_t IC = is_2D ? ne12 : ne11;
     const int64_t IH = is_2D ? ne11 : 1;
     const int64_t IW = ne10;
@@ -6613,26 +6055,25 @@ static void ggml_compute_forward_im2col_f32(
 
     // im2col: [N, IC, IH, IW] => [N, OH, OW, IC*KH*KW]
     {
-        float * const wdata = (float *) dst->data;
+        float* const wdata = (float*)dst->data;
 
         for (int64_t in = 0; in < N; in++) {
             for (int64_t ioh = 0; ioh < OH; ioh++) { // 1
                 for (int64_t iow = 0; iow < OW; iow++) {
                     for (int64_t iic = ith; iic < IC; iic += nth) {
-
                         // micro kernel
-                        float * dst_data = wdata + (in*OH*OW + ioh*OW + iow)*(IC*KH*KW); // [IC, KH, KW]
-                        const float * const src_data = (float *)((char *) src1->data + in*ofs0 + iic*ofs1); // [IH, IW]
+                        float* dst_data = wdata + (in * OH * OW + ioh * OW + iow) * (IC * KH * KW); // [IC, KH, KW]
+                        const float* const src_data = (float*)((char*)src1->data + in * ofs0 + iic * ofs1); // [IH, IW]
 
-                        for (int64_t ikh = 0; ikh < KH; ikh++) {  // 1
+                        for (int64_t ikh = 0; ikh < KH; ikh++) { // 1
                             for (int64_t ikw = 0; ikw < KW; ikw++) {
-                                const int64_t iiw = iow*s0 + ikw*d0 - p0;
-                                const int64_t iih = ioh*s1 + ikh*d1 - p1;
+                                const int64_t iiw = iow * s0 + ikw * d0 - p0;
+                                const int64_t iih = ioh * s1 + ikh * d1 - p1;
 
                                 if (iih < 0 || iih >= IH || iiw < 0 || iiw >= IW) {
-                                    dst_data[iic*(KH*KW) + ikh*KW + ikw] = 0;
+                                    dst_data[iic * (KH * KW) + ikh * KW + ikw] = 0;
                                 } else {
-                                    dst_data[iic*(KH*KW) + ikh*KW + ikw] = (src_data[iih*IW + iiw]);
+                                    dst_data[iic * (KH * KW) + ikh * KW + ikw] = (src_data[iih * IW + iiw]);
                                 }
                             }
                         }
@@ -6648,31 +6089,28 @@ static void ggml_compute_forward_im2col_f32(
 // src0: kernel [OC, IC, KH, KW]
 // src1: image [N, IC, IH, IW]
 // dst:  result [N, OH, OW, IC*KH*KW]
-static void ggml_compute_forward_im2col_f16(
-        const ggml_compute_params * params,
-              ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
-    const ggml_tensor * src1 = dst->src[1];
+static void ggml_compute_forward_im2col_f16(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
+    const ggml_tensor* src1 = dst->src[1];
 
     GGML_ASSERT(src0->type == GGML_TYPE_F16);
     GGML_ASSERT(src1->type == GGML_TYPE_F16 || src1->type == GGML_TYPE_F32);
-    GGML_ASSERT( dst->type == GGML_TYPE_F16);
+    GGML_ASSERT(dst->type == GGML_TYPE_F16);
 
     GGML_TENSOR_BINARY_OP_LOCALS;
 
-    const int32_t s0 = ((const int32_t *)(dst->op_params))[0];
-    const int32_t s1 = ((const int32_t *)(dst->op_params))[1];
-    const int32_t p0 = ((const int32_t *)(dst->op_params))[2];
-    const int32_t p1 = ((const int32_t *)(dst->op_params))[3];
-    const int32_t d0 = ((const int32_t *)(dst->op_params))[4];
-    const int32_t d1 = ((const int32_t *)(dst->op_params))[5];
-    const bool is_2D = ((const int32_t *)(dst->op_params))[6] == 1;
+    const int32_t s0 = ((const int32_t*)(dst->op_params))[0];
+    const int32_t s1 = ((const int32_t*)(dst->op_params))[1];
+    const int32_t p0 = ((const int32_t*)(dst->op_params))[2];
+    const int32_t p1 = ((const int32_t*)(dst->op_params))[3];
+    const int32_t d0 = ((const int32_t*)(dst->op_params))[4];
+    const int32_t d1 = ((const int32_t*)(dst->op_params))[5];
+    const bool is_2D = ((const int32_t*)(dst->op_params))[6] == 1;
 
     const int ith = params->ith;
     const int nth = params->nth;
 
-    const int64_t N  = is_2D ? ne13 : ne12;
+    const int64_t N = is_2D ? ne13 : ne12;
     const int64_t IC = is_2D ? ne12 : ne11;
     const int64_t IH = is_2D ? ne11 : 1;
     const int64_t IW = ne10;
@@ -6691,34 +6129,37 @@ static void ggml_compute_forward_im2col_f16(
 
     // im2col: [N, IC, IH, IW] => [N, OH, OW, IC*KH*KW]
     {
-        ggml_fp16_t * const wdata = (ggml_fp16_t *) dst->data;
+        ggml_fp16_t* const wdata = (ggml_fp16_t*)dst->data;
 
         for (int64_t in = 0; in < N; in++) {
             for (int64_t ioh = 0; ioh < OH; ioh++) { // 1
                 for (int64_t iow = 0; iow < OW; iow++) {
                     for (int64_t iic = ith; iic < IC; iic += nth) {
-
                         // micro kernel
-                        ggml_fp16_t * dst_data = wdata + (in*OH*OW + ioh*OW + iow)*(IC*KH*KW); // [IC, KH, KW]
-                        const float * const src_data_f32 = src1->type == GGML_TYPE_F32
-                            ? (const float *)((const char *) src1->data + in*ofs0 + iic*ofs1)
-                            : nullptr; // [IH, IW]
-                        const ggml_fp16_t * const src_data_f16 = src1->type == GGML_TYPE_F16
-                            ? (const ggml_fp16_t *)((const char *) src1->data + in*ofs0 + iic*ofs1)
-                            : nullptr; // [IH, IW]
+                        ggml_fp16_t* dst_data =
+                            wdata + (in * OH * OW + ioh * OW + iow) * (IC * KH * KW); // [IC, KH, KW]
+                        const float* const src_data_f32 =
+                            src1->type == GGML_TYPE_F32
+                                ? (const float*)((const char*)src1->data + in * ofs0 + iic * ofs1)
+                                : nullptr; // [IH, IW]
+                        const ggml_fp16_t* const src_data_f16 =
+                            src1->type == GGML_TYPE_F16
+                                ? (const ggml_fp16_t*)((const char*)src1->data + in * ofs0 + iic * ofs1)
+                                : nullptr; // [IH, IW]
 
-                        for (int64_t ikh = 0; ikh < KH; ikh++) {  // 1
+                        for (int64_t ikh = 0; ikh < KH; ikh++) { // 1
                             for (int64_t ikw = 0; ikw < KW; ikw++) {
-                                const int64_t iiw = iow*s0 + ikw*d0 - p0;
-                                const int64_t iih = ioh*s1 + ikh*d1 - p1;
+                                const int64_t iiw = iow * s0 + ikw * d0 - p0;
+                                const int64_t iih = ioh * s1 + ikh * d1 - p1;
 
                                 if (iih < 0 || iih >= IH || iiw < 0 || iiw >= IW) {
-                                    dst_data[iic*(KH*KW) + ikh*KW + ikw] = 0;
+                                    dst_data[iic * (KH * KW) + ikh * KW + ikw] = 0;
                                 } else {
                                     if (src_data_f32 != nullptr) {
-                                        dst_data[iic*(KH*KW) + ikh*KW + ikw] = GGML_CPU_FP32_TO_FP16(src_data_f32[iih*IW + iiw]);
+                                        dst_data[iic * (KH * KW) + ikh * KW + ikw] =
+                                            GGML_CPU_FP32_TO_FP16(src_data_f32[iih * IW + iiw]);
                                     } else {
-                                        dst_data[iic*(KH*KW) + ikh*KW + ikw] = src_data_f16[iih*IW + iiw];
+                                        dst_data[iic * (KH * KW) + ikh * KW + ikw] = src_data_f16[iih * IW + iiw];
                                     }
                                 }
                             }
@@ -6730,52 +6171,44 @@ static void ggml_compute_forward_im2col_f16(
     }
 }
 
-void ggml_compute_forward_im2col(
-        const ggml_compute_params * params,
-              ggml_tensor * dst) {
+void ggml_compute_forward_im2col(const ggml_compute_params* params, ggml_tensor* dst) {
     switch (dst->type) {
-        case GGML_TYPE_F16:
-            {
-                ggml_compute_forward_im2col_f16(params, dst);
-            } break;
-        case GGML_TYPE_F32:
-            {
-                ggml_compute_forward_im2col_f32(params, dst);
-            } break;
-        default:
-            {
-                GGML_ABORT("fatal error");
-            }
+    case GGML_TYPE_F16: {
+        ggml_compute_forward_im2col_f16(params, dst);
+    } break;
+    case GGML_TYPE_F32: {
+        ggml_compute_forward_im2col_f32(params, dst);
+    } break;
+    default: {
+        GGML_ABORT("fatal error");
+    }
     }
 }
 
 // ggml_compute_forward_im2col_back_f32
 
-void ggml_compute_forward_im2col_back_f32(
-        const ggml_compute_params * params,
-              ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0]; // gradients of forward pass output
-    const ggml_tensor * src1 = dst->src[1]; // convolution kernel
+void ggml_compute_forward_im2col_back_f32(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0]; // gradients of forward pass output
+    const ggml_tensor* src1 = dst->src[1]; // convolution kernel
 
     GGML_ASSERT(src0->type == GGML_TYPE_F32);
     GGML_ASSERT(src1->type == GGML_TYPE_F32);
-    GGML_ASSERT( dst->type == GGML_TYPE_F32);
+    GGML_ASSERT(dst->type == GGML_TYPE_F32);
 
     GGML_TENSOR_BINARY_OP_LOCALS;
 
-    const int32_t s0 = ((const int32_t *)(dst->op_params))[0];
-    const int32_t s1 = ((const int32_t *)(dst->op_params))[1];
-    const int32_t p0 = ((const int32_t *)(dst->op_params))[2];
-    const int32_t p1 = ((const int32_t *)(dst->op_params))[3];
-    const int32_t d0 = ((const int32_t *)(dst->op_params))[4];
-    const int32_t d1 = ((const int32_t *)(dst->op_params))[5];
-    const bool is_2D = ((const int32_t *)(dst->op_params))[6] == 1;
+    const int32_t s0 = ((const int32_t*)(dst->op_params))[0];
+    const int32_t s1 = ((const int32_t*)(dst->op_params))[1];
+    const int32_t p0 = ((const int32_t*)(dst->op_params))[2];
+    const int32_t p1 = ((const int32_t*)(dst->op_params))[3];
+    const int32_t d0 = ((const int32_t*)(dst->op_params))[4];
+    const int32_t d1 = ((const int32_t*)(dst->op_params))[5];
+    const bool is_2D = ((const int32_t*)(dst->op_params))[6] == 1;
 
     const int ith = params->ith;
     const int nth = params->nth;
 
-    const int64_t N  = is_2D ? ne3 : ne2;
+    const int64_t N = is_2D ? ne3 : ne2;
     const int64_t IC = is_2D ? ne2 : ne1;
     const int64_t IH = is_2D ? ne1 : 1;
     const int64_t IW = ne0;
@@ -6789,24 +6222,23 @@ void ggml_compute_forward_im2col_back_f32(
     int ofs0 = is_2D ? nb3 : nb2;
     int ofs1 = is_2D ? nb2 : nb1;
 
-    GGML_ASSERT(nb0  == sizeof(float));
+    GGML_ASSERT(nb0 == sizeof(float));
 
     // im2col: [N, IC, IH, IW] => [N, OH, OW, IC*KH*KW]
     {
-        float * const wdata = (float *) dst->data;
+        float* const wdata = (float*)dst->data;
 
         for (int64_t in = 0; in < N; in++) {
             for (int64_t iic = ith; iic < IC; iic += nth) {
                 for (int64_t iih = 0; iih < IH; iih++) {
                     for (int64_t iiw = 0; iiw < IW; iiw++) {
-
                         // micro kernel
                         float grad = 0.0f;
                         for (int64_t ikh = 0; ikh < KH; ikh++) {
                             for (int64_t ikw = 0; ikw < KW; ikw++) {
                                 // For s0 > 1 some values were skipped over in the forward pass.
                                 // These values have tmpw % s0 != 0 and need to be skipped in the backwards pass as well.
-                                const int64_t tmpw = (iiw + p0 - ikw*d0);
+                                const int64_t tmpw = (iiw + p0 - ikw * d0);
                                 if (tmpw % s0 != 0) {
                                     continue;
                                 }
@@ -6815,7 +6247,7 @@ void ggml_compute_forward_im2col_back_f32(
                                 // Equivalent logic as above except for s1.
                                 int64_t ioh;
                                 if (is_2D) {
-                                    const int64_t tmph = iih + p1 - ikh*d1;
+                                    const int64_t tmph = iih + p1 - ikh * d1;
 
                                     if (tmph % s1 != 0) {
                                         continue;
@@ -6830,13 +6262,14 @@ void ggml_compute_forward_im2col_back_f32(
                                     continue;
                                 }
 
-                                const float * const grad_in = (const float *) src0->data
-                                    + (in*OH*OW + ioh*OW + iow)*(IC*KH*KW); // [IC, KH, KW]
-                                grad += grad_in[iic*(KH*KW) + ikh*KW + ikw];
+                                const float* const grad_in =
+                                    (const float*)src0->data +
+                                    (in * OH * OW + ioh * OW + iow) * (IC * KH * KW); // [IC, KH, KW]
+                                grad += grad_in[iic * (KH * KW) + ikh * KW + ikw];
                             }
                         }
-                        float * dst_data = (float *)((char *) wdata + (in*ofs0 + iic*ofs1)); // [IH, IW]
-                        dst_data[iih*IW + iiw] = grad;
+                        float* dst_data = (float*)((char*)wdata + (in * ofs0 + iic * ofs1)); // [IH, IW]
+                        dst_data[iih * IW + iiw] = grad;
                     }
                 }
             }
@@ -6849,35 +6282,32 @@ void ggml_compute_forward_im2col_back_f32(
 // src0: kernel [OC*IC, KD, KH, KW]
 // src1: image [N*IC, ID, IH, IW]
 // dst:  result [N*OD, OH, OW, IC * KD * KH * KW]
-static void ggml_compute_forward_im2col_3d_f16(
-        const ggml_compute_params * params,
-              ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
-    const ggml_tensor * src1 = dst->src[1];
+static void ggml_compute_forward_im2col_3d_f16(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
+    const ggml_tensor* src1 = dst->src[1];
 
     GGML_ASSERT(src0->type == GGML_TYPE_F16);
     GGML_ASSERT(src1->type == GGML_TYPE_F32);
-    GGML_ASSERT( dst->type == GGML_TYPE_F16);
+    GGML_ASSERT(dst->type == GGML_TYPE_F16);
 
     GGML_TENSOR_BINARY_OP_LOCALS;
 
-    const int32_t s0 = ((const int32_t *)(dst->op_params))[0];
-    const int32_t s1 = ((const int32_t *)(dst->op_params))[1];
-    const int32_t s2 = ((const int32_t *)(dst->op_params))[2];
-    const int32_t p0 = ((const int32_t *)(dst->op_params))[3];
-    const int32_t p1 = ((const int32_t *)(dst->op_params))[4];
-    const int32_t p2 = ((const int32_t *)(dst->op_params))[5];
-    const int32_t d0 = ((const int32_t *)(dst->op_params))[6];
-    const int32_t d1 = ((const int32_t *)(dst->op_params))[7];
-    const int32_t d2 = ((const int32_t *)(dst->op_params))[8];
-    const int32_t IC = ((const int32_t *)(dst->op_params))[9];
+    const int32_t s0 = ((const int32_t*)(dst->op_params))[0];
+    const int32_t s1 = ((const int32_t*)(dst->op_params))[1];
+    const int32_t s2 = ((const int32_t*)(dst->op_params))[2];
+    const int32_t p0 = ((const int32_t*)(dst->op_params))[3];
+    const int32_t p1 = ((const int32_t*)(dst->op_params))[4];
+    const int32_t p2 = ((const int32_t*)(dst->op_params))[5];
+    const int32_t d0 = ((const int32_t*)(dst->op_params))[6];
+    const int32_t d1 = ((const int32_t*)(dst->op_params))[7];
+    const int32_t d2 = ((const int32_t*)(dst->op_params))[8];
+    const int32_t IC = ((const int32_t*)(dst->op_params))[9];
 
 
     const int ith = params->ith;
     const int nth = params->nth;
 
-    const int64_t N  = ne13 / IC;
+    const int64_t N = ne13 / IC;
     const int64_t ID = ne12;
     const int64_t IH = ne11;
     const int64_t IW = ne10;
@@ -6891,39 +6321,43 @@ static void ggml_compute_forward_im2col_3d_f16(
     const int64_t OD = ne3 / N;
     const int64_t OH = ne2;
     const int64_t OW = ne1;
-    const int64_t OH_OW = OH*OW;
-    const int64_t KD_KH_KW = KD*KH*KW;
-    const int64_t KH_KW = KH*KW;
-    const int64_t IC_KD_KH_KW = IC*KD*KH*KW;
+    const int64_t OH_OW = OH * OW;
+    const int64_t KD_KH_KW = KD * KH * KW;
+    const int64_t KH_KW = KH * KW;
+    const int64_t IC_KD_KH_KW = IC * KD * KH * KW;
 
     GGML_ASSERT(nb10 == sizeof(float));
 
     // im2col: [N*IC, ID, IH, IW] => [N*OD, OH, OW, IC * KD * KH * KW]
     {
-        ggml_fp16_t * const wdata = (ggml_fp16_t *) dst->data;
+        ggml_fp16_t* const wdata = (ggml_fp16_t*)dst->data;
 
         for (int64_t in = 0; in < N; in++) {
             for (int64_t iod = 0; iod < OD; iod++) {
                 for (int64_t ioh = 0; ioh < OH; ioh++) {
                     for (int64_t iow = 0; iow < OW; iow++) {
                         for (int64_t iic = ith; iic < IC; iic += nth) {
-
                             // micro kernel
-                            ggml_fp16_t * dst_data = wdata + (in*OD*OH_OW + iod*OH_OW + ioh*OW + iow)*IC_KD_KH_KW; // [IC, KD, KH, KW]
-                            const float * const src_data = (const float *) ((const char *)src1->data + (in*IC + iic)*nb13); // [ID, IH, IW]
+                            ggml_fp16_t* dst_data = wdata + (in * OD * OH_OW + iod * OH_OW + ioh * OW + iow) *
+                                                                IC_KD_KH_KW; // [IC, KD, KH, KW]
+                            const float* const src_data =
+                                (const float*)((const char*)src1->data + (in * IC + iic) * nb13); // [ID, IH, IW]
 
                             for (int64_t ikd = 0; ikd < KD; ikd++) {
                                 for (int64_t ikh = 0; ikh < KH; ikh++) {
                                     for (int64_t ikw = 0; ikw < KW; ikw++) {
-                                        const int64_t iiw = iow*s0 + ikw*d0 - p0;
-                                        const int64_t iih = ioh*s1 + ikh*d1 - p1;
-                                        const int64_t iid = iod*s2 + ikd*d2 - p2;
+                                        const int64_t iiw = iow * s0 + ikw * d0 - p0;
+                                        const int64_t iih = ioh * s1 + ikh * d1 - p1;
+                                        const int64_t iid = iod * s2 + ikd * d2 - p2;
 
                                         if (iid < 0 || iid >= ID || iih < 0 || iih >= IH || iiw < 0 || iiw >= IW) {
-                                            dst_data[iic*KD_KH_KW + ikd * KH_KW + ikh*KW + ikw] = 0;
+                                            dst_data[iic * KD_KH_KW + ikd * KH_KW + ikh * KW + ikw] = 0;
                                         } else {
-                                            const float * const s = (const float *) ((const char *)src_data + iid*nb12 + iih*nb11 + iiw*nb10); // [ID, IH, IW]
-                                            dst_data[iic*KD_KH_KW + ikd * KH_KW + ikh*KW + ikw] = GGML_CPU_FP32_TO_FP16(*s);
+                                            const float* const s =
+                                                (const float*)((const char*)src_data + iid * nb12 + iih * nb11 +
+                                                               iiw * nb10); // [ID, IH, IW]
+                                            dst_data[iic * KD_KH_KW + ikd * KH_KW + ikh * KW + ikw] =
+                                                GGML_CPU_FP32_TO_FP16(*s);
                                         }
                                     }
                                 }
@@ -6940,34 +6374,31 @@ static void ggml_compute_forward_im2col_3d_f16(
 // src0: kernel [OC*IC, KD, KH, KW]
 // src1: image [N*IC, ID, IH, IW]
 // dst:  result [N*OD, OH, OW, IC * KD * KH * KW]
-static void ggml_compute_forward_im2col_3d_f32(
-        const ggml_compute_params * params,
-              ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
-    const ggml_tensor * src1 = dst->src[1];
+static void ggml_compute_forward_im2col_3d_f32(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
+    const ggml_tensor* src1 = dst->src[1];
 
     GGML_ASSERT(src1->type == GGML_TYPE_F32);
-    GGML_ASSERT( dst->type == GGML_TYPE_F32);
+    GGML_ASSERT(dst->type == GGML_TYPE_F32);
 
     GGML_TENSOR_BINARY_OP_LOCALS;
 
-    const int32_t s0 = ((const int32_t *)(dst->op_params))[0];
-    const int32_t s1 = ((const int32_t *)(dst->op_params))[1];
-    const int32_t s2 = ((const int32_t *)(dst->op_params))[2];
-    const int32_t p0 = ((const int32_t *)(dst->op_params))[3];
-    const int32_t p1 = ((const int32_t *)(dst->op_params))[4];
-    const int32_t p2 = ((const int32_t *)(dst->op_params))[5];
-    const int32_t d0 = ((const int32_t *)(dst->op_params))[6];
-    const int32_t d1 = ((const int32_t *)(dst->op_params))[7];
-    const int32_t d2 = ((const int32_t *)(dst->op_params))[8];
-    const int32_t IC = ((const int32_t *)(dst->op_params))[9];
+    const int32_t s0 = ((const int32_t*)(dst->op_params))[0];
+    const int32_t s1 = ((const int32_t*)(dst->op_params))[1];
+    const int32_t s2 = ((const int32_t*)(dst->op_params))[2];
+    const int32_t p0 = ((const int32_t*)(dst->op_params))[3];
+    const int32_t p1 = ((const int32_t*)(dst->op_params))[4];
+    const int32_t p2 = ((const int32_t*)(dst->op_params))[5];
+    const int32_t d0 = ((const int32_t*)(dst->op_params))[6];
+    const int32_t d1 = ((const int32_t*)(dst->op_params))[7];
+    const int32_t d2 = ((const int32_t*)(dst->op_params))[8];
+    const int32_t IC = ((const int32_t*)(dst->op_params))[9];
 
 
     const int ith = params->ith;
     const int nth = params->nth;
 
-    const int64_t N  = ne13 / IC;
+    const int64_t N = ne13 / IC;
     const int64_t ID = ne12;
     const int64_t IH = ne11;
     const int64_t IW = ne10;
@@ -6982,39 +6413,43 @@ static void ggml_compute_forward_im2col_3d_f32(
     const int64_t OH = ne2;
     const int64_t OW = ne1;
 
-    const int64_t OH_OW = OH*OW;
-    const int64_t KD_KH_KW = KD*KH*KW;
-    const int64_t KH_KW = KH*KW;
-    const int64_t IC_KD_KH_KW = IC*KD*KH*KW;
+    const int64_t OH_OW = OH * OW;
+    const int64_t KD_KH_KW = KD * KH * KW;
+    const int64_t KH_KW = KH * KW;
+    const int64_t IC_KD_KH_KW = IC * KD * KH * KW;
 
     GGML_ASSERT(nb10 == sizeof(float));
 
     // im2col: [N*IC, ID, IH, IW] => [N*OD, OH, OW, IC * KD * KH * KW]
     {
-        float * const wdata = (float *) dst->data;
+        float* const wdata = (float*)dst->data;
 
         for (int64_t in = 0; in < N; in++) {
             for (int64_t iod = 0; iod < OD; iod++) {
                 for (int64_t ioh = 0; ioh < OH; ioh++) {
                     for (int64_t iow = 0; iow < OW; iow++) {
                         for (int64_t iic = ith; iic < IC; iic += nth) {
-
                             // micro kernel
-                            float * dst_data = wdata + (in*OD*OH_OW + iod*OH_OW + ioh*OW + iow)*IC_KD_KH_KW; // [IC, KD, KH, KW]
-                            const float * const src_data = (const float *) ((const char *)src1->data + (in*IC + iic)*nb13); // [ID, IH, IW]
+                            float* dst_data = wdata + (in * OD * OH_OW + iod * OH_OW + ioh * OW + iow) *
+                                                          IC_KD_KH_KW; // [IC, KD, KH, KW]
+                            const float* const src_data =
+                                (const float*)((const char*)src1->data + (in * IC + iic) * nb13); // [ID, IH, IW]
 
                             for (int64_t ikd = 0; ikd < KD; ikd++) {
                                 for (int64_t ikh = 0; ikh < KH; ikh++) {
                                     for (int64_t ikw = 0; ikw < KW; ikw++) {
-                                        const int64_t iiw = iow*s0 + ikw*d0 - p0;
-                                        const int64_t iih = ioh*s1 + ikh*d1 - p1;
-                                        const int64_t iid = iod*s2 + ikd*d2 - p2;
+                                        const int64_t iiw = iow * s0 + ikw * d0 - p0;
+                                        const int64_t iih = ioh * s1 + ikh * d1 - p1;
+                                        const int64_t iid = iod * s2 + ikd * d2 - p2;
 
-                                        if (iid < 0 || iid >= ID || iih < 0 || iih >= IH || iiw < 0 || iiw >= IW || iid < 0 || iid >= ID) {
-                                            dst_data[iic*KD_KH_KW + ikd * KH_KW + ikh*KW + ikw] = 0;
+                                        if (iid < 0 || iid >= ID || iih < 0 || iih >= IH || iiw < 0 || iiw >= IW ||
+                                            iid < 0 || iid >= ID) {
+                                            dst_data[iic * KD_KH_KW + ikd * KH_KW + ikh * KW + ikw] = 0;
                                         } else {
-                                            const float * const s = (const float *) ((const char *)src_data + iid*nb12 + iih*nb11 + iiw*nb10); // [ID, IH, IW]
-                                            dst_data[iic*KD_KH_KW + ikd * KH_KW + ikh*KW + ikw] = *s;
+                                            const float* const s =
+                                                (const float*)((const char*)src_data + iid * nb12 + iih * nb11 +
+                                                               iiw * nb10); // [ID, IH, IW]
+                                            dst_data[iic * KD_KH_KW + ikd * KH_KW + ikh * KW + ikw] = *s;
                                         }
                                     }
                                 }
@@ -7028,30 +6463,25 @@ static void ggml_compute_forward_im2col_3d_f32(
 }
 
 
-void ggml_compute_forward_im2col_3d(
-        const ggml_compute_params * params,
-              ggml_tensor * dst) {
+void ggml_compute_forward_im2col_3d(const ggml_compute_params* params, ggml_tensor* dst) {
     switch (dst->type) {
-        case GGML_TYPE_F16:
-            {
-                ggml_compute_forward_im2col_3d_f16(params, dst);
-            } break;
-        case GGML_TYPE_F32:
-            {
-                ggml_compute_forward_im2col_3d_f32(params, dst);
-            } break;
-        default:
-            {
-                GGML_ABORT("fatal error");
-            }
+    case GGML_TYPE_F16: {
+        ggml_compute_forward_im2col_3d_f16(params, dst);
+    } break;
+    case GGML_TYPE_F32: {
+        ggml_compute_forward_im2col_3d_f32(params, dst);
+    } break;
+    default: {
+        GGML_ABORT("fatal error");
+    }
     }
 }
 
-static void ggml_call_mul_mat(ggml_type type, const ggml_compute_params * params, int64_t m, int64_t n, int64_t k,
-                              void * a, void * b, float * c) {
-    const ggml_type_traits * traits = ggml_get_type_traits(type);
+static void ggml_call_mul_mat(ggml_type type, const ggml_compute_params* params, int64_t m, int64_t n, int64_t k,
+                              void* a, void* b, float* c) {
+    const ggml_type_traits* traits = ggml_get_type_traits(type);
     struct ggml_tensor src1 = {};
-    src1.type  = type;
+    src1.type = type;
     src1.ne[0] = k;
     src1.ne[1] = m;
     src1.ne[2] = 1;
@@ -7060,10 +6490,10 @@ static void ggml_call_mul_mat(ggml_type type, const ggml_compute_params * params
     src1.nb[1] = k * traits->type_size;
     src1.nb[2] = src1.nb[1];
     src1.nb[3] = src1.nb[2];
-    src1.data  = a;
+    src1.data = a;
 
     struct ggml_tensor src0 = {};
-    src0.type  = type;
+    src0.type = type;
     src0.ne[0] = k;
     src0.ne[1] = n;
     src0.ne[2] = 1;
@@ -7072,7 +6502,7 @@ static void ggml_call_mul_mat(ggml_type type, const ggml_compute_params * params
     src0.nb[1] = k * traits->type_size;
     src0.nb[2] = src0.nb[1];
     src0.nb[3] = src0.nb[2];
-    src0.data  = b;
+    src0.data = b;
 
     struct ggml_tensor dst = {};
     dst.ne[0] = n;
@@ -7083,7 +6513,7 @@ static void ggml_call_mul_mat(ggml_type type, const ggml_compute_params * params
     dst.nb[1] = n * sizeof(float);
     dst.nb[2] = dst.nb[1];
     dst.nb[3] = dst.nb[2];
-    dst.data  = c;
+    dst.data = c;
     dst.src[0] = &src0;
     dst.src[1] = &src1;
 
@@ -7091,32 +6521,31 @@ static void ggml_call_mul_mat(ggml_type type, const ggml_compute_params * params
 }
 
 static inline int64_t ggml_wrap_around(int64_t coord, int64_t size) {
-    return (coord  + size) % size; // adding size avoids negative number weirdness
+    return (coord + size) % size; // adding size avoids negative number weirdness
 }
 
 // ggml_compute_forward_conv_2d
 
 
-static void ggml_compute_forward_conv_2d_impl(const ggml_compute_params * params,
-                                              const ggml_tensor *         kernel,  // [KW, KH, IC, OC]
-                                              const ggml_tensor *         src,     // [W, H, C, N]
-                                              ggml_tensor *               dst,     // [OW, OH, OC, N]
-                                              ggml_type                   kernel_type) {
-
+static void ggml_compute_forward_conv_2d_impl(const ggml_compute_params* params,
+                                              const ggml_tensor* kernel, // [KW, KH, IC, OC]
+                                              const ggml_tensor* src,    // [W, H, C, N]
+                                              ggml_tensor* dst,          // [OW, OH, OC, N]
+                                              ggml_type kernel_type) {
     GGML_ASSERT(ggml_is_contiguous(kernel));
     GGML_ASSERT(kernel_type == GGML_TYPE_F16 || kernel_type == GGML_TYPE_F32);
     GGML_ASSERT(kernel->type == kernel_type);
 
-    const ggml_type_traits * traits = ggml_get_type_traits(kernel_type);
+    const ggml_type_traits* traits = ggml_get_type_traits(kernel_type);
 
-    const int32_t stride_x   = dst->op_params[0];
-    const int32_t stride_y   = dst->op_params[1];
-    const int32_t pad_x      = dst->op_params[2];
-    const int32_t pad_y      = dst->op_params[3];
+    const int32_t stride_x = dst->op_params[0];
+    const int32_t stride_y = dst->op_params[1];
+    const int32_t pad_x = dst->op_params[2];
+    const int32_t pad_y = dst->op_params[3];
     const int32_t dilation_x = dst->op_params[4];
     const int32_t dilation_y = dst->op_params[5];
 
-    const int64_t c_in  = src->ne[2];
+    const int64_t c_in = src->ne[2];
     const int64_t c_out = kernel->ne[3];
     GGML_ASSERT(c_in == kernel->ne[2]);
 
@@ -7127,41 +6556,39 @@ static void ggml_compute_forward_conv_2d_impl(const ggml_compute_params * params
     const int64_t dst_w = dst->ne[0];
     const int64_t dst_h = dst->ne[1];
 
-    const float * src_data = (float *) src->data;
-    void  * knl_data       = kernel->data;
-    float * dst_data       = (float *) dst->data;
+    const float* src_data = (float*)src->data;
+    void* knl_data = kernel->data;
+    float* dst_data = (float*)dst->data;
 
-    const int64_t knl_n           = knl_w * knl_h * c_in;
-    const int64_t patch_total     = dst->ne[3] * dst_w * dst_h;
+    const int64_t knl_n = knl_w * knl_h * c_in;
+    const int64_t patch_total = dst->ne[3] * dst_w * dst_h;
 
-    const int64_t space_per_patch   = knl_n * traits->type_size + c_out * sizeof(float);
-    const int64_t batch_size        = params->wsize / space_per_patch;
+    const int64_t space_per_patch = knl_n * traits->type_size + c_out * sizeof(float);
+    const int64_t batch_size = params->wsize / space_per_patch;
     const int64_t patches_per_batch = batch_size > 8 ? (batch_size / 8) * 8 : batch_size;
-    const int64_t batch_n           = (patch_total + patches_per_batch - 1) / patches_per_batch;
+    const int64_t batch_n = (patch_total + patches_per_batch - 1) / patches_per_batch;
 
     GGML_ASSERT(patches_per_batch > 0 && batch_size >= 1);
 
-    void * tmp = params->wdata;
+    void* tmp = params->wdata;
 
     for (int64_t batch_i = 0; batch_i < batch_n; ++batch_i) {
-
         const int64_t patch_start_batch = batch_i * patches_per_batch;
-        const int64_t patch_end_batch   = std::min(patch_start_batch + patches_per_batch,
-                                              patch_total);
-        const int64_t patch_n           = patch_end_batch - patch_start_batch;
+        const int64_t patch_end_batch = std::min(patch_start_batch + patches_per_batch, patch_total);
+        const int64_t patch_n = patch_end_batch - patch_start_batch;
 
-        const int64_t patch_per_thread  = (patch_n + params->nth - 1) / params->nth;
-        const int64_t patch_start       = patch_start_batch + params->ith * patch_per_thread;
-        const int64_t patch_end         = std::min(patch_start + patch_per_thread, patch_end_batch);
+        const int64_t patch_per_thread = (patch_n + params->nth - 1) / params->nth;
+        const int64_t patch_start = patch_start_batch + params->ith * patch_per_thread;
+        const int64_t patch_end = std::min(patch_start + patch_per_thread, patch_end_batch);
 
         //im2col for a patch
         for (int64_t p = patch_start; p < patch_end; ++p) {
-            const int64_t  batch_n     =  p / (dst_w * dst_h);
-            const int64_t  src_x       = (p / dst_w) % dst_h;
-            const int64_t  src_y       =  p % dst_w;
+            const int64_t batch_n = p / (dst_w * dst_h);
+            const int64_t src_x = (p / dst_w) % dst_h;
+            const int64_t src_y = p % dst_w;
 
-            const float * src_base = (const float *)((const char *)src_data + batch_n * src->nb[3]);
-            char *        dst_row  = (char *) tmp + (p % patches_per_batch) * knl_n * traits->type_size;
+            const float* src_base = (const float*)((const char*)src_data + batch_n * src->nb[3]);
+            char* dst_row = (char*)tmp + (p % patches_per_batch) * knl_n * traits->type_size;
 
             for (int64_t ic = 0; ic < c_in; ++ic) {
                 for (int64_t ky = 0; ky < knl_h; ++ky) {
@@ -7175,24 +6602,25 @@ static void ggml_compute_forward_conv_2d_impl(const ggml_compute_params * params
                         if (sy < 0 || sy >= src_h || sx < 0 || sx >= src_w) {
                             src_val = 0.0f;
                         } else {
-                            const float * src_ptr = (const float *)((const char *)src_base + sx * src->nb[0] + sy * src->nb[1] + ic * src->nb[2]);
-                            src_val               = *src_ptr;
+                            const float* src_ptr = (const float*)((const char*)src_base + sx * src->nb[0] +
+                                                                  sy * src->nb[1] + ic * src->nb[2]);
+                            src_val = *src_ptr;
                         }
 
-                        char * element_ptr = dst_row + dst_idx * traits->type_size;
+                        char* element_ptr = dst_row + dst_idx * traits->type_size;
                         if (kernel_type == GGML_TYPE_F32) {
-                            *(float *) element_ptr = src_val;
+                            *(float*)element_ptr = src_val;
                         } else if (kernel_type == GGML_TYPE_F16) {
-                            *(ggml_fp16_t *) element_ptr = GGML_CPU_FP32_TO_FP16(src_val);
+                            *(ggml_fp16_t*)element_ptr = GGML_CPU_FP32_TO_FP16(src_val);
                         }
                     }
                 }
             }
-        }   // patches handled by this thread
+        } // patches handled by this thread
 
         ggml_barrier(params->threadpool);
 
-        float * gemm_output = (float *) ((char *) tmp + patches_per_batch * knl_n * traits->type_size);
+        float* gemm_output = (float*)((char*)tmp + patches_per_batch * knl_n * traits->type_size);
 
         GGML_ASSERT(gemm_output + patch_n * c_out <= (float*)tmp + params->wsize);
 
@@ -7208,43 +6636,37 @@ static void ggml_compute_forward_conv_2d_impl(const ggml_compute_params * params
         const int64_t permute_end = std::min(permute_start + permute_per_thread, patch_n);
 
         for (int64_t i = permute_start; i < permute_end; ++i) {
-            const int64_t p       = patch_start_batch + i;
+            const int64_t p = patch_start_batch + i;
             const int64_t batch_n = p / (dst_w * dst_h);
-            const int64_t dst_y   = (p / dst_w) % dst_h;
-            const int64_t dst_x   = p % dst_w;
+            const int64_t dst_y = (p / dst_w) % dst_h;
+            const int64_t dst_x = p % dst_w;
 
             for (int64_t oc = 0; oc < c_out; ++oc) {
                 const float value = gemm_output[i * c_out + oc];
-                float * dst_ptr = (float *)((char *)dst_data + dst_x * dst->nb[0] + dst_y * dst->nb[1] + oc * dst->nb[2] + batch_n * dst->nb[3]);
+                float* dst_ptr = (float*)((char*)dst_data + dst_x * dst->nb[0] + dst_y * dst->nb[1] + oc * dst->nb[2] +
+                                          batch_n * dst->nb[3]);
                 *dst_ptr = value;
             }
         }
     }
 }
 
-void ggml_compute_forward_conv_2d(
-        const ggml_compute_params * params,
-        ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
-    const ggml_tensor * src1 = dst->src[1];
+void ggml_compute_forward_conv_2d(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
+    const ggml_tensor* src1 = dst->src[1];
 
     ggml_compute_forward_conv_2d_impl(params, src0, src1, dst, src0->type);
 }
 
 // ggml_compute_forward_conv_3d
 
-static void ggml_compute_forward_conv_3d_impl(const ggml_compute_params * params,
-                                              const ggml_tensor *         kernel,
-                                              const ggml_tensor *         src,
-                                              ggml_tensor *               dst,
-                                              ggml_type                   kernel_type) {
-
+static void ggml_compute_forward_conv_3d_impl(const ggml_compute_params* params, const ggml_tensor* kernel,
+                                              const ggml_tensor* src, ggml_tensor* dst, ggml_type kernel_type) {
     GGML_ASSERT(ggml_is_contiguous(kernel));
     GGML_ASSERT(kernel_type == GGML_TYPE_F16 || kernel_type == GGML_TYPE_F32);
     GGML_ASSERT(kernel->type == kernel_type);
 
-    const ggml_type_traits * traits = ggml_get_type_traits(kernel_type);
+    const ggml_type_traits* traits = ggml_get_type_traits(kernel_type);
 
     const int32_t s0 = dst->op_params[0];
     const int32_t s1 = dst->op_params[1];
@@ -7255,8 +6677,8 @@ static void ggml_compute_forward_conv_3d_impl(const ggml_compute_params * params
     const int32_t d0 = dst->op_params[6];
     const int32_t d1 = dst->op_params[7];
     const int32_t d2 = dst->op_params[8];
-    const int32_t c  = dst->op_params[9];
-    const int32_t n  = dst->op_params[10];
+    const int32_t c = dst->op_params[9];
+    const int32_t n = dst->op_params[10];
     const int32_t oc = dst->op_params[11];
 
     const int64_t src_w = src->ne[0];
@@ -7269,41 +6691,41 @@ static void ggml_compute_forward_conv_3d_impl(const ggml_compute_params * params
     const int64_t dst_h = dst->ne[1];
     const int64_t dst_d = dst->ne[2];
 
-    const float * src_data = (float *) src->data;
-    void  * knl_data       = kernel->data;
-    float * dst_data       = (float *) dst->data;
+    const float* src_data = (float*)src->data;
+    void* knl_data = kernel->data;
+    float* dst_data = (float*)dst->data;
 
     const int64_t knl_n_per_channel = knl_w * knl_h * knl_d;
-    const int64_t knl_n_total       = knl_n_per_channel * c;
-    const int64_t patch_total       = n * dst_w * dst_h * dst_d;
+    const int64_t knl_n_total = knl_n_per_channel * c;
+    const int64_t patch_total = n * dst_w * dst_h * dst_d;
 
-    const int64_t space_per_patch   = knl_n_total * traits->type_size + oc * sizeof(float);
-    const int64_t batch_size        = params->wsize / space_per_patch;
+    const int64_t space_per_patch = knl_n_total * traits->type_size + oc * sizeof(float);
+    const int64_t batch_size = params->wsize / space_per_patch;
     const int64_t patches_per_batch = batch_size > 8 ? (batch_size / 8) * 8 : batch_size;
-    const int64_t batch_n           = (patch_total + patches_per_batch - 1) / patches_per_batch;
+    const int64_t batch_n = (patch_total + patches_per_batch - 1) / patches_per_batch;
 
     GGML_ASSERT(patches_per_batch > 0 && batch_size >= 1);
 
-    void * tmp = params->wdata;
+    void* tmp = params->wdata;
 
     for (int64_t batch_i = 0; batch_i < batch_n; ++batch_i) {
         const int64_t patch_start_batch = batch_i * patches_per_batch;
-        const int64_t patch_end_batch   = std::min(patch_start_batch + patches_per_batch, patch_total);
-        const int64_t patch_n_in_batch  = patch_end_batch - patch_start_batch;
+        const int64_t patch_end_batch = std::min(patch_start_batch + patches_per_batch, patch_total);
+        const int64_t patch_n_in_batch = patch_end_batch - patch_start_batch;
 
-        const int64_t patch_per_thread  = (patch_n_in_batch + params->nth - 1) / params->nth;
-        const int64_t patch_start       = patch_start_batch + params->ith * patch_per_thread;
-        const int64_t patch_end         = std::min(patch_start + patch_per_thread, patch_end_batch);
+        const int64_t patch_per_thread = (patch_n_in_batch + params->nth - 1) / params->nth;
+        const int64_t patch_start = patch_start_batch + params->ith * patch_per_thread;
+        const int64_t patch_end = std::min(patch_start + patch_per_thread, patch_end_batch);
 
         for (int64_t p = patch_start; p < patch_end; ++p) {
             const int64_t p_in_batch = p % (dst_w * dst_h * dst_d);
             const int64_t p_in_depth = p_in_batch % (dst_w * dst_h);
-            const int64_t batch_idx  = p / (dst_w * dst_h * dst_d);
-            const int64_t dst_z      = p_in_batch / (dst_w * dst_h);
-            const int64_t dst_y      = p_in_depth / dst_w;
-            const int64_t dst_x      = p_in_depth % dst_w;
+            const int64_t batch_idx = p / (dst_w * dst_h * dst_d);
+            const int64_t dst_z = p_in_batch / (dst_w * dst_h);
+            const int64_t dst_y = p_in_depth / dst_w;
+            const int64_t dst_x = p_in_depth % dst_w;
 
-            char * dst_row = (char *) tmp + (p % patches_per_batch) * knl_n_total * traits->type_size;
+            char* dst_row = (char*)tmp + (p % patches_per_batch) * knl_n_total * traits->type_size;
 
             for (int64_t ic = 0; ic < c; ++ic) {
                 for (int64_t kz = 0; kz < knl_d; ++kz) {
@@ -7320,15 +6742,17 @@ static void ggml_compute_forward_conv_3d_impl(const ggml_compute_params * params
                                 src_val = 0.0f;
                             } else {
                                 const int64_t cn_idx = batch_idx * c + ic;
-                                const float * src_ptr = (const float *)((const char *)src_data + sx*src->nb[0] + sy*src->nb[1] + sz*src->nb[2] + cn_idx*src->nb[3]);
+                                const float* src_ptr =
+                                    (const float*)((const char*)src_data + sx * src->nb[0] + sy * src->nb[1] +
+                                                   sz * src->nb[2] + cn_idx * src->nb[3]);
                                 src_val = *src_ptr;
                             }
 
-                            char * element_ptr = dst_row + dst_idx * traits->type_size;
+                            char* element_ptr = dst_row + dst_idx * traits->type_size;
                             if (kernel_type == GGML_TYPE_F32) {
-                                *(float *)element_ptr = src_val;
+                                *(float*)element_ptr = src_val;
                             } else if (kernel_type == GGML_TYPE_F16) {
-                                *(ggml_fp16_t *)element_ptr = GGML_CPU_FP32_TO_FP16(src_val);
+                                *(ggml_fp16_t*)element_ptr = GGML_CPU_FP32_TO_FP16(src_val);
                             }
                         }
                     }
@@ -7338,7 +6762,7 @@ static void ggml_compute_forward_conv_3d_impl(const ggml_compute_params * params
 
         ggml_barrier(params->threadpool);
 
-        float * gemm_output = (float *) ((char *) tmp + patches_per_batch * knl_n_total * traits->type_size);
+        float* gemm_output = (float*)((char*)tmp + patches_per_batch * knl_n_total * traits->type_size);
         ggml_call_mul_mat(kernel_type, params, patch_n_in_batch, oc, knl_n_total, tmp, knl_data, gemm_output);
 
         ggml_barrier(params->threadpool);
@@ -7351,47 +6775,43 @@ static void ggml_compute_forward_conv_3d_impl(const ggml_compute_params * params
             const int64_t p = patch_start_batch + i;
             const int64_t p_in_batch = p % (dst_w * dst_h * dst_d);
             const int64_t p_in_depth = p_in_batch % (dst_w * dst_h);
-            const int64_t batch_idx  = p / (dst_w * dst_h * dst_d);
-            const int64_t dst_z      = p_in_batch / (dst_w * dst_h);
-            const int64_t dst_y      = p_in_depth / dst_w;
-            const int64_t dst_x      = p_in_depth % dst_w;
+            const int64_t batch_idx = p / (dst_w * dst_h * dst_d);
+            const int64_t dst_z = p_in_batch / (dst_w * dst_h);
+            const int64_t dst_y = p_in_depth / dst_w;
+            const int64_t dst_x = p_in_depth % dst_w;
 
             for (int64_t ioc = 0; ioc < oc; ++ioc) {
                 const float value = gemm_output[i * oc + ioc];
                 const int64_t ocn_idx = batch_idx * oc + ioc;
-                float * dst_ptr = (float *)((char *)dst_data + dst_x*dst->nb[0] + dst_y*dst->nb[1] + dst_z*dst->nb[2] + ocn_idx*dst->nb[3]);
+                float* dst_ptr = (float*)((char*)dst_data + dst_x * dst->nb[0] + dst_y * dst->nb[1] +
+                                          dst_z * dst->nb[2] + ocn_idx * dst->nb[3]);
                 *dst_ptr = value;
             }
         }
     }
 }
 
-void ggml_compute_forward_conv_3d(
-        const ggml_compute_params * params,
-        ggml_tensor * dst) {
-    const ggml_tensor * src0 = dst->src[0];
-    const ggml_tensor * src1 = dst->src[1];
+void ggml_compute_forward_conv_3d(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
+    const ggml_tensor* src1 = dst->src[1];
     ggml_compute_forward_conv_3d_impl(params, src0, src1, dst, src0->type);
 }
 
 template <typename kernel_t>
-static void ggml_compute_forward_conv_transpose_2d_impl(
-    const ggml_compute_params * params,
-          ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
-    const ggml_tensor * src1 = dst->src[1];
+static void ggml_compute_forward_conv_transpose_2d_impl(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
+    const ggml_tensor* src1 = dst->src[1];
 
     GGML_ASSERT(src0->type == GGML_TYPE_F16 || src0->type == GGML_TYPE_F32);
     GGML_ASSERT(src1->type == GGML_TYPE_F32);
-    GGML_ASSERT( dst->type == GGML_TYPE_F32);
+    GGML_ASSERT(dst->type == GGML_TYPE_F32);
 
     GGML_TENSOR_BINARY_OP_LOCALS
 
     const int ith = params->ith;
     const int nth = params->nth;
 
-    const int nk = ne00*ne01*ne02*ne03;
+    const int nk = ne00 * ne01 * ne02 * ne03;
 
     GGML_ASSERT(nb00 == ggml_type_size(src0->type));
     GGML_ASSERT(nb10 == sizeof(float));
@@ -7401,15 +6821,15 @@ static void ggml_compute_forward_conv_transpose_2d_impl(
 
         // permute kernel data (src0) from (Kw x Kh x Cout x Cin) to (Cin x Kw x Kh x Cout)
         {
-            kernel_t * const wdata = (kernel_t *) params->wdata + 0;
+            kernel_t* const wdata = (kernel_t*)params->wdata + 0;
 
             for (int64_t i03 = 0; i03 < ne03; i03++) {
                 for (int64_t i02 = 0; i02 < ne02; i02++) {
-                    const kernel_t * const src = (kernel_t *)((char *) src0->data + i03*nb03 + i02*nb02);
-                    kernel_t * dst_data = wdata + i02*ne01*ne00*ne03;
+                    const kernel_t* const src = (kernel_t*)((char*)src0->data + i03 * nb03 + i02 * nb02);
+                    kernel_t* dst_data = wdata + i02 * ne01 * ne00 * ne03;
                     for (int64_t i01 = 0; i01 < ne01; i01++) {
                         for (int64_t i00 = 0; i00 < ne00; i00++) {
-                            dst_data[i01*ne00*ne03 + i00*ne03 + i03] = src[i01 * ne00 + i00];
+                            dst_data[i01 * ne00 * ne03 + i00 * ne03 + i03] = src[i01 * ne00 + i00];
                         }
                     }
                 }
@@ -7418,16 +6838,16 @@ static void ggml_compute_forward_conv_transpose_2d_impl(
 
         // permute source data (src1) from (Sw x Sh x Cin) to (Cin x Sw x Sh)
         {
-            kernel_t * const wdata = (kernel_t *) params->wdata + nk;
+            kernel_t* const wdata = (kernel_t*)params->wdata + nk;
             for (int i12 = 0; i12 < ne12; i12++) {
                 for (int i11 = 0; i11 < ne11; i11++) {
-                    const float * const src = (float *)((char *) src1->data + i12*nb12 + i11*nb11);
-                    kernel_t * dst_data = wdata + i11*ne10*ne12;
+                    const float* const src = (float*)((char*)src1->data + i12 * nb12 + i11 * nb11);
+                    kernel_t* dst_data = wdata + i11 * ne10 * ne12;
                     for (int i10 = 0; i10 < ne10; i10++) {
                         if constexpr (std::is_same_v<kernel_t, ggml_fp16_t>) {
-                            dst_data[i10*ne12 + i12] = GGML_CPU_FP32_TO_FP16(src[i10]);
+                            dst_data[i10 * ne12 + i12] = GGML_CPU_FP32_TO_FP16(src[i10]);
                         } else {
-                            dst_data[i10*ne12 + i12] = src[i10];
+                            dst_data[i10 * ne12 + i12] = src[i10];
                         }
                     }
                 }
@@ -7444,34 +6864,32 @@ static void ggml_compute_forward_conv_transpose_2d_impl(
     const int np = ne2;
 
     // patches per thread
-    const int dp = (np + nth - 1)/nth;
+    const int dp = (np + nth - 1) / nth;
 
     // patch range for this thread
-    const int ip0 = dp*ith;
+    const int ip0 = dp * ith;
     const int ip1 = MIN(ip0 + dp, np);
 
-    kernel_t * const wdata = (kernel_t *) params->wdata + 0;
-    kernel_t * const wdata_src = wdata + nk;
+    kernel_t* const wdata = (kernel_t*)params->wdata + 0;
+    kernel_t* const wdata_src = wdata + nk;
 
     for (int i2 = ip0; i2 < ip1; i2++) { // Cout
-        float * dst_data = (float *)((char *) dst->data + i2*nb2);
-        kernel_t * wdata_kernel = wdata + i2*ne01*ne00*ne03;
+        float* dst_data = (float*)((char*)dst->data + i2 * nb2);
+        kernel_t* wdata_kernel = wdata + i2 * ne01 * ne00 * ne03;
         for (int i11 = 0; i11 < ne11; i11++) {
             for (int i10 = 0; i10 < ne10; i10++) {
-                const int i1n = i11*ne10*ne12 + i10*ne12;
+                const int i1n = i11 * ne10 * ne12 + i10 * ne12;
                 for (int i01 = 0; i01 < ne01; i01++) {
                     for (int i00 = 0; i00 < ne00; i00++) {
                         float v = 0;
                         if constexpr (std::is_same_v<kernel_t, ggml_fp16_t>) {
-                            ggml_vec_dot_f16(ne03, &v, 0,
-                                    wdata_src + i1n, 0,
-                                    wdata_kernel + i01*ne00*ne03 + i00*ne03, 0, 1);
+                            ggml_vec_dot_f16(ne03, &v, 0, wdata_src + i1n, 0,
+                                             wdata_kernel + i01 * ne00 * ne03 + i00 * ne03, 0, 1);
                         } else {
-                            ggml_vec_dot_f32(ne03, &v, 0,
-                                    wdata_src + i1n, 0,
-                                    wdata_kernel + i01*ne00*ne03 + i00*ne03, 0, 1);
+                            ggml_vec_dot_f32(ne03, &v, 0, wdata_src + i1n, 0,
+                                             wdata_kernel + i01 * ne00 * ne03 + i00 * ne03, 0, 1);
                         }
-                        dst_data[(i11*stride + i01)*ne0 + i10*stride + i00] += v;
+                        dst_data[(i11 * stride + i01) * ne0 + i10 * stride + i00] += v;
                     }
                 }
             }
@@ -7479,25 +6897,19 @@ static void ggml_compute_forward_conv_transpose_2d_impl(
     }
 }
 
-void ggml_compute_forward_conv_transpose_2d(
-        const ggml_compute_params * params,
-              ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
+void ggml_compute_forward_conv_transpose_2d(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
 
     switch (src0->type) {
-        case GGML_TYPE_F16:
-            {
-                ggml_compute_forward_conv_transpose_2d_impl<ggml_fp16_t>(params, dst);
-            } break;
-        case GGML_TYPE_F32:
-            {
-                ggml_compute_forward_conv_transpose_2d_impl<float>(params, dst);
-            } break;
-        default:
-            {
-                GGML_ABORT("fatal error");
-            }
+    case GGML_TYPE_F16: {
+        ggml_compute_forward_conv_transpose_2d_impl<ggml_fp16_t>(params, dst);
+    } break;
+    case GGML_TYPE_F32: {
+        ggml_compute_forward_conv_transpose_2d_impl<float>(params, dst);
+    } break;
+    default: {
+        GGML_ABORT("fatal error");
+    }
     }
 }
 
@@ -7520,15 +6932,11 @@ struct ggml_conv_2d_dw_params {
     int dilation_y;
 };
 
-static void ggml_compute_forward_conv_2d_dw_cwhn(
-        const ggml_compute_params * params,
-        const ggml_tensor * src,
-        const ggml_tensor * kernel,
-        ggml_tensor * dst,
-        const ggml_conv_2d_dw_params & p) {
-
+static void ggml_compute_forward_conv_2d_dw_cwhn(const ggml_compute_params* params, const ggml_tensor* src,
+                                                 const ggml_tensor* kernel, ggml_tensor* dst,
+                                                 const ggml_conv_2d_dw_params& p) {
     const int64_t c = p.channels;
-    const float * knl_data = (const float *)kernel->data;
+    const float* knl_data = (const float*)kernel->data;
 
     const int64_t rows_total = p.dst_h * p.batch;
     const int64_t rows_per_thread = (rows_total + params->nth - 1) / params->nth;
@@ -7536,11 +6944,11 @@ static void ggml_compute_forward_conv_2d_dw_cwhn(
     const int64_t row_end = MIN(row_start + rows_per_thread, rows_total);
 
 #ifdef GGML_SIMD
-    #if defined(__ARM_FEATURE_SVE)
-        const int64_t pkg_size = svcntw();
-    #else
-        const int64_t pkg_size = GGML_F32_EPR;
-    #endif
+#if defined(__ARM_FEATURE_SVE)
+    const int64_t pkg_size = svcntw();
+#else
+    const int64_t pkg_size = GGML_F32_EPR;
+#endif
     const int64_t pkg_count = c / pkg_size;
     const int64_t c_pkg_end = pkg_count * pkg_size;
 #else
@@ -7549,9 +6957,9 @@ static void ggml_compute_forward_conv_2d_dw_cwhn(
 
     for (int64_t row = row_start; row < row_end; ++row) {
         const int64_t dst_y = row % p.dst_h;
-        const float * src_data = (const float *)src->data + (row / p.dst_h) * p.src_w * p.src_h * c;
+        const float* src_data = (const float*)src->data + (row / p.dst_h) * p.src_w * p.src_h * c;
         for (int64_t dst_x = 0; dst_x < p.dst_w; ++dst_x) {
-            float * dst_data = (float *)dst->data + (row * p.dst_w + dst_x) * c;
+            float* dst_data = (float*)dst->data + (row * p.dst_w + dst_x) * c;
             const int64_t src_y_base = dst_y * p.stride_y - p.pad_y;
             const int64_t src_x_base = dst_x * p.stride_x - p.pad_x;
 
@@ -7590,8 +6998,8 @@ static void ggml_compute_forward_conv_2d_dw_cwhn(
                         if (src_x < 0 || src_x >= p.src_w) {
                             continue;
                         }
-                        sum += knl_data[(knl_y * p.knl_w + knl_x) * c + c_i]
-                             * src_data[(src_y * p.src_w + src_x) * c + c_i];
+                        sum += knl_data[(knl_y * p.knl_w + knl_x) * c + c_i] *
+                               src_data[(src_y * p.src_w + src_x) * c + c_i];
                     }
                 }
                 dst_data[c_i] = sum;
@@ -7600,26 +7008,21 @@ static void ggml_compute_forward_conv_2d_dw_cwhn(
     }
 }
 
-static void ggml_compute_forward_conv_2d_dw_whcn(
-        const ggml_compute_params * params,
-        const ggml_tensor * src,
-        const ggml_tensor * kernel,
-        ggml_tensor * dst,
-        const ggml_conv_2d_dw_params & p) {
-
+static void ggml_compute_forward_conv_2d_dw_whcn(const ggml_compute_params* params, const ggml_tensor* src,
+                                                 const ggml_tensor* kernel, ggml_tensor* dst,
+                                                 const ggml_conv_2d_dw_params& p) {
     const int64_t n = p.channels * p.batch;
     const int64_t per_thread = (n + params->nth - 1) / params->nth;
     const int64_t start = params->ith * per_thread;
     const int64_t end = MIN(start + per_thread, n);
 
     for (int64_t i = start; i < end; ++i) {
-        const float * knl_data = (const float *)kernel->data + (i % p.channels) * p.knl_w * p.knl_h;
-        const float * src_data = (const float *)src->data + i * p.src_w * p.src_h;
-        float * dst_data = (float *)dst->data + i * p.dst_w * p.dst_h;
+        const float* knl_data = (const float*)kernel->data + (i % p.channels) * p.knl_w * p.knl_h;
+        const float* src_data = (const float*)src->data + i * p.src_w * p.src_h;
+        float* dst_data = (float*)dst->data + i * p.dst_w * p.dst_h;
 
         for (int64_t dst_y = 0; dst_y < p.dst_h; ++dst_y) {
             for (int64_t dst_x = 0; dst_x < p.dst_w; ++dst_x) {
-
                 float sum = 0.0f;
                 for (int64_t knl_y = 0; knl_y < p.knl_h; ++knl_y) {
                     const int64_t src_y = dst_y * p.stride_y + knl_y * p.dilation_y - p.pad_y;
@@ -7631,8 +7034,7 @@ static void ggml_compute_forward_conv_2d_dw_whcn(
                         if (src_x < 0 || src_x >= p.src_w) {
                             continue;
                         }
-                        sum += knl_data[knl_y * p.knl_w + knl_x]
-                             * src_data[src_y * p.src_w + src_x];
+                        sum += knl_data[knl_y * p.knl_w + knl_x] * src_data[src_y * p.src_w + src_x];
                     }
                 }
                 dst_data[dst_y * p.dst_w + dst_x] = sum;
@@ -7641,12 +7043,9 @@ static void ggml_compute_forward_conv_2d_dw_whcn(
     }
 }
 
-void ggml_compute_forward_conv_2d_dw(
-        const ggml_compute_params * params,
-        ggml_tensor * dst) {
-
-    const ggml_tensor * kernel = dst->src[0];
-    const ggml_tensor * src = dst->src[1];
+void ggml_compute_forward_conv_2d_dw(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* kernel = dst->src[0];
+    const ggml_tensor* src = dst->src[1];
     ggml_conv_2d_dw_params p;
     p.channels = src->ne[2];
     p.batch = src->ne[3];
@@ -7678,15 +7077,9 @@ void ggml_compute_forward_conv_2d_dw(
 }
 
 // ggml_compute_forward_pool_1d_ksp
-static void ggml_compute_forward_pool_1d_ksp(
-        const ggml_compute_params * params,
-        const ggml_op_pool op,
-        const int k,
-        const int s,
-        const int p,
-        ggml_tensor * dst) {
-
-    const ggml_tensor * src = dst->src[0];
+static void ggml_compute_forward_pool_1d_ksp(const ggml_compute_params* params, const ggml_op_pool op, const int k,
+                                             const int s, const int p, ggml_tensor* dst) {
+    const ggml_tensor* src = dst->src[0];
 
     assert(src->type == GGML_TYPE_F32 || src->type == GGML_TYPE_F16);
 
@@ -7700,46 +7093,60 @@ static void ggml_compute_forward_pool_1d_ksp(
     const int64_t nr = ggml_nrows(src);
 
     for (int64_t ir = 0; ir < nr; ++ir) {
-        const char * srow_bytes =            (const char *) src->data + ir * src->nb[1];
-        float      * drow       = (float *) ((      char *) dst->data + ir * dst->nb[1]);
+        const char* srow_bytes = (const char*)src->data + ir * src->nb[1];
+        float* drow = (float*)((char*)dst->data + ir * dst->nb[1]);
 
         for (int64_t ow = 0; ow < OW; ++ow) {
             float res = 0;
             switch (op) {
-                case GGML_OP_POOL_AVG: res = 0.0f;     break;
-                case GGML_OP_POOL_MAX: res = -FLT_MAX; break;
-                case GGML_OP_POOL_COUNT: GGML_ABORT("fatal error");
+            case GGML_OP_POOL_AVG:
+                res = 0.0f;
+                break;
+            case GGML_OP_POOL_MAX:
+                res = -FLT_MAX;
+                break;
+            case GGML_OP_POOL_COUNT:
+                GGML_ABORT("fatal error");
             }
 
             int count = 0;
-            const int base = (int) ow * s - p;
+            const int base = (int)ow * s - p;
 
             for (int ki = 0; ki < k; ++ki) {
                 const int j = base + ki;
-                if (j < 0 || j >= (int) IW) {
+                if (j < 0 || j >= (int)IW) {
                     continue;
                 }
 
                 float v;
                 if (src->type == GGML_TYPE_F32) {
-                    v = ((const float *) srow_bytes)[j];
+                    v = ((const float*)srow_bytes)[j];
                 } else {
-                    v = GGML_CPU_FP16_TO_FP32(((const ggml_fp16_t *) srow_bytes)[j]);
+                    v = GGML_CPU_FP16_TO_FP32(((const ggml_fp16_t*)srow_bytes)[j]);
                 }
 
                 switch (op) {
-                    case GGML_OP_POOL_AVG: res += v;                break;
-                    case GGML_OP_POOL_MAX: res =  std::max(v, res); break;
-                    case GGML_OP_POOL_COUNT: GGML_ABORT("fatal error");
+                case GGML_OP_POOL_AVG:
+                    res += v;
+                    break;
+                case GGML_OP_POOL_MAX:
+                    res = std::max(v, res);
+                    break;
+                case GGML_OP_POOL_COUNT:
+                    GGML_ABORT("fatal error");
                 }
 
                 ++count;
             }
 
             switch (op) {
-                case GGML_OP_POOL_AVG: res = (count > 0) ? (res / count) : 0.0f; break;
-                case GGML_OP_POOL_MAX:                                           break;
-                case GGML_OP_POOL_COUNT: GGML_ABORT("fatal error");
+            case GGML_OP_POOL_AVG:
+                res = (count > 0) ? (res / count) : 0.0f;
+                break;
+            case GGML_OP_POOL_MAX:
+                break;
+            case GGML_OP_POOL_COUNT:
+                GGML_ABORT("fatal error");
             }
 
             drow[ow] = res;
@@ -7749,11 +7156,8 @@ static void ggml_compute_forward_pool_1d_ksp(
 
 // ggml_compute_forward_pool_1d
 
-void ggml_compute_forward_pool_1d(
-        const ggml_compute_params * params,
-              ggml_tensor * dst) {
-
-    const int32_t * opts = (const int32_t *)dst->op_params;
+void ggml_compute_forward_pool_1d(const ggml_compute_params* params, ggml_tensor* dst) {
+    const int32_t* opts = (const int32_t*)dst->op_params;
     ggml_op_pool op = static_cast<ggml_op_pool>(opts[0]);
     const int k0 = opts[1];
     const int s0 = opts[2];
@@ -7764,11 +7168,8 @@ void ggml_compute_forward_pool_1d(
 
 // ggml_compute_forward_pool_2d
 
-void ggml_compute_forward_pool_2d(
-        const ggml_compute_params * params,
-        ggml_tensor * dst) {
-
-    const ggml_tensor * src = dst->src[0];
+void ggml_compute_forward_pool_2d(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src = dst->src[0];
 
     assert(src->type == GGML_TYPE_F32 || src->type == GGML_TYPE_F16);
 
@@ -7776,7 +7177,7 @@ void ggml_compute_forward_pool_2d(
         return;
     }
 
-    const int32_t * opts = (const int32_t *)dst->op_params;
+    const int32_t* opts = (const int32_t*)dst->op_params;
 
     ggml_op_pool op = static_cast<ggml_op_pool>(opts[0]);
     const int k0 = opts[1];
@@ -7785,14 +7186,14 @@ void ggml_compute_forward_pool_2d(
     const int s1 = opts[4];
     const int p0 = opts[5];
     const int p1 = opts[6];
-    const char * cdata = (const char*)src->data;
-    const char * const data_end = cdata + ggml_nbytes(src);
+    const char* cdata = (const char*)src->data;
+    const char* const data_end = cdata + ggml_nbytes(src);
 
     const int64_t px = dst->ne[0];
     const int64_t py = dst->ne[1];
     const int64_t pa = px * py;
 
-    float * dplane = (float *)dst->data;
+    float* dplane = (float*)dst->data;
 
     const int ka = k0 * k1;
     const int offset0 = -p0;
@@ -7800,15 +7201,20 @@ void ggml_compute_forward_pool_2d(
 
     while (cdata < data_end) {
         for (int oy = 0; oy < py; ++oy) {
-            float * const drow = dplane + oy * px;
-            float * const out  = drow;
+            float* const drow = dplane + oy * px;
+            float* const out = drow;
 
             for (int ox = 0; ox < px; ++ox) {
                 float res = 0;
                 switch (op) {
-                    case GGML_OP_POOL_AVG: res = 0;        break;
-                    case GGML_OP_POOL_MAX: res = -FLT_MAX; break;
-                    case GGML_OP_POOL_COUNT: GGML_ABORT("fatal error");
+                case GGML_OP_POOL_AVG:
+                    res = 0;
+                    break;
+                case GGML_OP_POOL_MAX:
+                    res = -FLT_MAX;
+                    break;
+                case GGML_OP_POOL_COUNT:
+                    GGML_ABORT("fatal error");
                 }
 
                 const int ix = offset0 + ox * s0;
@@ -7819,44 +7225,52 @@ void ggml_compute_forward_pool_2d(
                         continue;
                     }
 
-                    const void * srow = (const void *)(cdata + src->nb[1] * (iy + ky));
+                    const void* srow = (const void*)(cdata + src->nb[1] * (iy + ky));
                     for (int kx = 0; kx < k0; ++kx) {
                         int j = ix + kx;
                         if (j < 0 || j >= src->ne[0]) {
                             continue;
                         }
 
-                        const float srow_j = (src->type == GGML_TYPE_F32) ? ((const float*)srow)[j] : GGML_CPU_FP16_TO_FP32(((const ggml_fp16_t*)srow)[j]);
+                        const float srow_j = (src->type == GGML_TYPE_F32)
+                                                 ? ((const float*)srow)[j]
+                                                 : GGML_CPU_FP16_TO_FP32(((const ggml_fp16_t*)srow)[j]);
                         switch (op) {
-                            case GGML_OP_POOL_AVG: res += srow_j;                break;
-                            case GGML_OP_POOL_MAX: res =  std::max(srow_j, res); break;
-                            case GGML_OP_POOL_COUNT:               GGML_ABORT("fatal error");
+                        case GGML_OP_POOL_AVG:
+                            res += srow_j;
+                            break;
+                        case GGML_OP_POOL_MAX:
+                            res = std::max(srow_j, res);
+                            break;
+                        case GGML_OP_POOL_COUNT:
+                            GGML_ABORT("fatal error");
                         }
                     }
                 }
                 switch (op) {
-                    case GGML_OP_POOL_AVG:           res /= ka; break;
-                    case GGML_OP_POOL_MAX:                      break;
-                    case GGML_OP_POOL_COUNT: GGML_ABORT("fatal error");
+                case GGML_OP_POOL_AVG:
+                    res /= ka;
+                    break;
+                case GGML_OP_POOL_MAX:
+                    break;
+                case GGML_OP_POOL_COUNT:
+                    GGML_ABORT("fatal error");
                 }
 
                 out[ox] = res;
             }
         }
 
-        cdata  += src->nb[2];
+        cdata += src->nb[2];
         dplane += pa;
     }
 }
 
 // ggml_compute_forward_pool_2d_back
 
-void ggml_compute_forward_pool_2d_back(
-        const ggml_compute_params * params,
-        ggml_tensor * dst) {
-
-    const ggml_tensor * src  = dst->src[0];
-    const ggml_tensor * dstf = dst->src[1]; // forward tensor of dst
+void ggml_compute_forward_pool_2d_back(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src = dst->src[0];
+    const ggml_tensor* dstf = dst->src[1]; // forward tensor of dst
 
     assert(dst->type == GGML_TYPE_F32 || dst->type == GGML_TYPE_F16);
 
@@ -7864,7 +7278,7 @@ void ggml_compute_forward_pool_2d_back(
         return;
     }
 
-    const int32_t * opts = (const int32_t *)dst->op_params;
+    const int32_t* opts = (const int32_t*)dst->op_params;
     ggml_op_pool op = static_cast<ggml_op_pool>(opts[0]);
     const int k0 = opts[1];
     const int k1 = opts[2];
@@ -7873,9 +7287,9 @@ void ggml_compute_forward_pool_2d_back(
     const int p0 = opts[5];
     const int p1 = opts[6];
 
-    char       * cdata  = (char       *) dst->data;
-    const char * cdataf = (const char *) dstf->data;
-    const char * const data_end = cdata + ggml_nbytes(dst);
+    char* cdata = (char*)dst->data;
+    const char* cdataf = (const char*)dstf->data;
+    const char* const data_end = cdata + ggml_nbytes(dst);
 
     GGML_ASSERT(params->ith == 0);
     memset(cdata, 0, ggml_nbytes(dst));
@@ -7884,7 +7298,7 @@ void ggml_compute_forward_pool_2d_back(
     const int64_t py = src->ne[1];
     const int64_t pa = px * py;
 
-    const float * splane = (const float *) src->data;
+    const float* splane = (const float*)src->data;
 
     const int ka = k0 * k1;
     const int offset0 = -p0;
@@ -7892,7 +7306,7 @@ void ggml_compute_forward_pool_2d_back(
 
     while (cdata < data_end) {
         for (int oy = 0; oy < py; ++oy) {
-            const float * const srow = splane + oy * px;
+            const float* const srow = splane + oy * px;
             for (int ox = 0; ox < px; ++ox) {
                 const float grad0 = srow[ox];
 
@@ -7908,15 +7322,16 @@ void ggml_compute_forward_pool_2d_back(
                         if (iy + ky < 0 || iy + ky >= dst->ne[1]) {
                             continue;
                         }
-                        const void * drowf = (const void *)(cdataf + dst->nb[1] * (iy + ky));
+                        const void* drowf = (const void*)(cdataf + dst->nb[1] * (iy + ky));
                         for (int kx = 0; kx < k0; ++kx) {
                             int j = ix + kx;
                             if (j < 0 || j >= dst->ne[0]) {
                                 continue;
                             }
 
-                            const float val = dst->type == GGML_TYPE_F32 ?
-                                ((const float *) drowf)[j] : GGML_CPU_FP16_TO_FP32(((const ggml_fp16_t *) drowf)[j]);
+                            const float val = dst->type == GGML_TYPE_F32
+                                                  ? ((const float*)drowf)[j]
+                                                  : GGML_CPU_FP16_TO_FP32(((const ggml_fp16_t*)drowf)[j]);
                             if (val <= maxval) {
                                 continue;
                             }
@@ -7931,12 +7346,13 @@ void ggml_compute_forward_pool_2d_back(
                         continue;
                     }
 
-                    void * drow = (void *)(cdata + dst->nb[1] * (iy + kymax));
+                    void* drow = (void*)(cdata + dst->nb[1] * (iy + kymax));
                     const int j = ix + kxmax;
                     if (dst->type == GGML_TYPE_F32) {
-                        ((float *) drow)[j] += grad0;
+                        ((float*)drow)[j] += grad0;
                     } else {
-                        ((ggml_fp16_t *) drow)[j] = GGML_CPU_FP32_TO_FP16(grad0 + GGML_CPU_FP16_TO_FP32(((const ggml_fp16_t *) drow)[j]));
+                        ((ggml_fp16_t*)drow)[j] =
+                            GGML_CPU_FP32_TO_FP16(grad0 + GGML_CPU_FP16_TO_FP32(((const ggml_fp16_t*)drow)[j]));
                     }
                 } else if (op == GGML_OP_POOL_AVG) {
                     const float grad = grad0 / ka;
@@ -7945,7 +7361,7 @@ void ggml_compute_forward_pool_2d_back(
                         if (iy + ky < 0 || iy + ky >= dst->ne[1]) {
                             continue;
                         }
-                        void * drow = (void *)(cdata + dst->nb[1] * (iy + ky));
+                        void* drow = (void*)(cdata + dst->nb[1] * (iy + ky));
                         for (int kx = 0; kx < k0; ++kx) {
                             int j = ix + kx;
                             if (j < 0 || j >= dst->ne[0]) {
@@ -7953,9 +7369,9 @@ void ggml_compute_forward_pool_2d_back(
                             }
 
                             if (dst->type == GGML_TYPE_F32) {
-                                ((float *) drow)[j] += grad;
+                                ((float*)drow)[j] += grad;
                             } else {
-                                ((ggml_fp16_t *) drow)[j] += GGML_CPU_FP32_TO_FP16(grad);
+                                ((ggml_fp16_t*)drow)[j] += GGML_CPU_FP32_TO_FP16(grad);
                             }
                         }
                     }
@@ -7965,7 +7381,7 @@ void ggml_compute_forward_pool_2d_back(
             }
         }
 
-        cdata  += dst->nb[2];
+        cdata += dst->nb[2];
         cdataf += dst->nb[2];
         splane += pa;
     }
@@ -7973,11 +7389,8 @@ void ggml_compute_forward_pool_2d_back(
 
 // ggml_compute_forward_upscale
 
-static void ggml_compute_forward_upscale_f32(
-    const ggml_compute_params * params,
-    ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
+static void ggml_compute_forward_upscale_f32(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
 
     GGML_ASSERT(src0->type == GGML_TYPE_F32);
 
@@ -7986,14 +7399,14 @@ static void ggml_compute_forward_upscale_f32(
 
     GGML_TENSOR_UNARY_OP_LOCALS
 
-    float sf0 = (float)ne0/src0->ne[0];
-    float sf1 = (float)ne1/src0->ne[1];
-    float sf2 = (float)ne2/src0->ne[2];
-    float sf3 = (float)ne3/src0->ne[3];
+    float sf0 = (float)ne0 / src0->ne[0];
+    float sf1 = (float)ne1 / src0->ne[1];
+    float sf2 = (float)ne2 / src0->ne[2];
+    float sf3 = (float)ne3 / src0->ne[3];
     float pixel_offset = 0.5f;
 
     const int32_t mode_flags = ggml_get_op_params_i32(dst, 0);
-    const ggml_scale_mode mode = (ggml_scale_mode) (mode_flags & 0xFF);
+    const ggml_scale_mode mode = (ggml_scale_mode)(mode_flags & 0xFF);
 
     if (mode_flags & GGML_SCALE_FLAG_ALIGN_CORNERS) {
         pixel_offset = 0.0f;
@@ -8011,8 +7424,9 @@ static void ggml_compute_forward_upscale_f32(
                     for (int64_t i0 = 0; i0 < ne0; i0++) {
                         const int64_t i00 = i0 / sf0;
 
-                        const float * x = (float *)((char *) src0->data + i00*nb00 + i01*nb01 + i02*nb02 + i03*nb03);
-                              float * y = (float *)((char *)  dst->data +  i0*nb0  +  i1*nb1  +  i2*nb2  +  i3*nb3);
+                        const float* x =
+                            (float*)((char*)src0->data + i00 * nb00 + i01 * nb01 + i02 * nb02 + i03 * nb03);
+                        float* y = (float*)((char*)dst->data + i0 * nb0 + i1 * nb1 + i2 * nb2 + i3 * nb3);
 
                         *y = *x;
                     }
@@ -8022,14 +7436,12 @@ static void ggml_compute_forward_upscale_f32(
     } else if (mode == GGML_SCALE_MODE_BILINEAR && (mode_flags & GGML_SCALE_FLAG_ANTIALIAS)) {
         // Similar to F.interpolate(..., mode="bilinear", align_corners=False, antialias=True)
         // https://github.com/pytorch/pytorch/blob/8871ff29b743948d1225389d5b7068f37b22750b/aten/src/ATen/native/cpu/UpSampleKernel.cpp
-        auto triangle_filter = [](float x) -> float {
-            return std::max(1.0f - fabsf(x), 0.0f);
-        };
+        auto triangle_filter = [](float x) -> float { return std::max(1.0f - fabsf(x), 0.0f); };
 
         // support and invscale, minimum 1 pixel for bilinear
-        const float support1  = std::max(1.0f, 1.0f / sf1);
+        const float support1 = std::max(1.0f, 1.0f / sf1);
         const float invscale1 = 1.0f / support1;
-        const float support0  = std::max(1.0f, 1.0f / sf0);
+        const float support0 = std::max(1.0f, 1.0f / sf0);
         const float invscale0 = 1.0f / support0;
 
         for (int64_t i3 = 0; i3 < ne3; i3++) {
@@ -8037,9 +7449,9 @@ static void ggml_compute_forward_upscale_f32(
             for (int64_t i2 = ith; i2 < ne2; i2 += nth) {
                 const int64_t i02 = i2 / sf2;
                 for (int64_t i1 = 0; i1 < ne1; i1++) {
-                    const float y = ((float) i1 + pixel_offset) / sf1;
+                    const float y = ((float)i1 + pixel_offset) / sf1;
                     for (int64_t i0 = 0; i0 < ne0; i0++) {
-                        const float x = ((float) i0 + pixel_offset) / sf0;
+                        const float x = ((float)i0 + pixel_offset) / sf0;
 
                         // the range of source pixels that contribute
                         const int64_t x_min = std::max<int64_t>(x - support0 + pixel_offset, 0);
@@ -8062,7 +7474,8 @@ static void ggml_compute_forward_upscale_f32(
                                     continue;
                                 }
 
-                                const float pixel = *(const float *)((const char *)src0->data + sx*nb00 + sy*nb01 + i02*nb02 + i03*nb03);
+                                const float pixel = *(const float*)((const char*)src0->data + sx * nb00 + sy * nb01 +
+                                                                    i02 * nb02 + i03 * nb03);
                                 val += pixel * weight;
                                 total_weight += weight;
                             }
@@ -8072,7 +7485,7 @@ static void ggml_compute_forward_upscale_f32(
                             val /= total_weight;
                         }
 
-                        float * dst_ptr = (float *)((char *)dst->data + i0*nb0 + i1*nb1 + i2*nb2 + i3*nb3);
+                        float* dst_ptr = (float*)((char*)dst->data + i0 * nb0 + i1 * nb1 + i2 * nb2 + i3 * nb3);
                         *dst_ptr = val;
                     }
                 }
@@ -8106,14 +7519,18 @@ static void ggml_compute_forward_upscale_f32(
                         dx = std::max(0.0f, std::min(dx, 1.0f));
 
                         // fetch the four surrounding pixel values and interpolate
-                        const float a = *(const float *)((const char *)src0->data + x0*nb00 + y0*nb01 + i02*nb02 + i03*nb03);
-                        const float b = *(const float *)((const char *)src0->data + x1*nb00 + y0*nb01 + i02*nb02 + i03*nb03);
-                        const float c = *(const float *)((const char *)src0->data + x0*nb00 + y1*nb01 + i02*nb02 + i03*nb03);
-                        const float d = *(const float *)((const char *)src0->data + x1*nb00 + y1*nb01 + i02*nb02 + i03*nb03);
+                        const float a =
+                            *(const float*)((const char*)src0->data + x0 * nb00 + y0 * nb01 + i02 * nb02 + i03 * nb03);
+                        const float b =
+                            *(const float*)((const char*)src0->data + x1 * nb00 + y0 * nb01 + i02 * nb02 + i03 * nb03);
+                        const float c =
+                            *(const float*)((const char*)src0->data + x0 * nb00 + y1 * nb01 + i02 * nb02 + i03 * nb03);
+                        const float d =
+                            *(const float*)((const char*)src0->data + x1 * nb00 + y1 * nb01 + i02 * nb02 + i03 * nb03);
 
-                        const float val = a*(1 - dx)*(1 - dy) + b*dx*(1 - dy) + c*(1 - dx)*dy + d*dx*dy;
+                        const float val = a * (1 - dx) * (1 - dy) + b * dx * (1 - dy) + c * (1 - dx) * dy + d * dx * dy;
 
-                        float * y_dst = (float *)((char *)dst->data + i0*nb0 + i1*nb1 + i2*nb2 + i3*nb3);
+                        float* y_dst = (float*)((char*)dst->data + i0 * nb0 + i1 * nb1 + i2 * nb2 + i3 * nb3);
                         *y_dst = val;
                     }
                 }
@@ -8129,7 +7546,7 @@ static void ggml_compute_forward_upscale_f32(
             const float w1 = weight1(x + 0);
             const float w2 = weight1(1 - x);
             const float w3 = weight2(2 - x);
-            return p0*w0 + p1*w1 + p2*w2 + p3*w3;
+            return p0 * w0 + p1 * w1 + p2 * w2 + p3 * w3;
         };
 
         for (int64_t i3 = 0; i3 < ne3; i3++) {
@@ -8149,16 +7566,16 @@ static void ggml_compute_forward_upscale_f32(
                         auto p = [=](int64_t x_off, int64_t y_off) -> float {
                             int64_t i00 = std::max(int64_t(0), std::min(x0 + x_off, ne00 - 1));
                             int64_t i01 = std::max(int64_t(0), std::min(y0 + y_off, ne01 - 1));
-                            return *(const float *)((const char *)src0->data + i00*nb00 + i01*nb01 + i02*nb02 + i03*nb03);
+                            return *(const float*)((const char*)src0->data + i00 * nb00 + i01 * nb01 + i02 * nb02 +
+                                                   i03 * nb03);
                         };
 
-                        const float val = bicubic(
-                            bicubic(p(-1,-1), p(0,-1), p(1,-1), p(2,-1), dx),
-                            bicubic(p(-1, 0), p(0, 0), p(1, 0), p(2, 0), dx),
-                            bicubic(p(-1, 1), p(0, 1), p(1, 1), p(2, 1), dx),
-                            bicubic(p(-1, 2), p(0, 2), p(1, 2), p(2, 2), dx), dy);
+                        const float val = bicubic(bicubic(p(-1, -1), p(0, -1), p(1, -1), p(2, -1), dx),
+                                                  bicubic(p(-1, 0), p(0, 0), p(1, 0), p(2, 0), dx),
+                                                  bicubic(p(-1, 1), p(0, 1), p(1, 1), p(2, 1), dx),
+                                                  bicubic(p(-1, 2), p(0, 2), p(1, 2), p(2, 2), dx), dy);
 
-                        float * y_dst = (float *)((char *)dst->data + i0*nb0 + i1*nb1 + i2*nb2 + i3*nb3);
+                        float* y_dst = (float*)((char*)dst->data + i0 * nb0 + i1 * nb1 + i2 * nb2 + i3 * nb3);
                         *y_dst = val;
                     }
                 }
@@ -8169,33 +7586,25 @@ static void ggml_compute_forward_upscale_f32(
     }
 }
 
-void ggml_compute_forward_upscale(
-    const ggml_compute_params * params,
-    ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
+void ggml_compute_forward_upscale(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
 
     switch (src0->type) {
-        case GGML_TYPE_F32:
-            {
-                ggml_compute_forward_upscale_f32(params, dst);
-            } break;
-        default:
-            {
-                GGML_ABORT("fatal error");
-            }
+    case GGML_TYPE_F32: {
+        ggml_compute_forward_upscale_f32(params, dst);
+    } break;
+    default: {
+        GGML_ABORT("fatal error");
+    }
     }
 }
 
 
 // ggml_compute_forward_pad
 
-template<bool circular_t>
-static void ggml_compute_forward_pad_f32(
-    const ggml_compute_params * params,
-          ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
+template <bool circular_t>
+static void ggml_compute_forward_pad_f32(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
 
     assert(dst->nb[0] == sizeof(float));
 
@@ -8204,7 +7613,7 @@ static void ggml_compute_forward_pad_f32(
 
     GGML_TENSOR_UNARY_OP_LOCALS
 
-    float * dst_ptr = (float *) dst->data;
+    float* dst_ptr = (float*)dst->data;
     const int32_t lp0 = ggml_get_op_params_i32(dst, 0);
     const int32_t rp0 = ggml_get_op_params_i32(dst, 1);
     const int32_t lp1 = ggml_get_op_params_i32(dst, 2);
@@ -8222,28 +7631,23 @@ static void ggml_compute_forward_pad_f32(
                 for (int64_t i3 = 0; i3 < ne3; ++i3) {
                     // circular means wrap around on a torus, so x and y loop around
                     if constexpr (circular_t) {
-                        const int64_t dst_idx = i3*(ne0*ne1*ne2) + i2*(ne0*ne1) + i1*ne0 + i0;
+                        const int64_t dst_idx = i3 * (ne0 * ne1 * ne2) + i2 * (ne0 * ne1) + i1 * ne0 + i0;
                         const int64_t src_i0 = ggml_wrap_around(i0 - lp0, ne00);
                         const int64_t src_i1 = ggml_wrap_around(i1 - lp1, ne01);
                         const int64_t src_i2 = ggml_wrap_around(i2 - lp2, ne02);
                         const int64_t src_i3 = ggml_wrap_around(i3 - lp3, ne03);
 
-                        const int64_t src_idx =
-                            src_i3*nb03 +
-                            src_i2*nb02 +
-                            src_i1*nb01 +
-                            src_i0*nb00;
+                        const int64_t src_idx = src_i3 * nb03 + src_i2 * nb02 + src_i1 * nb01 + src_i0 * nb00;
 
-                        const float * src_ptr = (const float *)((char *) src0->data + src_idx);
+                        const float* src_ptr = (const float*)((char*)src0->data + src_idx);
                         dst_ptr[dst_idx] = *src_ptr;
                     } else {
-                        const int64_t dst_idx = i3*(ne0*ne1*ne2) + i2*(ne0*ne1) + i1*ne0 + i0;
-                        if ((i0 >= lp0 && i0 < ne0 - rp0) \
-                            && (i1 >= lp1 && i1 < ne1 - rp1) \
-                            && (i2 >= lp2 && i2 < ne2 - rp2) \
-                            && (i3 >= lp3 && i3 < ne3 - rp3)) {
-                            const int64_t src_idx = (i3 - lp3)*nb03 + (i2 - lp2)*nb02 + (i1 - lp1)*nb01 + (i0 - lp0)*nb00;
-                            const float * src_ptr = (const float *)((char *) src0->data + src_idx);
+                        const int64_t dst_idx = i3 * (ne0 * ne1 * ne2) + i2 * (ne0 * ne1) + i1 * ne0 + i0;
+                        if ((i0 >= lp0 && i0 < ne0 - rp0) && (i1 >= lp1 && i1 < ne1 - rp1) &&
+                            (i2 >= lp2 && i2 < ne2 - rp2) && (i3 >= lp3 && i3 < ne3 - rp3)) {
+                            const int64_t src_idx =
+                                (i3 - lp3) * nb03 + (i2 - lp2) * nb02 + (i1 - lp1) * nb01 + (i0 - lp0) * nb00;
+                            const float* src_ptr = (const float*)((char*)src0->data + src_idx);
                             dst_ptr[dst_idx] = *src_ptr;
                         } else {
                             dst_ptr[dst_idx] = 0;
@@ -8256,42 +7660,35 @@ static void ggml_compute_forward_pad_f32(
 }
 
 
-void ggml_compute_forward_pad(
-    const ggml_compute_params * params,
-    ggml_tensor * dst) {
-    const ggml_tensor * src0 = dst->src[0];
-    const bool circular = (bool) ggml_get_op_params_i32(dst, 8);
+void ggml_compute_forward_pad(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
+    const bool circular = (bool)ggml_get_op_params_i32(dst, 8);
     switch (src0->type) {
-        case GGML_TYPE_F32:
-            {
-                if (circular) {
-                    ggml_compute_forward_pad_f32<true>(params, dst);
-                } else {
-                    ggml_compute_forward_pad_f32<false>(params, dst);
-                }
-            } break;
-        default:
-            {
-                GGML_ABORT("fatal error");
-            }
+    case GGML_TYPE_F32: {
+        if (circular) {
+            ggml_compute_forward_pad_f32<true>(params, dst);
+        } else {
+            ggml_compute_forward_pad_f32<false>(params, dst);
+        }
+    } break;
+    default: {
+        GGML_ABORT("fatal error");
+    }
     }
 }
 
 // ggml_compute_forward_pad_reflect_1d
 
-void ggml_compute_forward_pad_reflect_1d(
-        const ggml_compute_params * params,
-              ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
+void ggml_compute_forward_pad_reflect_1d(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
 
     GGML_ASSERT(src0->type == GGML_TYPE_F32);
-    GGML_ASSERT( dst->type == GGML_TYPE_F32);
+    GGML_ASSERT(dst->type == GGML_TYPE_F32);
 
     const int ith = params->ith;
     const int nth = params->nth;
 
-    const int32_t * opts = (const int32_t *) dst->op_params;
+    const int32_t* opts = (const int32_t*)dst->op_params;
     const int p0 = opts[0];
     const int p1 = opts[1];
 
@@ -8300,13 +7697,17 @@ void ggml_compute_forward_pad_reflect_1d(
     for (int64_t i3 = 0; i3 < ne3; i3++) {
         for (int64_t i2 = 0; i2 < ne2; i2++) {
             for (int64_t i1 = ith; i1 < ne1; i1 += nth) {
-                float * left  = (float *) ((char *) dst->data + i3*nb3 + i2*nb2 + i1*nb1 +         p0*nb0);
-                float * right = (float *) ((char *) dst->data + i3*nb3 + i2*nb2 + i1*nb1 + (ne0-p1-1)*nb0);
+                float* left = (float*)((char*)dst->data + i3 * nb3 + i2 * nb2 + i1 * nb1 + p0 * nb0);
+                float* right = (float*)((char*)dst->data + i3 * nb3 + i2 * nb2 + i1 * nb1 + (ne0 - p1 - 1) * nb0);
 
-                ggml_vec_cpy_f32(ne00, left, (float *) ((char *) src0->data + i3*nb03 + i2*nb02 + i1*nb01));
+                ggml_vec_cpy_f32(ne00, left, (float*)((char*)src0->data + i3 * nb03 + i2 * nb02 + i1 * nb01));
 
-                for (int i0 = 1; i0 <= p0; i0++) { left[-i0] = left[i0];   }
-                for (int i0 = 1; i0 <= p1; i0++) { right[i0] = right[-i0]; }
+                for (int i0 = 1; i0 <= p0; i0++) {
+                    left[-i0] = left[i0];
+                }
+                for (int i0 = 1; i0 <= p1; i0++) {
+                    right[i0] = right[-i0];
+                }
             }
         }
     }
@@ -8323,13 +7724,10 @@ static int64_t ggml_wrap_index(int64_t i, int64_t ne) {
     return i;
 }
 
-static void ggml_compute_forward_roll_f32(
-        const ggml_compute_params * params,
-        ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
-    const float * src_data = (const float *) src0->data;
-    float * dst_data = (float *) dst->data;
+static void ggml_compute_forward_roll_f32(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
+    const float* src_data = (const float*)src0->data;
+    float* dst_data = (float*)dst->data;
 
     GGML_TENSOR_UNARY_OP_LOCALS
 
@@ -8341,89 +7739,74 @@ static void ggml_compute_forward_roll_f32(
     const int64_t total = ne1 * ne2 * ne3;
     const int64_t per_thread = (total + params->nth) / params->nth;
     const int64_t start = params->ith * per_thread;
-    const int64_t end   = std::min(start + per_thread, total);
+    const int64_t end = std::min(start + per_thread, total);
 
     for (int64_t i = start; i < end; ++i) {
         const int64_t i1 = i % ne1;
         const int64_t i2 = (i / ne1) % ne2;
         const int64_t i3 = i / (ne2 * ne1);
-        float * dst_row = dst_data + (i3*nb3 + i2*nb2 + i1*nb1) / sizeof(float);
+        float* dst_row = dst_data + (i3 * nb3 + i2 * nb2 + i1 * nb1) / sizeof(float);
 
         const int64_t i01 = ggml_wrap_index(i1 - s1, ne01);
         const int64_t i02 = ggml_wrap_index(i2 - s2, ne02);
         const int64_t i03 = ggml_wrap_index(i3 - s3, ne03);
-        const float * src_row = src_data + (i03*nb03 + i02*nb02 + i01*nb01) / sizeof(float);
+        const float* src_row = src_data + (i03 * nb03 + i02 * nb02 + i01 * nb01) / sizeof(float);
 
         const int64_t s = ggml_wrap_index(-s0, ne00);
         const int64_t n = ne00 - s;
-        ggml_vec_cpy_f32(n, dst_row,     src_row + s);
+        ggml_vec_cpy_f32(n, dst_row, src_row + s);
         ggml_vec_cpy_f32(s, dst_row + n, src_row);
     }
 }
 
-void ggml_compute_forward_roll(
-        const ggml_compute_params * params,
-        ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
+void ggml_compute_forward_roll(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
 
     switch (src0->type) {
-        case GGML_TYPE_F32:
-            {
-                ggml_compute_forward_roll_f32(params, dst);
-            } break;
-        default:
-            {
-                GGML_ABORT("fatal error");
-            }
+    case GGML_TYPE_F32: {
+        ggml_compute_forward_roll_f32(params, dst);
+    } break;
+    default: {
+        GGML_ABORT("fatal error");
+    }
     }
 }
 
 // ggml_compute_forward_arange
 
-static void ggml_compute_forward_arange_f32(
-    const ggml_compute_params * params,
-    ggml_tensor * dst) {
-
+static void ggml_compute_forward_arange_f32(const ggml_compute_params* params, ggml_tensor* dst) {
     GGML_ASSERT(dst->nb[0] == sizeof(float));
 
     const int ith = params->ith;
     const int nth = params->nth;
 
     const float start = ggml_get_op_params_f32(dst, 0);
-    const float stop  = ggml_get_op_params_f32(dst, 1);
-    const float step  = ggml_get_op_params_f32(dst, 2);
+    const float stop = ggml_get_op_params_f32(dst, 1);
+    const float step = ggml_get_op_params_f32(dst, 2);
 
-    const int64_t steps = (int64_t) ceilf((stop - start) / step);
+    const int64_t steps = (int64_t)ceilf((stop - start) / step);
 
     GGML_ASSERT(ggml_nelements(dst) == steps);
 
-    for (int64_t i = ith; i < steps; i+= nth) {
+    for (int64_t i = ith; i < steps; i += nth) {
         float value = start + step * i;
-        ((float *)dst->data)[i] = value;
+        ((float*)dst->data)[i] = value;
     }
 }
 
-void ggml_compute_forward_arange(
-    const ggml_compute_params * params,
-    ggml_tensor * dst) {
+void ggml_compute_forward_arange(const ggml_compute_params* params, ggml_tensor* dst) {
     switch (dst->type) {
-        case GGML_TYPE_F32:
-            {
-                ggml_compute_forward_arange_f32(params, dst);
-            } break;
-        default:
-            {
-                GGML_ABORT("fatal error");
-            }
+    case GGML_TYPE_F32: {
+        ggml_compute_forward_arange_f32(params, dst);
+    } break;
+    default: {
+        GGML_ABORT("fatal error");
+    }
     }
 }
 
-static void ggml_compute_forward_timestep_embedding_f32(
-    const ggml_compute_params * params,
-    ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
+static void ggml_compute_forward_timestep_embedding_f32(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
 
     GGML_ASSERT(src0->nb[0] == sizeof(float));
 
@@ -8438,9 +7821,9 @@ static void ggml_compute_forward_timestep_embedding_f32(
     int half = dim / 2;
 
     for (int64_t i = 0; i < ne00; i++) {
-        float * embed_data = (float *)((char *)  dst->data +  i*nb1);
+        float* embed_data = (float*)((char*)dst->data + i * nb1);
         for (int64_t j = ith; j < half; j += nth) {
-            float timestep = ((float *)src0->data)[i];
+            float timestep = ((float*)src0->data)[i];
             float freq = (float)expf(-logf(max_period) * j / half);
             float arg = timestep * freq;
             embed_data[j] = cosf(arg);
@@ -8452,29 +7835,23 @@ static void ggml_compute_forward_timestep_embedding_f32(
     }
 }
 
-void ggml_compute_forward_timestep_embedding(
-    const ggml_compute_params * params,
-    ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
+void ggml_compute_forward_timestep_embedding(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
 
     switch (src0->type) {
-        case GGML_TYPE_F32:
-            {
-                ggml_compute_forward_timestep_embedding_f32(params, dst);
-            } break;
-        default:
-            {
-                GGML_ABORT("fatal error");
-            }
+    case GGML_TYPE_F32: {
+        ggml_compute_forward_timestep_embedding_f32(params, dst);
+    } break;
+    default: {
+        GGML_ABORT("fatal error");
+    }
     }
 }
 
 // ggml_compute_forward_argsort
 
-template<enum ggml_sort_order order>
-struct cmp_argsort {
-    const float * data;
+template <enum ggml_sort_order order> struct cmp_argsort {
+    const float* data;
     bool operator()(int32_t a, int32_t b) const {
         if constexpr (order == GGML_SORT_ORDER_ASC) {
             return data[a] < data[b];
@@ -8484,11 +7861,8 @@ struct cmp_argsort {
     }
 };
 
-static void ggml_compute_forward_argsort_f32(
-    const ggml_compute_params * params,
-    ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
+static void ggml_compute_forward_argsort_f32(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
 
     GGML_TENSOR_UNARY_OP_LOCALS
 
@@ -8499,64 +7873,54 @@ static void ggml_compute_forward_argsort_f32(
 
     const int64_t nr = ggml_nrows(src0);
 
-    ggml_sort_order order = (ggml_sort_order) ggml_get_op_params_i32(dst, 0);
+    ggml_sort_order order = (ggml_sort_order)ggml_get_op_params_i32(dst, 0);
 
     for (int64_t i = ith; i < nr; i += nth) {
-        const float * src_data = (float *)((char *) src0->data + i*nb01);
+        const float* src_data = (float*)((char*)src0->data + i * nb01);
 
-        int32_t * dst_data = (int32_t *)((char *) dst->data + i*nb1);
+        int32_t* dst_data = (int32_t*)((char*)dst->data + i * nb1);
 
         for (int64_t j = 0; j < ne0; j++) {
             dst_data[j] = j;
         }
 
         switch (order) {
-            case GGML_SORT_ORDER_ASC:
-                std::sort(dst_data, dst_data + ne0, cmp_argsort<GGML_SORT_ORDER_ASC>{src_data});
-                break;
+        case GGML_SORT_ORDER_ASC:
+            std::sort(dst_data, dst_data + ne0, cmp_argsort<GGML_SORT_ORDER_ASC>{src_data});
+            break;
 
-            case GGML_SORT_ORDER_DESC:
-                std::sort(dst_data, dst_data + ne0, cmp_argsort<GGML_SORT_ORDER_DESC>{src_data});
-                break;
+        case GGML_SORT_ORDER_DESC:
+            std::sort(dst_data, dst_data + ne0, cmp_argsort<GGML_SORT_ORDER_DESC>{src_data});
+            break;
 
-            default:
-                GGML_ABORT("invalid sort order");
+        default:
+            GGML_ABORT("invalid sort order");
         }
     }
 }
 
-void ggml_compute_forward_argsort(
-    const ggml_compute_params * params,
-    ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
+void ggml_compute_forward_argsort(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
 
     switch (src0->type) {
-        case GGML_TYPE_F32:
-            {
-                ggml_compute_forward_argsort_f32(params, dst);
-            } break;
-        default:
-            {
-                GGML_ABORT("fatal error");
-            }
+    case GGML_TYPE_F32: {
+        ggml_compute_forward_argsort_f32(params, dst);
+    } break;
+    default: {
+        GGML_ABORT("fatal error");
+    }
     }
 }
 
 // ggml_compute_forward_top_k
 
 struct cmp_top_k {
-    const float * data;
-    bool operator()(int32_t a, int32_t b) const {
-        return data[a] > data[b];
-    }
+    const float* data;
+    bool operator()(int32_t a, int32_t b) const { return data[a] > data[b]; }
 };
 
-static void ggml_compute_forward_top_k_f32(
-    const ggml_compute_params * params,
-    ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
+static void ggml_compute_forward_top_k_f32(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
 
     GGML_TENSOR_UNARY_OP_LOCALS
 
@@ -8569,10 +7933,10 @@ static void ggml_compute_forward_top_k_f32(
 
     const int top_k = ne0;
 
-    int32_t * tmp = (int32_t *) params->wdata + (ne00 + CACHE_LINE_SIZE_F32) * ith;
+    int32_t* tmp = (int32_t*)params->wdata + (ne00 + CACHE_LINE_SIZE_F32) * ith;
 
     for (int64_t i = ith; i < nr; i += nth) {
-        const float * src_data = (float *)((char *) src0->data + i*nb01);
+        const float* src_data = (float*)((char*)src0->data + i * nb01);
 
         for (int64_t j = 0; j < ne00; j++) {
             tmp[j] = j;
@@ -8580,7 +7944,7 @@ static void ggml_compute_forward_top_k_f32(
 
         std::partial_sort(tmp, tmp + top_k, tmp + ne00, cmp_top_k{src_data});
 
-        int32_t * dst_data = (int32_t *)((char *) dst->data + i*nb1);
+        int32_t* dst_data = (int32_t*)((char*)dst->data + i * nb1);
 
         std::copy(tmp, tmp + top_k, dst_data);
 
@@ -8591,50 +7955,41 @@ static void ggml_compute_forward_top_k_f32(
     }
 }
 
-void ggml_compute_forward_top_k(
-    const ggml_compute_params * params,
-    ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
+void ggml_compute_forward_top_k(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
 
     switch (src0->type) {
-        case GGML_TYPE_F32:
-            {
-                ggml_compute_forward_top_k_f32(params, dst);
-            } break;
-        default:
-            {
-                GGML_ABORT("fatal error");
-            }
+    case GGML_TYPE_F32: {
+        ggml_compute_forward_top_k_f32(params, dst);
+    } break;
+    default: {
+        GGML_ABORT("fatal error");
+    }
     }
 }
 
-static void ggml_compute_forward_flash_attn_ext_f16_one_chunk(
-        const ggml_compute_params * params,
-        ggml_tensor * dst,
-        int ir0, int ir1,
-        int64_t ic_start, int64_t ic_end,
-        float * partials, int64_t partial_stride) {
-
+static void ggml_compute_forward_flash_attn_ext_f16_one_chunk(const ggml_compute_params* params, ggml_tensor* dst,
+                                                              int ir0, int ir1, int64_t ic_start, int64_t ic_end,
+                                                              float* partials, int64_t partial_stride) {
     const bool write_partials = (partials != nullptr);
-    const ggml_tensor * q     = dst->src[0];
-    const ggml_tensor * k     = dst->src[1];
-    const ggml_tensor * v     = dst->src[2];
-    const ggml_tensor * mask  = dst->src[3];
-    const ggml_tensor * sinks = dst->src[4];
+    const ggml_tensor* q = dst->src[0];
+    const ggml_tensor* k = dst->src[1];
+    const ggml_tensor* v = dst->src[2];
+    const ggml_tensor* mask = dst->src[3];
+    const ggml_tensor* sinks = dst->src[4];
 
-    GGML_TENSOR_LOCALS(int64_t, neq, q,   ne)
-    GGML_TENSOR_LOCALS(size_t,  nbq, q,   nb)
-    GGML_TENSOR_LOCALS(int64_t, nek, k,   ne)
-    GGML_TENSOR_LOCALS(size_t,  nbk, k,   nb)
-    GGML_TENSOR_LOCALS(int64_t, nev, v,   ne)
-    GGML_TENSOR_LOCALS(size_t,  nbv, v,   nb)
-    GGML_TENSOR_LOCALS(int64_t, ne,  dst, ne)
-    GGML_TENSOR_LOCALS(size_t,  nb,  dst, nb)
+    GGML_TENSOR_LOCALS(int64_t, neq, q, ne)
+    GGML_TENSOR_LOCALS(size_t, nbq, q, nb)
+    GGML_TENSOR_LOCALS(int64_t, nek, k, ne)
+    GGML_TENSOR_LOCALS(size_t, nbk, k, nb)
+    GGML_TENSOR_LOCALS(int64_t, nev, v, ne)
+    GGML_TENSOR_LOCALS(size_t, nbv, v, nb)
+    GGML_TENSOR_LOCALS(int64_t, ne, dst, ne)
+    GGML_TENSOR_LOCALS(size_t, nb, dst, nb)
 
     const int64_t DK = nek0;
     const int64_t DV = nev0;
-    const int64_t N  = neq1;
+    const int64_t N = neq1;
 
     GGML_ASSERT(ne0 == DV);
     GGML_ASSERT(ne2 == N);
@@ -8657,66 +8012,70 @@ static void ggml_compute_forward_flash_attn_ext_f16_one_chunk(
     GGML_ASSERT(nb2 <= nb3);
 
     // broadcast factors
-    const int64_t rk2 = neq2/nek2;
-    const int64_t rk3 = neq3/nek3;
+    const int64_t rk2 = neq2 / nek2;
+    const int64_t rk3 = neq3 / nek3;
 
-    const int64_t rv2 = neq2/nev2;
-    const int64_t rv3 = neq3/nev3;
+    const int64_t rv2 = neq2 / nev2;
+    const int64_t rv3 = neq3 / nev3;
 
     // parallelize by q rows using ggml_vec_dot_f32
 
-    float scale         = 1.0f;
-    float max_bias      = 0.0f;
+    float scale = 1.0f;
+    float max_bias = 0.0f;
     float logit_softcap = 0.0f;
 
-    memcpy(&scale,         (float *) dst->op_params + 0, sizeof(float));
-    memcpy(&max_bias,      (float *) dst->op_params + 1, sizeof(float));
-    memcpy(&logit_softcap, (float *) dst->op_params + 2, sizeof(float));
+    memcpy(&scale, (float*)dst->op_params + 0, sizeof(float));
+    memcpy(&max_bias, (float*)dst->op_params + 1, sizeof(float));
+    memcpy(&logit_softcap, (float*)dst->op_params + 2, sizeof(float));
 
     if (logit_softcap != 0) {
         scale /= logit_softcap;
     }
 
-    const uint32_t n_head      = neq2;
-    const uint32_t n_head_log2 = 1u << (uint32_t) floor(log2(n_head));
+    const uint32_t n_head = neq2;
+    const uint32_t n_head_log2 = 1u << (uint32_t)floor(log2(n_head));
 
-    const float m0 = powf(2.0f, -(max_bias       ) / n_head_log2);
+    const float m0 = powf(2.0f, -(max_bias) / n_head_log2);
     const float m1 = powf(2.0f, -(max_bias / 2.0f) / n_head_log2);
 
-    ggml_type         const k_vec_dot_type = ggml_get_type_traits_cpu(k->type)->vec_dot_type;
-    ggml_from_float_t const q_to_vec_dot   = ggml_get_type_traits_cpu(k_vec_dot_type)->from_float;
-    ggml_vec_dot_t    const kq_vec_dot     = ggml_get_type_traits_cpu(k->type)->vec_dot;
-    ggml_to_float_t   const v_to_float     = ggml_get_type_traits(v->type)->to_float;
+    ggml_type const k_vec_dot_type = ggml_get_type_traits_cpu(k->type)->vec_dot_type;
+    ggml_from_float_t const q_to_vec_dot = ggml_get_type_traits_cpu(k_vec_dot_type)->from_float;
+    ggml_vec_dot_t const kq_vec_dot = ggml_get_type_traits_cpu(k->type)->vec_dot;
+    ggml_to_float_t const v_to_float = ggml_get_type_traits(v->type)->to_float;
 
-    GGML_ASSERT((                            q_to_vec_dot) && "fattn: unsupported K-type");
-    GGML_ASSERT((v->type == GGML_TYPE_F32 || v_to_float  ) && "fattn: unsupported V-type");
+    GGML_ASSERT((q_to_vec_dot) && "fattn: unsupported K-type");
+    GGML_ASSERT((v->type == GGML_TYPE_F32 || v_to_float) && "fattn: unsupported V-type");
 
     int ith = params->ith;
 
     for (int ir = ir0; ir < ir1; ++ir) {
         // q indices
-        const int iq3 = ir/(neq2*neq1);
-        const int iq2 = (ir - iq3*neq2*neq1)/neq1;
-        const int iq1 = (ir - iq3*neq2*neq1 - iq2*neq1);
+        const int iq3 = ir / (neq2 * neq1);
+        const int iq2 = (ir - iq3 * neq2 * neq1) / neq1;
+        const int iq1 = (ir - iq3 * neq2 * neq1 - iq2 * neq1);
 
         const uint32_t h = iq2; // head index
-        const float slope = (max_bias > 0.0f) ? h < n_head_log2 ? powf(m0, h + 1) : powf(m1, 2*(h - n_head_log2) + 1) : 1.0f;
+        const float slope =
+            (max_bias > 0.0f) ? h < n_head_log2 ? powf(m0, h + 1) : powf(m1, 2 * (h - n_head_log2) + 1) : 1.0f;
 
         float S = 0.0f;      // sum
         float M = -INFINITY; // maximum KQ value
 
-        float       * VKQ32 = (float       *) params->wdata + ith*(1*DK + 2*DV + CACHE_LINE_SIZE_F32); // FP32 VKQ accumulator
-        float       * V32   =                 (VKQ32 + 1*DV); // (temporary) FP32 V buffer
-        ggml_fp16_t * VKQ16 = (ggml_fp16_t *) (VKQ32 + 1*DV); // (temporary) FP16 VKQ accumulator
-        ggml_fp16_t * Q_q   = (ggml_fp16_t *) (VKQ32 + 2*DV); // (temporary) buffer for Q converted to quantized/FP16
+        float* VKQ32 = (float*)params->wdata + ith * (1 * DK + 2 * DV + CACHE_LINE_SIZE_F32); // FP32 VKQ accumulator
+        float* V32 = (VKQ32 + 1 * DV);                       // (temporary) FP32 V buffer
+        ggml_fp16_t* VKQ16 = (ggml_fp16_t*)(VKQ32 + 1 * DV); // (temporary) FP16 VKQ accumulator
+        ggml_fp16_t* Q_q = (ggml_fp16_t*)(VKQ32 + 2 * DV);   // (temporary) buffer for Q converted to quantized/FP16
 
         if (v->type == GGML_TYPE_F16) {
-            memset(VKQ16, 0, DV*sizeof(ggml_fp16_t));
+            memset(VKQ16, 0, DV * sizeof(ggml_fp16_t));
         } else {
-            memset(VKQ32, 0, DV*sizeof(float));
+            memset(VKQ32, 0, DV * sizeof(float));
         }
 
-        const ggml_fp16_t * mp = mask ? (ggml_fp16_t *)((char *) mask->data + iq1*mask->nb[1] + (iq2%mask->ne[2])*mask->nb[2] + (iq3%mask->ne[3])*mask->nb[3]) : NULL;
+        const ggml_fp16_t* mp =
+            mask ? (ggml_fp16_t*)((char*)mask->data + iq1 * mask->nb[1] + (iq2 % mask->ne[2]) * mask->nb[2] +
+                                  (iq3 % mask->ne[3]) * mask->nb[3])
+                 : NULL;
 
         // k indices
         const int ik3 = iq3 / rk3;
@@ -8726,7 +8085,7 @@ static void ggml_compute_forward_flash_attn_ext_f16_one_chunk(
         const int iv3 = iq3 / rv3;
         const int iv2 = iq2 / rv2;
 
-        const float * pq = (const float *) ((char *) q->data + (iq1*nbq1 + iq2*nbq2 + iq3*nbq3));
+        const float* pq = (const float*)((char*)q->data + (iq1 * nbq1 + iq2 * nbq2 + iq3 * nbq3));
         q_to_vec_dot(pq, Q_q, DK);
 
         // online softmax / attention
@@ -8734,20 +8093,20 @@ static void ggml_compute_forward_flash_attn_ext_f16_one_chunk(
         // ref: https://arxiv.org/pdf/2112.05682.pdf
 
         for (int64_t ic = ic_start; ic < ic_end; ++ic) {
-            const float mv = mp ? slope*GGML_CPU_FP16_TO_FP32(mp[ic]) : 0.0f;
+            const float mv = mp ? slope * GGML_CPU_FP16_TO_FP32(mp[ic]) : 0.0f;
             if (mv == -INFINITY) {
                 continue;
             }
 
             float s; // KQ value
 
-            const char * k_data = (const char *) k->data + ( ic*nbk1 + ik2*nbk2 + ik3*nbk3);
+            const char* k_data = (const char*)k->data + (ic * nbk1 + ik2 * nbk2 + ik3 * nbk3);
             kq_vec_dot(DK, &s, 0, k_data, 0, Q_q, 0, 1);
 
-            s = s*scale; // scale KQ value
+            s = s * scale; // scale KQ value
 
             if (logit_softcap != 0.0f) {
-                s = logit_softcap*tanhf(s);
+                s = logit_softcap * tanhf(s);
             }
 
             s += mv; // apply mask
@@ -8757,7 +8116,7 @@ static void ggml_compute_forward_flash_attn_ext_f16_one_chunk(
             float ms = 1.0f; // upon new higher max val, scale VKQ and KQ sum with this value
             float vs = 1.0f; // post-softmax KQ value, expf(s - M)
 
-            const char * v_data = ((const char *) v->data + (ic*nbv1 + iv2*nbv2 + iv3*nbv3));
+            const char* v_data = ((const char*)v->data + (ic * nbv1 + iv2 * nbv2 + iv3 * nbv3));
 
             if (v->type == GGML_TYPE_F16) {
                 if (s > M) {
@@ -8773,7 +8132,7 @@ static void ggml_compute_forward_flash_attn_ext_f16_one_chunk(
                 }
 
                 // V += v*expf(s - M)
-                ggml_vec_mad_f16(DV, VKQ16, (const ggml_fp16_t *) v_data, vs);
+                ggml_vec_mad_f16(DV, VKQ16, (const ggml_fp16_t*)v_data, vs);
             } else {
                 if (s > M) {
                     // s is new maximum, ms < 1.0f, vs == expf(s - s) == 1.0f
@@ -8793,11 +8152,11 @@ static void ggml_compute_forward_flash_attn_ext_f16_one_chunk(
                     ggml_vec_mad_f32(DV, VKQ32, V32, vs);
                 } else {
                     // V is F32
-                    ggml_vec_mad_f32(DV, VKQ32, (const float *) v_data, vs);
+                    ggml_vec_mad_f32(DV, VKQ32, (const float*)v_data, vs);
                 }
             }
 
-            S = S*ms + vs; // scale and increment sum with partial sum
+            S = S * ms + vs; // scale and increment sum with partial sum
         }
 
         if (v->type == GGML_TYPE_F16) {
@@ -8808,7 +8167,7 @@ static void ggml_compute_forward_flash_attn_ext_f16_one_chunk(
 
         // sinks - apply only on the first kv-chunk
         if (sinks && ic_start == 0) {
-            const float s = ((float *)((char *) sinks->data))[h];
+            const float s = ((float*)((char*)sinks->data))[h];
 
             float ms = 1.0f;
             float vs = 1.0f;
@@ -8821,19 +8180,19 @@ static void ggml_compute_forward_flash_attn_ext_f16_one_chunk(
                 vs = expf(s - M);
             }
 
-            S = S*ms + vs;
+            S = S * ms + vs;
         }
 
         if (write_partials) {
             // Write M, S, VKQ to partials for later reduction
             // partials layout: [M, S, VKQ[DV]] per query head
-            float * partial = partials + ir * partial_stride;
+            float* partial = partials + ir * partial_stride;
             partial[0] = M;
             partial[1] = S;
             memcpy(partial + 2, VKQ32, DV * sizeof(float));
         } else {
             // V /= S
-            const float S_inv = S == 0.0f ? 0.0f : 1.0f/S;
+            const float S_inv = S == 0.0f ? 0.0f : 1.0f / S;
             ggml_vec_scale_f32(DV, VKQ32, S_inv);
 
             // dst indices
@@ -8842,33 +8201,31 @@ static void ggml_compute_forward_flash_attn_ext_f16_one_chunk(
             const int i3 = iq3;
 
             // permute(0, 2, 1, 3)
-            memcpy((char *) dst->data + (i3*ne2*ne1 + i2 + i1*ne1)*nb1, VKQ32, nb1);
+            memcpy((char*)dst->data + (i3 * ne2 * ne1 + i2 + i1 * ne1) * nb1, VKQ32, nb1);
         }
     }
 }
 
-static void ggml_compute_forward_flash_attn_ext_tiled(
-        const ggml_compute_params * params,
-        ggml_tensor * dst,
-        int ir0, int ir1) {
-    const ggml_tensor * q     = dst->src[0];
-    const ggml_tensor * k     = dst->src[1];
-    const ggml_tensor * v     = dst->src[2];
-    const ggml_tensor * mask  = dst->src[3];
-    const ggml_tensor * sinks = dst->src[4];
+static void ggml_compute_forward_flash_attn_ext_tiled(const ggml_compute_params* params, ggml_tensor* dst, int ir0,
+                                                      int ir1) {
+    const ggml_tensor* q = dst->src[0];
+    const ggml_tensor* k = dst->src[1];
+    const ggml_tensor* v = dst->src[2];
+    const ggml_tensor* mask = dst->src[3];
+    const ggml_tensor* sinks = dst->src[4];
 
-    GGML_TENSOR_LOCALS(int64_t, neq, q,   ne)
-    GGML_TENSOR_LOCALS(size_t,  nbq, q,   nb)
-    GGML_TENSOR_LOCALS(int64_t, nek, k,   ne)
-    GGML_TENSOR_LOCALS(size_t,  nbk, k,   nb)
-    GGML_TENSOR_LOCALS(int64_t, nev, v,   ne)
-    GGML_TENSOR_LOCALS(size_t,  nbv, v,   nb)
-    GGML_TENSOR_LOCALS(int64_t, ne,  dst, ne)
-    GGML_TENSOR_LOCALS(size_t,  nb,  dst, nb)
+    GGML_TENSOR_LOCALS(int64_t, neq, q, ne)
+    GGML_TENSOR_LOCALS(size_t, nbq, q, nb)
+    GGML_TENSOR_LOCALS(int64_t, nek, k, ne)
+    GGML_TENSOR_LOCALS(size_t, nbk, k, nb)
+    GGML_TENSOR_LOCALS(int64_t, nev, v, ne)
+    GGML_TENSOR_LOCALS(size_t, nbv, v, nb)
+    GGML_TENSOR_LOCALS(int64_t, ne, dst, ne)
+    GGML_TENSOR_LOCALS(size_t, nb, dst, nb)
 
     const int64_t DK = nek0;
     const int64_t DV = nev0;
-    const int64_t N  = neq1;
+    const int64_t N = neq1;
 
     GGML_ASSERT(ne0 == DV);
     GGML_ASSERT(ne2 == N);
@@ -8895,41 +8252,41 @@ static void ggml_compute_forward_flash_attn_ext_tiled(
 
 
     // broadcast factors
-    const int64_t rk2 = neq2/nek2;
-    const int64_t rk3 = neq3/nek3;
+    const int64_t rk2 = neq2 / nek2;
+    const int64_t rk3 = neq3 / nek3;
 
-    const int64_t rv2 = neq2/nev2;
-    const int64_t rv3 = neq3/nev3;
+    const int64_t rv2 = neq2 / nev2;
+    const int64_t rv3 = neq3 / nev3;
 
-    float scale         = 1.0f;
-    float max_bias      = 0.0f;
+    float scale = 1.0f;
+    float max_bias = 0.0f;
     float logit_softcap = 0.0f;
 
-    memcpy(&scale,         (float *) dst->op_params + 0, sizeof(float));
-    memcpy(&max_bias,      (float *) dst->op_params + 1, sizeof(float));
-    memcpy(&logit_softcap, (float *) dst->op_params + 2, sizeof(float));
+    memcpy(&scale, (float*)dst->op_params + 0, sizeof(float));
+    memcpy(&max_bias, (float*)dst->op_params + 1, sizeof(float));
+    memcpy(&logit_softcap, (float*)dst->op_params + 2, sizeof(float));
 
     if (logit_softcap != 0) {
         scale /= logit_softcap;
     }
 
-    const uint32_t n_head      = neq2;
-    const uint32_t n_head_log2 = 1u << (uint32_t) floor(log2(n_head));
+    const uint32_t n_head = neq2;
+    const uint32_t n_head_log2 = 1u << (uint32_t)floor(log2(n_head));
 
-    const float m0 = powf(2.0f, -(max_bias       ) / n_head_log2);
+    const float m0 = powf(2.0f, -(max_bias) / n_head_log2);
     const float m1 = powf(2.0f, -(max_bias / 2.0f) / n_head_log2);
 
     int ith = params->ith;
 
-    static constexpr int Q_TILE_SZ  = ggml_fa_tile_config::Q;
+    static constexpr int Q_TILE_SZ = ggml_fa_tile_config::Q;
     static constexpr int KV_TILE_SZ = ggml_fa_tile_config::KV;
 
     int ir = ir0;
     while (ir < ir1) {
         // q indices for the start of this tile
-        const int iq3 = ir/(neq2*neq1);
-        const int iq2 = (ir - iq3*neq2*neq1)/neq1;
-        const int iq1 = (ir - iq3*neq2*neq1 - iq2*neq1);
+        const int iq3 = ir / (neq2 * neq1);
+        const int iq2 = (ir - iq3 * neq2 * neq1) / neq1;
+        const int iq1 = (ir - iq3 * neq2 * neq1 - iq2 * neq1);
 
         // Number of valid rows in this tile:
         // - limited by tile size (Q_TILE_SZ)
@@ -8939,12 +8296,13 @@ static void ggml_compute_forward_flash_attn_ext_tiled(
         GGML_ASSERT(tile_rows > 0);
 
         const uint32_t h = iq2; // head index
-        const float slope = (max_bias > 0.0f) ? h < n_head_log2 ? powf(m0, h + 1) : powf(m1, 2*(h - n_head_log2) + 1) : 1.0f;
+        const float slope =
+            (max_bias > 0.0f) ? h < n_head_log2 ? powf(m0, h + 1) : powf(m1, 2 * (h - n_head_log2) + 1) : 1.0f;
 
         float S[Q_TILE_SZ];
         float M[Q_TILE_SZ];
 
-        for (int i = 0 ; i < Q_TILE_SZ; ++i) {
+        for (int i = 0; i < Q_TILE_SZ; ++i) {
             S[i] = 0.;
             M[i] = -INFINITY;
         }
@@ -8956,14 +8314,15 @@ static void ggml_compute_forward_flash_attn_ext_tiled(
         // VKQ32:  Q_TILE_SZ * DV (FP32 output accumulator)
         // V32:    KV_TILE_SZ * DV (F32 buffer for V tile)
         // K_f32:  KV_TILE_SZ * DK (F32 buffer for K tile — GEMM path)
-        float * base  = (float *) params->wdata + ith*(Q_TILE_SZ*DK + 2*Q_TILE_SZ*KV_TILE_SZ + Q_TILE_SZ*DV + KV_TILE_SZ*DV + KV_TILE_SZ*DK + CACHE_LINE_SIZE_F32);
+        float* base = (float*)params->wdata + ith * (Q_TILE_SZ * DK + 2 * Q_TILE_SZ * KV_TILE_SZ + Q_TILE_SZ * DV +
+                                                     KV_TILE_SZ * DV + KV_TILE_SZ * DK + CACHE_LINE_SIZE_F32);
 
-        void  * Q_q    = base;
-        float * KQ     = (float *)((char *)base + Q_TILE_SZ * DK * sizeof(float));
-        float * mask32 = KQ + Q_TILE_SZ * KV_TILE_SZ;
-        float * VKQ32  = mask32 + Q_TILE_SZ * KV_TILE_SZ;
-        float * V32    = VKQ32 + Q_TILE_SZ * DV;
-        float * K_f32  = V32 + KV_TILE_SZ * DV;
+        void* Q_q = base;
+        float* KQ = (float*)((char*)base + Q_TILE_SZ * DK * sizeof(float));
+        float* mask32 = KQ + Q_TILE_SZ * KV_TILE_SZ;
+        float* VKQ32 = mask32 + Q_TILE_SZ * KV_TILE_SZ;
+        float* V32 = VKQ32 + Q_TILE_SZ * DV;
+        float* K_f32 = V32 + KV_TILE_SZ * DV;
 
         memset(VKQ32, 0, Q_TILE_SZ * DV * sizeof(float));
         memset(mask32, 0, Q_TILE_SZ * KV_TILE_SZ * sizeof(float));
@@ -8977,9 +8336,9 @@ static void ggml_compute_forward_flash_attn_ext_tiled(
         const int iv2 = iq2 / rv2;
 
         {
-            float * Q_f32 = (float *)Q_q;
+            float* Q_f32 = (float*)Q_q;
             for (int tq = 0; tq < tile_rows; tq++) {
-                const float * pq = (const float *) ((char *) q->data + ((iq1 + tq)*nbq1 + iq2*nbq2 + iq3*nbq3));
+                const float* pq = (const float*)((char*)q->data + ((iq1 + tq) * nbq1 + iq2 * nbq2 + iq3 * nbq3));
                 memcpy(Q_f32 + tq * DK, pq, DK * sizeof(float));
             }
             for (int tq = tile_rows; tq < Q_TILE_SZ; tq++) {
@@ -8988,7 +8347,7 @@ static void ggml_compute_forward_flash_attn_ext_tiled(
         }
 
         memset(K_f32, 0, DK * KV_TILE_SZ * sizeof(float));
-        memset(V32,   0, KV_TILE_SZ * DV * sizeof(float));
+        memset(V32, 0, KV_TILE_SZ * DV * sizeof(float));
 
         for (int64_t ic = 0; ic < nek1; ic += KV_TILE_SZ) {
             const int kv_tile = (int)std::min((int64_t)KV_TILE_SZ, nek1 - ic);
@@ -8997,7 +8356,9 @@ static void ggml_compute_forward_flash_attn_ext_tiled(
             if (mask) {
                 bool can_skip = true;
                 for (int tq = 0; tq < tile_rows; tq++) {
-                    const ggml_fp16_t * mp_row = (const ggml_fp16_t *)((const char *) mask->data + (iq1 + tq)*mask->nb[1] + (iq2%mask->ne[2])*mask->nb[2] + (iq3%mask->ne[3])*mask->nb[3]);
+                    const ggml_fp16_t* mp_row =
+                        (const ggml_fp16_t*)((const char*)mask->data + (iq1 + tq) * mask->nb[1] +
+                                             (iq2 % mask->ne[2]) * mask->nb[2] + (iq3 % mask->ne[3]) * mask->nb[3]);
                     for (int tk = 0; tk < kv_tile; tk++) {
                         mask32[tq * KV_TILE_SZ + tk] = slope * GGML_CPU_FP16_TO_FP32(mp_row[ic + tk]);
                         if (mask32[tq * KV_TILE_SZ + tk] != -INFINITY) {
@@ -9018,21 +8379,21 @@ static void ggml_compute_forward_flash_attn_ext_tiled(
             // Pack K tile transposed: K_f32[dk][kv] so KV_TILE is contiguous (SIMD dim)
             // Zero-pad the last tile so the GEMM always operates on KV_TILE_SZ columns
             for (int tk = 0; tk < kv_tile; tk++) {
-                const char * k_data = (const char *)k->data + (ic + tk)*nbk1 + ik2*nbk2 + ik3*nbk3;
+                const char* k_data = (const char*)k->data + (ic + tk) * nbk1 + ik2 * nbk2 + ik3 * nbk3;
                 if (kv_type == GGML_TYPE_F16) {
-                    const ggml_fp16_t * k_f16 = (const ggml_fp16_t *)k_data;
+                    const ggml_fp16_t* k_f16 = (const ggml_fp16_t*)k_data;
                     for (int64_t dk = 0; dk < DK; dk++) {
                         K_f32[dk * KV_TILE_SZ + tk] = GGML_CPU_FP16_TO_FP32(k_f16[dk]);
                     }
                 } else {
-                    const float * k_f32_src = (const float *)k_data;
+                    const float* k_f32_src = (const float*)k_data;
                     for (int64_t dk = 0; dk < DK; dk++) {
                         K_f32[dk * KV_TILE_SZ + tk] = k_f32_src[dk];
                     }
                 }
             }
             memset(KQ, 0, Q_TILE_SZ * KV_TILE_SZ * sizeof(float));
-            simd_gemm(KQ, (const float *)Q_q, K_f32, Q_TILE_SZ, DK, KV_TILE_SZ);
+            simd_gemm(KQ, (const float*)Q_q, K_f32, Q_TILE_SZ, DK, KV_TILE_SZ);
             ggml_vec_scale_f32(Q_TILE_SZ * KV_TILE_SZ, KQ, scale);
 
             // Set padded KQ entries to -inf so softmax gives them zero weight
@@ -9056,7 +8417,7 @@ static void ggml_compute_forward_flash_attn_ext_tiled(
             bool skip[Q_TILE_SZ] = {};
 
             for (int tq = 0; tq < Q_TILE_SZ; tq++) {
-                float * kq_row = KQ + tq * KV_TILE_SZ;
+                float* kq_row = KQ + tq * KV_TILE_SZ;
 
                 float tile_max;
                 ggml_vec_max_f32(KV_TILE_SZ, &tile_max, kq_row);
@@ -9083,9 +8444,9 @@ static void ggml_compute_forward_flash_attn_ext_tiled(
             // V accumulation: VKQ32 += softmax(KQ) * V
             // Pack V tile to contiguous F32, zero-padded
             for (int tk = 0; tk < kv_tile; tk++) {
-                const char * v_data = (const char *)v->data + (ic + tk)*nbv1 + iv2*nbv2 + iv3*nbv3;
+                const char* v_data = (const char*)v->data + (ic + tk) * nbv1 + iv2 * nbv2 + iv3 * nbv3;
                 if (kv_type == GGML_TYPE_F16) {
-                    ggml_fp16_to_fp32_row((const ggml_fp16_t *)v_data, V32 + tk * DV, DV);
+                    ggml_fp16_to_fp32_row((const ggml_fp16_t*)v_data, V32 + tk * DV, DV);
                 } else {
                     memcpy(V32 + tk * DV, v_data, DV * sizeof(float));
                 }
@@ -9100,7 +8461,7 @@ static void ggml_compute_forward_flash_attn_ext_tiled(
 
         // sinks (apply only to valid rows in the tile)
         if (sinks) {
-            const float s = ((float *)((char *) sinks->data))[h];
+            const float s = ((float*)((char*)sinks->data))[h];
 
             for (int tq = 0; tq < tile_rows; tq++) {
                 float ms = 1.0f;
@@ -9128,7 +8489,7 @@ static void ggml_compute_forward_flash_attn_ext_tiled(
             const int i3 = iq3;
 
             // permute(0, 2, 1, 3)
-            memcpy((char *) dst->data + (i3*ne2*ne1 + i2 + i1*ne1)*nb1, VKQ32 + tq * DV, nb1);
+            memcpy((char*)dst->data + (i3 * ne2 * ne1 + i2 + i1 * ne1) * nb1, VKQ32 + tq * DV, nb1);
         }
 
         ir += tile_rows;
@@ -9137,56 +8498,54 @@ static void ggml_compute_forward_flash_attn_ext_tiled(
 
 // Reduction function: combines partial results across KV chunks
 // Partials layout in wdata: [n_q_heads][n_chunks][2 + DV]
-static void ggml_flash_attn_ext_reduce_partials(
-        const ggml_compute_params * params,
-        ggml_tensor * dst,
-        const int64_t n_chunks,
-        const int64_t chunk_size) {
+static void ggml_flash_attn_ext_reduce_partials(const ggml_compute_params* params, ggml_tensor* dst,
+                                                const int64_t n_chunks, const int64_t chunk_size) {
+    const ggml_tensor* q = dst->src[0];
+    const ggml_tensor* k = dst->src[1];
+    const ggml_tensor* v = dst->src[2];
 
-    const ggml_tensor * q = dst->src[0];
-    const ggml_tensor * k = dst->src[1];
-    const ggml_tensor * v = dst->src[2];
-
-    const int64_t DK        = k->ne[0];
-    const int64_t DV        = v->ne[0];
-    const int64_t nek1      = k->ne[1];
+    const int64_t DK = k->ne[0];
+    const int64_t DV = v->ne[0];
+    const int64_t nek1 = k->ne[1];
     const int64_t n_q_heads = q->ne[2];
 
     const int ith = params->ith;
     const int nth = params->nth;
 
-    const int64_t wdata_per_thread = DK + 2*DV + CACHE_LINE_SIZE_F32;
-    float *       thread_wdata     = (float *) params->wdata + ith * wdata_per_thread;
+    const int64_t wdata_per_thread = DK + 2 * DV + CACHE_LINE_SIZE_F32;
+    float* thread_wdata = (float*)params->wdata + ith * wdata_per_thread;
 
-    const int64_t partials_offset  = nth * (DK + 2*DV + CACHE_LINE_SIZE_F32);
-    const int64_t partial_size     = 2 + DV;
-    const float * partials_base    = (const float *) params->wdata + partials_offset;
+    const int64_t partials_offset = nth * (DK + 2 * DV + CACHE_LINE_SIZE_F32);
+    const int64_t partial_size = 2 + DV;
+    const float* partials_base = (const float*)params->wdata + partials_offset;
 
     // Output layout
     const int64_t ne1 = dst->ne[1];
     const int64_t ne2 = dst->ne[2];
-    const size_t  nb1 = dst->nb[1];
+    const size_t nb1 = dst->nb[1];
 
     // Each thread reduces a subset of query heads
     for (int64_t q_head = ith; q_head < n_q_heads; q_head += nth) {
-        float   M_final   = -INFINITY;
-        float   S_final   = 0.0f;
-        float * VKQ_final = thread_wdata;
+        float M_final = -INFINITY;
+        float S_final = 0.0f;
+        float* VKQ_final = thread_wdata;
         memset(VKQ_final, 0, DV * sizeof(float));
 
         // Combine partials from all chunks
         for (int64_t chunk_idx = 0; chunk_idx < n_chunks; ++chunk_idx) {
             const int64_t ic_start = chunk_idx * chunk_size;
-            if (ic_start >= nek1) continue;
+            if (ic_start >= nek1)
+                continue;
 
-            const float * partial   = partials_base + (q_head * n_chunks + chunk_idx) * partial_size;
-            const float   M_chunk   = partial[0];
-            const float   S_chunk   = partial[1];
-            const float * VKQ_chunk = partial + 2;
+            const float* partial = partials_base + (q_head * n_chunks + chunk_idx) * partial_size;
+            const float M_chunk = partial[0];
+            const float S_chunk = partial[1];
+            const float* VKQ_chunk = partial + 2;
 
-            if (S_chunk == 0.0f) continue;
+            if (S_chunk == 0.0f)
+                continue;
 
-            const float M_new     = fmaxf(M_final, M_chunk);
+            const float M_new = fmaxf(M_final, M_chunk);
             const float scale_old = expf(M_final - M_new);
             const float scale_new = expf(M_chunk - M_new);
 
@@ -9203,30 +8562,27 @@ static void ggml_flash_attn_ext_reduce_partials(
             ggml_vec_scale_f32(DV, VKQ_final, S_inv);
         }
         // iq1=0, iq3=0 for decode
-        memcpy((char *) dst->data + (0*ne2*ne1 + q_head + 0*ne1)*nb1, VKQ_final, nb1);
+        memcpy((char*)dst->data + (0 * ne2 * ne1 + q_head + 0 * ne1) * nb1, VKQ_final, nb1);
     }
 }
 
-static void ggml_compute_forward_flash_attn_ext_f16(
-        const ggml_compute_params * params,
-        ggml_tensor * dst) {
+static void ggml_compute_forward_flash_attn_ext_f16(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* q = dst->src[0];
+    const ggml_tensor* k = dst->src[1];
+    const ggml_tensor* v = dst->src[2];
 
-    const ggml_tensor * q     = dst->src[0];
-    const ggml_tensor * k     = dst->src[1];
-    const ggml_tensor * v     = dst->src[2];
-
-    GGML_TENSOR_LOCALS(int64_t, neq, q,   ne)
-    GGML_TENSOR_LOCALS(size_t,  nbq, q,   nb)
-    GGML_TENSOR_LOCALS(int64_t, nek, k,   ne)
-    GGML_TENSOR_LOCALS(size_t,  nbk, k,   nb)
-    GGML_TENSOR_LOCALS(int64_t, nev, v,   ne)
-    GGML_TENSOR_LOCALS(size_t,  nbv, v,   nb)
-    GGML_TENSOR_LOCALS(int64_t, ne,  dst, ne)
-    GGML_TENSOR_LOCALS(size_t,  nb,  dst, nb)
+    GGML_TENSOR_LOCALS(int64_t, neq, q, ne)
+    GGML_TENSOR_LOCALS(size_t, nbq, q, nb)
+    GGML_TENSOR_LOCALS(int64_t, nek, k, ne)
+    GGML_TENSOR_LOCALS(size_t, nbk, k, nb)
+    GGML_TENSOR_LOCALS(int64_t, nev, v, ne)
+    GGML_TENSOR_LOCALS(size_t, nbv, v, nb)
+    GGML_TENSOR_LOCALS(int64_t, ne, dst, ne)
+    GGML_TENSOR_LOCALS(size_t, nb, dst, nb)
 
     const int64_t DK = nek0;
     const int64_t DV = nev0;
-    const int64_t N  = neq1;
+    const int64_t N = neq1;
 
 
     GGML_ASSERT(ne0 == DV);
@@ -9256,41 +8612,40 @@ static void ggml_compute_forward_flash_attn_ext_f16(
     const bool use_ref = params->use_ref;
 
     const bool kv_is_f32_or_f16 = (k->type == GGML_TYPE_F32 || k->type == GGML_TYPE_F16);
-    const bool use_split_kv_path = !use_ref && (neq1 == 1 && neq3 == 1) && kv_is_f32_or_f16 && (k->type == v->type) && q->type == GGML_TYPE_F32 && nek1 >= 512;
+    const bool use_split_kv_path = !use_ref && (neq1 == 1 && neq3 == 1) && kv_is_f32_or_f16 && (k->type == v->type) &&
+                                   q->type == GGML_TYPE_F32 && nek1 >= 512;
 
     if (use_split_kv_path) {
         const int64_t chunk_size = (nek1 + nth - 1) / nth;
 
         // Partials buffer layout: [q_head][kv_chunk][M, S, VKQ]
-        const int64_t partial_size  = 2 + DV;
-        float *       partials_base = (float *) params->wdata + nth * (DK + 2*DV + CACHE_LINE_SIZE_F32);
+        const int64_t partial_size = 2 + DV;
+        float* partials_base = (float*)params->wdata + nth * (DK + 2 * DV + CACHE_LINE_SIZE_F32);
 
         const int64_t ic_start = ith * chunk_size;
-        const int64_t ic_end   = std::min(ic_start + chunk_size, nek1);
+        const int64_t ic_end = std::min(ic_start + chunk_size, nek1);
 
         const int64_t partial_stride = nth * partial_size;
-        float *       chunk_partials = partials_base + ith * partial_size;
+        float* chunk_partials = partials_base + ith * partial_size;
 
         if (ic_start < nek1) {
             for (int64_t q_head = 0; q_head < neq2; q_head++) {
-                ggml_compute_forward_flash_attn_ext_f16_one_chunk(
-                    params, dst, q_head, q_head + 1, ic_start, ic_end,
-                    chunk_partials, partial_stride);
+                ggml_compute_forward_flash_attn_ext_f16_one_chunk(params, dst, q_head, q_head + 1, ic_start, ic_end,
+                                                                  chunk_partials, partial_stride);
             }
         } else {
             for (int64_t q_head = 0; q_head < neq2; q_head++) {
-                float * q_partials = chunk_partials + q_head * partial_stride;
-                q_partials[0] = -INFINITY;  // M
-                q_partials[1] = 0.0f;       // S
+                float* q_partials = chunk_partials + q_head * partial_stride;
+                q_partials[0] = -INFINITY; // M
+                q_partials[1] = 0.0f;      // S
             }
         }
 
         ggml_barrier(params->threadpool);
         ggml_flash_attn_ext_reduce_partials(params, dst, nth, chunk_size);
     } else {
-
         // total rows in q
-        const int64_t nr = neq1*neq2*neq3;
+        const int64_t nr = neq1 * neq2 * neq3;
 
         // disable for NUMA
         const bool disable_chunking = ggml_is_numa();
@@ -9298,7 +8653,7 @@ static void ggml_compute_forward_flash_attn_ext_f16(
         // 4x chunks per thread
         int nth_scaled = nth * 4;
         int64_t chunk_size = (nr + nth_scaled - 1) / nth_scaled;
-        int64_t nchunk     = (nr + chunk_size - 1) / chunk_size;
+        int64_t nchunk = (nr + chunk_size - 1) / chunk_size;
 
         if (nth == 1 || nchunk < nth || disable_chunking) {
             nchunk = nth;
@@ -9312,12 +8667,9 @@ static void ggml_compute_forward_flash_attn_ext_f16(
 
         const int64_t dr = (nr + nchunk - 1) / nchunk;
 
-        static constexpr int64_t Q_TILE_SZ  = ggml_fa_tile_config::Q;
-        bool use_tiled = !use_ref &&
-                               (q->type == GGML_TYPE_F32 &&
-                                kv_is_f32_or_f16 &&
-                                k->type == v->type &&
-                                neq1 >= Q_TILE_SZ);
+        static constexpr int64_t Q_TILE_SZ = ggml_fa_tile_config::Q;
+        bool use_tiled =
+            !use_ref && (q->type == GGML_TYPE_F32 && kv_is_f32_or_f16 && k->type == v->type && neq1 >= Q_TILE_SZ);
 #ifdef GGML_SIMD
         use_tiled &= (DV % GGML_F32_EPR == 0);
 #endif
@@ -9338,45 +8690,38 @@ static void ggml_compute_forward_flash_attn_ext_f16(
     }
 }
 
-void ggml_compute_forward_flash_attn_ext(
-        const ggml_compute_params * params,
-        ggml_tensor * dst) {
+void ggml_compute_forward_flash_attn_ext(const ggml_compute_params* params, ggml_tensor* dst) {
     switch (dst->op_params[3]) {
-        case GGML_PREC_DEFAULT:
-        case GGML_PREC_F32:
-            {
-                // uses F32 accumulators
-                ggml_compute_forward_flash_attn_ext_f16(params, dst);
-            } break;
-        default:
-            {
-                GGML_ABORT("fatal error");
-            }
+    case GGML_PREC_DEFAULT:
+    case GGML_PREC_F32: {
+        // uses F32 accumulators
+        ggml_compute_forward_flash_attn_ext_f16(params, dst);
+    } break;
+    default: {
+        GGML_ABORT("fatal error");
+    }
     }
 }
 
 // ggml_compute_forward_flash_attn_back
 
-static void ggml_compute_forward_flash_attn_back_f32(
-        const ggml_compute_params * params,
-        const bool masked,
-              ggml_tensor * dst) {
+static void ggml_compute_forward_flash_attn_back_f32(const ggml_compute_params* params, const bool masked,
+                                                     ggml_tensor* dst) {
+    const ggml_tensor* q = dst->src[0];
+    const ggml_tensor* k = dst->src[1];
+    const ggml_tensor* v = dst->src[2];
+    const ggml_tensor* d = dst->src[3];
 
-    const ggml_tensor * q = dst->src[0];
-    const ggml_tensor * k = dst->src[1];
-    const ggml_tensor * v = dst->src[2];
-    const ggml_tensor * d = dst->src[3];
-
-    GGML_TENSOR_LOCALS(int64_t, neq, q,   ne)
-    GGML_TENSOR_LOCALS(size_t,  nbq, q,   nb)
-    GGML_TENSOR_LOCALS(int64_t, nek, k,   ne)
-    GGML_TENSOR_LOCALS(size_t,  nbk, k,   nb)
-    GGML_TENSOR_LOCALS(int64_t, nev, v,   ne)
-    GGML_TENSOR_LOCALS(size_t,  nbv, v,   nb)
-    GGML_TENSOR_LOCALS(int64_t, ned, d,   ne)
-    GGML_TENSOR_LOCALS(size_t,  nbd, d,   nb)
-    GGML_TENSOR_LOCALS(int64_t, ne,  dst, ne)
-    GGML_TENSOR_LOCALS(size_t,  nb,  dst, nb)
+    GGML_TENSOR_LOCALS(int64_t, neq, q, ne)
+    GGML_TENSOR_LOCALS(size_t, nbq, q, nb)
+    GGML_TENSOR_LOCALS(int64_t, nek, k, ne)
+    GGML_TENSOR_LOCALS(size_t, nbk, k, nb)
+    GGML_TENSOR_LOCALS(int64_t, nev, v, ne)
+    GGML_TENSOR_LOCALS(size_t, nbv, v, nb)
+    GGML_TENSOR_LOCALS(int64_t, ned, d, ne)
+    GGML_TENSOR_LOCALS(size_t, nbd, d, nb)
+    GGML_TENSOR_LOCALS(int64_t, ne, dst, ne)
+    GGML_TENSOR_LOCALS(size_t, nb, dst, nb)
 
     const int ith = params->ith;
     const int nth = params->nth;
@@ -9386,7 +8731,7 @@ static void ggml_compute_forward_flash_attn_back_f32(
     const int64_t P = nek1 - N;
     const int64_t M = P + N;
 
-    const int Mup  = ggml_up(M, GGML_SOFT_MAX_UNROLL);
+    const int Mup = ggml_up(M, GGML_SOFT_MAX_UNROLL);
     const int mxDM = MAX(D, Mup);
 
     // GGML_ASSERT(ne0 == D);
@@ -9414,7 +8759,7 @@ static void ggml_compute_forward_flash_attn_back_f32(
     GGML_ASSERT(nb2 <= nb3);
 
     if (ith == 0) {
-        memset(dst->data, 0, nb0*ne0*ne1*ne2*ne3);
+        memset(dst->data, 0, nb0 * ne0 * ne1 * ne2 * ne3);
     }
     ggml_barrier(params->threadpool);
 
@@ -9429,45 +8774,45 @@ static void ggml_compute_forward_flash_attn_back_f32(
     const size_t offs_k = offs_q + GGML_PAD(elem_q * tsize, GGML_MEM_ALIGN);
     const size_t offs_v = offs_k + GGML_PAD(elem_k * tsize, GGML_MEM_ALIGN);
 
-    void * grad_q = (char *) dst->data;
-    void * grad_k = (char *) dst->data + offs_k;
-    void * grad_v = (char *) dst->data + offs_v;
+    void* grad_q = (char*)dst->data;
+    void* grad_k = (char*)dst->data + offs_k;
+    void* grad_v = (char*)dst->data + offs_v;
 
-    const size_t nbgq1 = nb0*neq0;
-    const size_t nbgq2 = nb0*neq0*neq1;
-    const size_t nbgq3 = nb0*neq0*neq1*neq2;
+    const size_t nbgq1 = nb0 * neq0;
+    const size_t nbgq2 = nb0 * neq0 * neq1;
+    const size_t nbgq3 = nb0 * neq0 * neq1 * neq2;
 
-    const size_t nbgk1 = nb0*nek0;
-    const size_t nbgk2 = nb0*nek0*nek1;
-    const size_t nbgk3 = nb0*nek0*nek1*neq2;
+    const size_t nbgk1 = nb0 * nek0;
+    const size_t nbgk2 = nb0 * nek0 * nek1;
+    const size_t nbgk3 = nb0 * nek0 * nek1 * neq2;
 
-    const size_t nbgv1 = nb0*nev0;
-    const size_t nbgv2 = nb0*nev0*nev1;
-    const size_t nbgv3 = nb0*nev0*nev1*neq2;
+    const size_t nbgv1 = nb0 * nev0;
+    const size_t nbgv2 = nb0 * nev0 * nev1;
+    const size_t nbgv3 = nb0 * nev0 * nev1 * neq2;
 
     // parallelize by k rows using ggml_vec_dot_f32
 
     // total rows in k
-    const int nr = nek2*nek3;
+    const int nr = nek2 * nek3;
 
     // rows per thread
-    const int dr = (nr + nth - 1)/nth;
+    const int dr = (nr + nth - 1) / nth;
 
     // row range for this thread
-    const int ir0 = dr*ith;
+    const int ir0 = dr * ith;
     const int ir1 = MIN(ir0 + dr, nr);
 
-    const float scale = 1.0f/sqrtf(D);
+    const float scale = 1.0f / sqrtf(D);
 
     //printf("P=%d N=%d D=%d ir0=%d ir1=%d scale = %f\n", P, N, D, ir0, ir1, scale);
 
     // how often k2 (and v2) is repeated in q2
-    int nrep = neq2/nek2;
+    int nrep = neq2 / nek2;
 
     for (int ir = ir0; ir < ir1; ++ir) {
         // q indices
-        const int ik3 = ir/(nek2);
-        const int ik2 = ir - ik3*nek2;
+        const int ik3 = ir / (nek2);
+        const int ik2 = ir - ik3 * nek2;
 
         const int iq3 = ik3;
         const int id3 = ik3;
@@ -9475,7 +8820,7 @@ static void ggml_compute_forward_flash_attn_back_f32(
         const int iv2 = ik2;
 
         for (int irep = 0; irep < nrep; ++irep) {
-            const int iq2 = ik2 + irep*nek2;
+            const int iq2 = ik2 + irep * nek2;
             const int id2 = iq2;
 
             // (ik2 + irep*nek2) % nek2 == ik2
@@ -9484,8 +8829,10 @@ static void ggml_compute_forward_flash_attn_back_f32(
 
                 // not sure about CACHE_LINE_SIZE_F32..
                 // - maybe it must not be multiplied by 2 and excluded from .. in SM 1*(..) offset?
-                float * S  = (float *) params->wdata + ith*2*(mxDM + CACHE_LINE_SIZE_F32) + 0*(mxDM+CACHE_LINE_SIZE_F32);
-                float * SM = (float *) params->wdata + ith*2*(mxDM + CACHE_LINE_SIZE_F32) + 1*(mxDM+CACHE_LINE_SIZE_F32);
+                float* S =
+                    (float*)params->wdata + ith * 2 * (mxDM + CACHE_LINE_SIZE_F32) + 0 * (mxDM + CACHE_LINE_SIZE_F32);
+                float* SM =
+                    (float*)params->wdata + ith * 2 * (mxDM + CACHE_LINE_SIZE_F32) + 1 * (mxDM + CACHE_LINE_SIZE_F32);
 
                 for (int i = M; i < Mup; ++i) {
                     S[i] = -INFINITY;
@@ -9499,10 +8846,8 @@ static void ggml_compute_forward_flash_attn_back_f32(
                     // S indices
                     const int i1 = ik1;
 
-                    ggml_vec_dot_f32(neq0,
-                            S + i1, 0,
-                            (float *) ((char *) k->data + (ik1*nbk1 + ik2*nbk2 + ik3*nbk3)), 0,
-                            (float *) ((char *) q->data + (iq1*nbq1 + iq2*nbq2 + iq3*nbq3)), 0, 1);
+                    ggml_vec_dot_f32(neq0, S + i1, 0, (float*)((char*)k->data + (ik1 * nbk1 + ik2 * nbk2 + ik3 * nbk3)),
+                                     0, (float*)((char*)q->data + (iq1 * nbq1 + iq2 * nbq2 + iq3 * nbq3)), 0, 1);
                 }
 
                 // scale
@@ -9533,9 +8878,8 @@ static void ggml_compute_forward_flash_attn_back_f32(
 
                     assert(sum > 0.0);
 
-                    sum = 1.0/sum;
+                    sum = 1.0 / sum;
                     ggml_vec_scale_f32(masked_begin, SM, sum);
-
                 }
 
                 // step-by-step explanation
@@ -9608,17 +8952,15 @@ static void ggml_compute_forward_flash_attn_back_f32(
                 // exclude known future zero S[..] values from operation
                 ggml_vec_set_f32(masked_begin, S, 0);
                 for (int64_t ic = 0; ic < D; ++ic) {
-                    ggml_vec_mad_f32(masked_begin,
-                            S,
-                             (float *) ((char *) v->data + (          ic*nbv1  + iv2*nbv2 + iv3*nbv3)),
-                            *(float *) ((char *) d->data + (ic*nbd0 + id1*nbd1 + id2*nbd2 + id3*nbd3)));
+                    ggml_vec_mad_f32(masked_begin, S, (float*)((char*)v->data + (ic * nbv1 + iv2 * nbv2 + iv3 * nbv3)),
+                                     *(float*)((char*)d->data + (ic * nbd0 + id1 * nbd1 + id2 * nbd2 + id3 * nbd3)));
                 }
 
                 // S = SM * (S - dot(SM, S))
                 float dot_SM_gradSM = 0;
-                ggml_vec_dot_f32 (masked_begin, &dot_SM_gradSM, 0, SM, 0, S, 0, 1);
+                ggml_vec_dot_f32(masked_begin, &dot_SM_gradSM, 0, SM, 0, S, 0, 1);
                 ggml_vec_acc1_f32(M, S, -dot_SM_gradSM);
-                ggml_vec_mul_f32 (masked_begin, S, S, SM);
+                ggml_vec_mul_f32(masked_begin, S, S, SM);
 
                 // S = diag_mask_zero(S, P) * scale
                 // already done by above ggml_vec_set_f32
@@ -9638,10 +8980,8 @@ static void ggml_compute_forward_flash_attn_back_f32(
                 //  grad[q][:D,iq1,iq2,iq3] += S[ic] * kcur[:D,ic,ik2,ik3]
                 // exclude known zero S[..] values from loop
                 for (int64_t ic = 0; ic < masked_begin; ++ic) {
-                    ggml_vec_mad_f32(D,
-                            (float *) ((char *) grad_q  + (iq1*nbgq1 + iq2*nbgq2  + iq3*nbgq3)),
-                            (float *) ((char *) k->data + (ic*nbk1   + ik2*nbk2   + ik3*nbk3)),
-                            S[ic]);
+                    ggml_vec_mad_f32(D, (float*)((char*)grad_q + (iq1 * nbgq1 + iq2 * nbgq2 + iq3 * nbgq3)),
+                                     (float*)((char*)k->data + (ic * nbk1 + ik2 * nbk2 + ik3 * nbk3)), S[ic]);
                 }
 
                 // grad[k][:D,:M,iq2,iq3] += S.T @ qcur
@@ -9650,10 +8990,8 @@ static void ggml_compute_forward_flash_attn_back_f32(
                 //  grad[k][:D,ic,iq2,iq3] += S[ic]     * qcur[:D,0]
                 // exclude known zero S[..] values from loop
                 for (int64_t ic = 0; ic < masked_begin; ++ic) {
-                    ggml_vec_mad_f32(D,
-                            (float *) ((char *) grad_k  + (ic*nbgk1  + ik2*nbgk2  + ik3*nbgk3)),
-                            (float *) ((char *) q->data + (iq1*nbq1  + iq2*nbq2   + iq3*nbq3)),
-                            S[ic]);
+                    ggml_vec_mad_f32(D, (float*)((char*)grad_k + (ic * nbgk1 + ik2 * nbgk2 + ik3 * nbgk3)),
+                                     (float*)((char*)q->data + (iq1 * nbq1 + iq2 * nbq2 + iq3 * nbq3)), S[ic]);
                 }
 
                 // grad[v][:M,:D,iv2,iv3] += d[:D,id1,id2,id3].T       @ SM
@@ -9662,72 +9000,65 @@ static void ggml_compute_forward_flash_attn_back_f32(
                 //  grad[v][:M,ic,iv2,iv3] += d[ic,id1,id2,id3]         * SM[:M]
                 // exclude known zero SM[..] values from mad
                 for (int64_t ic = 0; ic < D; ++ic) {
-                    ggml_vec_mad_f32(masked_begin,
-                            (float *) ((char *) grad_v   + (          ic*nbgv1 + iv2*nbgv2 + iv3*nbgv3)),
-                            SM,
-                            *(float *) ((char *) d->data + (ic*nbd0 + id1*nbd1 + id2*nbd2  + id3*nbd3)));
+                    ggml_vec_mad_f32(masked_begin, (float*)((char*)grad_v + (ic * nbgv1 + iv2 * nbgv2 + iv3 * nbgv3)),
+                                     SM,
+                                     *(float*)((char*)d->data + (ic * nbd0 + id1 * nbd1 + id2 * nbd2 + id3 * nbd3)));
                 }
             }
         }
     }
 }
 
-void ggml_compute_forward_flash_attn_back(
-        const ggml_compute_params * params,
-        const bool masked,
-        ggml_tensor * dst) {
-
-    const ggml_tensor * q = dst->src[0];
+void ggml_compute_forward_flash_attn_back(const ggml_compute_params* params, const bool masked, ggml_tensor* dst) {
+    const ggml_tensor* q = dst->src[0];
 
     switch (q->type) {
-        case GGML_TYPE_F32:
-            {
-                ggml_compute_forward_flash_attn_back_f32(params, masked, dst);
-            } break;
-        default:
-            {
-                GGML_ABORT("fatal error");
-            }
+    case GGML_TYPE_F32: {
+        ggml_compute_forward_flash_attn_back_f32(params, masked, dst);
+    } break;
+    default: {
+        GGML_ABORT("fatal error");
+    }
     }
 }
 
 // ggml_compute_forward_ssm_conv
 
-static void ggml_compute_forward_ssm_conv_f32(
-        const ggml_compute_params * params,
-        ggml_tensor * dst) {
-    const ggml_tensor * src0 = dst->src[0]; // conv_x
-    const ggml_tensor * src1 = dst->src[1]; // conv1d.weight
+static void ggml_compute_forward_ssm_conv_f32(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0]; // conv_x
+    const ggml_tensor* src1 = dst->src[1]; // conv1d.weight
 
     const int ith = params->ith;
     const int nth = params->nth;
 
-    const int nc  = src1->ne[0]; // d_conv
+    const int nc = src1->ne[0];  // d_conv
     const int ncs = src0->ne[0]; // d_conv - 1 + n_t
-    const int nr  = src0->ne[1]; // d_inner
-    const int n_t =  dst->ne[1]; // tokens per sequence
-    const int n_s =  dst->ne[2]; // number of sequences in the batch
+    const int nr = src0->ne[1];  // d_inner
+    const int n_t = dst->ne[1];  // tokens per sequence
+    const int n_s = dst->ne[2];  // number of sequences in the batch
 
-    GGML_ASSERT( dst->ne[0] == nr);
+    GGML_ASSERT(dst->ne[0] == nr);
     GGML_ASSERT(src0->nb[0] == sizeof(float));
     GGML_ASSERT(src1->nb[0] == sizeof(float));
-    GGML_ASSERT(src0->nb[1] == src0->ne[0]*sizeof(float));
+    GGML_ASSERT(src0->nb[1] == src0->ne[0] * sizeof(float));
 
     // rows per thread
-    const int dr = (nr + nth - 1)/nth;
+    const int dr = (nr + nth - 1) / nth;
 
     // row range for this thread
-    const int ir0 = dr*ith;
+    const int ir0 = dr * ith;
     const int ir1 = MIN(ir0 + dr, nr);
-    const int ir  = ir1 - ir0;
+    const int ir = ir1 - ir0;
 
     for (int i3 = 0; i3 < n_s; ++i3) {
         for (int i2 = 0; i2 < n_t; ++i2) {
             // {d_conv - 1 + n_t, d_inner, n_seqs}
             // sliding window
-            const float * s = (const float *) ((const char *) src0->data + ir0*(src0->nb[1]) + i2*(src0->nb[0]) + i3*(src0->nb[2])); // {d_conv, d_inner, n_s}
-            const float * c = (const float *) ((const char *) src1->data + ir0*(src1->nb[1])); // {d_conv, d_inner}
-            float * x = (float *) ((char *) dst->data + ir0*(dst->nb[0]) + i2*(dst->nb[1]) + i3*(dst->nb[2])); // {d_inner, n_t, n_s}
+            const float* s = (const float*)((const char*)src0->data + ir0 * (src0->nb[1]) + i2 * (src0->nb[0]) +
+                                            i3 * (src0->nb[2]));                            // {d_conv, d_inner, n_s}
+            const float* c = (const float*)((const char*)src1->data + ir0 * (src1->nb[1])); // {d_conv, d_inner}
+            float* x = (float*)((char*)dst->data + ir0 * (dst->nb[0]) + i2 * (dst->nb[1]) +
+                                i3 * (dst->nb[2])); // {d_inner, n_t, n_s}
 
             // TODO: transpose the output for smaller strides for big batches?
             // d_inner
@@ -9738,7 +9069,7 @@ static void ggml_compute_forward_ssm_conv_f32(
 
                 // d_conv
                 for (int i0 = 0; i0 < nc; ++i0) {
-                    sumf += s[i0 + i1*ncs] * c[i0 + i1*nc];
+                    sumf += s[i0 + i1 * ncs] * c[i0 + i1 * nc];
                 }
                 x[i1] = sumf;
             }
@@ -9746,33 +9077,27 @@ static void ggml_compute_forward_ssm_conv_f32(
     }
 }
 
-void ggml_compute_forward_ssm_conv(
-        const ggml_compute_params * params,
-        ggml_tensor * dst) {
+void ggml_compute_forward_ssm_conv(const ggml_compute_params* params, ggml_tensor* dst) {
     switch (dst->src[0]->type) {
-        case GGML_TYPE_F32:
-            {
-                ggml_compute_forward_ssm_conv_f32(params, dst);
-            } break;
-        default:
-            {
-                GGML_ABORT("fatal error");
-            }
+    case GGML_TYPE_F32: {
+        ggml_compute_forward_ssm_conv_f32(params, dst);
+    } break;
+    default: {
+        GGML_ABORT("fatal error");
+    }
     }
 }
 
 // ggml_compute_forward_ssm_scan
 
-static void ggml_compute_forward_ssm_scan_f32(
-        const ggml_compute_params * params,
-        ggml_tensor * dst) {
-    const ggml_tensor * src0 = dst->src[0]; // s  {d_state, dim, n_head, n_seqs+}
-    const ggml_tensor * src1 = dst->src[1]; // x  {dim, n_head, n_seq_tokens, n_seqs}
-    const ggml_tensor * src2 = dst->src[2]; // dt {n_head, n_seq_tokens, n_seqs}
-    const ggml_tensor * src3 = dst->src[3]; // A  {d_state, n_head} or {1, n_head}
-    const ggml_tensor * src4 = dst->src[4]; // B  {d_state, n_group, n_seq_tokens, n_seqs}
-    const ggml_tensor * src5 = dst->src[5]; // C  {d_state, n_group, n_seq_tokens, n_seqs}
-    const ggml_tensor * src6 = dst->src[6]; // ids {n_seqs}
+static void ggml_compute_forward_ssm_scan_f32(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0]; // s  {d_state, dim, n_head, n_seqs+}
+    const ggml_tensor* src1 = dst->src[1]; // x  {dim, n_head, n_seq_tokens, n_seqs}
+    const ggml_tensor* src2 = dst->src[2]; // dt {n_head, n_seq_tokens, n_seqs}
+    const ggml_tensor* src3 = dst->src[3]; // A  {d_state, n_head} or {1, n_head}
+    const ggml_tensor* src4 = dst->src[4]; // B  {d_state, n_group, n_seq_tokens, n_seqs}
+    const ggml_tensor* src5 = dst->src[5]; // C  {d_state, n_group, n_seq_tokens, n_seqs}
+    const ggml_tensor* src6 = dst->src[6]; // ids {n_seqs}
 
     const int ith = params->ith;
     const int nth = params->nth;
@@ -9787,7 +9112,7 @@ static void ggml_compute_forward_ssm_scan_f32(
     // can't use ggml_nbytes because src1 is not necessarily contiguous
     const int64_t s_off = ggml_nelements(src1) * ggml_element_size(src1);
 
-    GGML_ASSERT(ggml_nelements(src1) + nc*nr*nh*ns == ggml_nelements(dst));
+    GGML_ASSERT(ggml_nelements(src1) + nc * nr * nh * ns == ggml_nelements(dst));
     GGML_ASSERT(src0->nb[0] == sizeof(float));
     GGML_ASSERT(src1->nb[0] == sizeof(float));
     GGML_ASSERT(src2->nb[0] == sizeof(float));
@@ -9798,25 +9123,30 @@ static void ggml_compute_forward_ssm_scan_f32(
     GGML_ASSERT(nh % ng == 0);
 
     // heads per thread
-    const int dh = (nh + nth - 1)/nth;
+    const int dh = (nh + nth - 1) / nth;
 
     // head range for this thread
-    const int ih0 = dh*ith;
+    const int ih0 = dh * ith;
     const int ih1 = MIN(ih0 + dh, nh);
 
-    const int32_t * ids = (const int32_t *) src6->data;
+    const int32_t* ids = (const int32_t*)src6->data;
 
     for (int i3 = 0; i3 < ns; ++i3) {
-        const float * s0 = (const float *) ((const char *) src0->data + ids[i3]*(src0->nb[3])); // {d_state, dim, nh, ns}
-              float * s  = (      float *) ((      char *) dst->data  + i3*(src0->nb[3]) + s_off); // {d_state, dim, nh, ns}
+        const float* s0 = (const float*)((const char*)src0->data + ids[i3] * (src0->nb[3])); // {d_state, dim, nh, ns}
+        float* s = (float*)((char*)dst->data + i3 * (src0->nb[3]) + s_off);                  // {d_state, dim, nh, ns}
 
         for (int i2 = 0; i2 < nt; ++i2) {
-            const float * x  = (const float *) ((const char *) src1->data + i2*(src1->nb[2]) + i3*(src1->nb[3])); // {dim, nh, nt, ns}
-            const float * dt = (const float *) ((const char *) src2->data + i2*(src2->nb[1]) + i3*(src2->nb[2])); // {nh, nt, ns}
-            const float * A  = (const float *) ((const char *) src3->data); // {d_state, nh} or {1, nh}
-            const float * B  = (const float *) ((const char *) src4->data + i2*(src4->nb[2]) + i3*(src4->nb[3])); // {d_state, ng, nt, ns}
-            const float * C  = (const float *) ((const char *) src5->data + i2*(src5->nb[2]) + i3*(src5->nb[3])); // {d_state, ng, nt, ns}
-                  float * y  = (      float *) ((      char *) dst->data + i2*(nh*nr*sizeof(float)) + i3*(nt*nh*nr*sizeof(float))); // {dim, nh, nt, ns}
+            const float* x =
+                (const float*)((const char*)src1->data + i2 * (src1->nb[2]) + i3 * (src1->nb[3])); // {dim, nh, nt, ns}
+            const float* dt =
+                (const float*)((const char*)src2->data + i2 * (src2->nb[1]) + i3 * (src2->nb[2])); // {nh, nt, ns}
+            const float* A = (const float*)((const char*)src3->data); // {d_state, nh} or {1, nh}
+            const float* B = (const float*)((const char*)src4->data + i2 * (src4->nb[2]) +
+                                            i3 * (src4->nb[3])); // {d_state, ng, nt, ns}
+            const float* C = (const float*)((const char*)src5->data + i2 * (src5->nb[2]) +
+                                            i3 * (src5->nb[3])); // {d_state, ng, nt, ns}
+            float* y = (float*)((char*)dst->data + i2 * (nh * nr * sizeof(float)) +
+                                i3 * (nt * nh * nr * sizeof(float))); // {dim, nh, nt, ns}
 
             if (src3->ne[0] == 1) {
                 // Mamba-2 has a scalar decay factor per head; dA can be outside the state-wise loop
@@ -9830,11 +9160,11 @@ static void ggml_compute_forward_ssm_scan_f32(
 
                     // dim
                     for (int i1 = 0; i1 < nr; ++i1) {
-                        const int ii = i1 + h*nr;
+                        const int ii = i1 + h * nr;
                         const float x_dt = x[ii] * dt_soft_plus;
                         float sumf = 0.0f;
 #if defined(GGML_SIMD)
-    #if defined(__ARM_FEATURE_SVE)
+#if defined(__ARM_FEATURE_SVE)
                         const int ggml_f32_epr = svcntw();
                         const int ggml_f32_step = 1 * ggml_f32_epr;
 
@@ -9848,9 +9178,9 @@ static void ggml_compute_forward_ssm_scan_f32(
                         for (int i = 0; i < np; i += ggml_f32_step) {
                             // TODO: maybe unroll more?
                             for (int j = 0; j < 1; j++) {
-                                GGML_F32_VEC t0 = GGML_F32_VEC_LOAD(s0 + i + j*ggml_f32_epr + ii*nc);
-                                GGML_F32_VEC t1 = GGML_F32_VEC_LOAD(B + i + j*ggml_f32_epr + g*nc);
-                                GGML_F32_VEC t2 = GGML_F32_VEC_LOAD(C + i + j*ggml_f32_epr + g*nc);
+                                GGML_F32_VEC t0 = GGML_F32_VEC_LOAD(s0 + i + j * ggml_f32_epr + ii * nc);
+                                GGML_F32_VEC t1 = GGML_F32_VEC_LOAD(B + i + j * ggml_f32_epr + g * nc);
+                                GGML_F32_VEC t2 = GGML_F32_VEC_LOAD(C + i + j * ggml_f32_epr + g * nc);
 
                                 t0 = GGML_F32_VEC_MUL(t0, adA);
                                 t1 = GGML_F32_VEC_MUL(t1, axdt);
@@ -9859,18 +9189,18 @@ static void ggml_compute_forward_ssm_scan_f32(
 
                                 sum = GGML_F32_VEC_FMA(sum, t0, t2);
 
-                                GGML_F32_VEC_STORE(s + i + j*ggml_f32_epr + ii*nc, t0);
+                                GGML_F32_VEC_STORE(s + i + j * ggml_f32_epr + ii * nc, t0);
                             }
                         }
 
                         sumf = GGML_F32xt_REDUCE_ONE(sum);
-    #elif defined(__riscv_v_intrinsic)
+#elif defined(__riscv_v_intrinsic)
                         // todo: RVV implementation
                         const int np = 0;
-    #else
+#else
                         const int np = (nc & ~(GGML_F32_STEP - 1));
 
-                        GGML_F32_VEC sum[GGML_F32_ARR] = { GGML_F32_VEC_ZERO };
+                        GGML_F32_VEC sum[GGML_F32_ARR] = {GGML_F32_VEC_ZERO};
 
                         GGML_F32_VEC adA = GGML_F32_VEC_SET1(dA);
                         GGML_F32_VEC axdt = GGML_F32_VEC_SET1(x_dt);
@@ -9881,9 +9211,9 @@ static void ggml_compute_forward_ssm_scan_f32(
 
                         for (int i = 0; i < np; i += GGML_F32_STEP) {
                             for (int j = 0; j < GGML_F32_ARR; j++) {
-                                ax[j] = GGML_F32_VEC_LOAD(s0 + i + j*GGML_F32_EPR + ii*nc);
-                                ay[j] = GGML_F32_VEC_LOAD(B + i + j*GGML_F32_EPR + g*nc);
-                                az[j] = GGML_F32_VEC_LOAD(C + i + j*GGML_F32_EPR + g*nc);
+                                ax[j] = GGML_F32_VEC_LOAD(s0 + i + j * GGML_F32_EPR + ii * nc);
+                                ay[j] = GGML_F32_VEC_LOAD(B + i + j * GGML_F32_EPR + g * nc);
+                                az[j] = GGML_F32_VEC_LOAD(C + i + j * GGML_F32_EPR + g * nc);
 
                                 ax[j] = GGML_F32_VEC_MUL(ax[j], adA);
                                 ay[j] = GGML_F32_VEC_MUL(ay[j], axdt);
@@ -9892,20 +9222,20 @@ static void ggml_compute_forward_ssm_scan_f32(
 
                                 sum[j] = GGML_F32_VEC_FMA(sum[j], ax[j], az[j]);
 
-                                GGML_F32_VEC_STORE(s + i + j*GGML_F32_EPR + ii*nc, ax[j]);
+                                GGML_F32_VEC_STORE(s + i + j * GGML_F32_EPR + ii * nc, ax[j]);
                             }
                         }
 
                         // reduce sum0..sum3 to sum0
                         GGML_F32_VEC_REDUCE(sumf, sum);
-    #endif
+#endif
 #else
                         const int np = 0;
 #endif
                         // d_state
                         for (int i0 = np; i0 < nc; ++i0) {
-                            const int i = i0 + ii*nc;
-                            const int ig = i0 + g*nc;
+                            const int i = i0 + ii * nc;
+                            const int ig = i0 + g * nc;
                             // state = prev_state * dA + dB * x
                             const float state = (s0[i] * dA) + (B[ig] * x_dt);
                             // y = rowwise_dotprod(state, C)
@@ -9926,7 +9256,7 @@ static void ggml_compute_forward_ssm_scan_f32(
 
                     // dim
                     for (int i1 = 0; i1 < nr; ++i1) {
-                        const int ii = i1 + h*nr;
+                        const int ii = i1 + h * nr;
                         const float x_dt = x[ii] * dt_soft_plus;
 #if defined(__ARM_FEATURE_SVE)
                         svfloat32_t vx_dt = GGML_F32_VEC_SET1(x_dt);
@@ -9936,10 +9266,10 @@ static void ggml_compute_forward_ssm_scan_f32(
                         // d_state
                         // TODO: what happens when (d_state % svcntw()) != 0?
                         for (int64_t k = 0; k < nc; k += svcntw()) {
-                            svfloat32_t vA = GGML_F32_VEC_LOAD(&A[h*nc + k]);
-                            svfloat32_t vB = GGML_F32_VEC_LOAD(&B[k + g*nc]);
-                            svfloat32_t vC = GGML_F32_VEC_LOAD(&C[k + g*nc]);
-                            svfloat32_t vs0 = GGML_F32_VEC_LOAD(&s0[ii*nc + k]);
+                            svfloat32_t vA = GGML_F32_VEC_LOAD(&A[h * nc + k]);
+                            svfloat32_t vB = GGML_F32_VEC_LOAD(&B[k + g * nc]);
+                            svfloat32_t vC = GGML_F32_VEC_LOAD(&C[k + g * nc]);
+                            svfloat32_t vs0 = GGML_F32_VEC_LOAD(&s0[ii * nc + k]);
 
                             svfloat32_t t1 = GGML_F32_VEC_MUL(vdt_soft_plus, vA);
                             t1 = exp_ps_sve(svptrue_b32(), t1);
@@ -9948,7 +9278,7 @@ static void ggml_compute_forward_ssm_scan_f32(
                             vs0 = GGML_F32_VEC_FMA(t2, vs0, t1);
                             r1_vector = GGML_F32_VEC_ADD(GGML_F32_VEC_MUL(vs0, vC), r1_vector);
 
-                            GGML_F32_VEC_STORE(&s[ii*nc + k], vs0);
+                            GGML_F32_VEC_STORE(&s[ii * nc + k], vs0);
                         }
                         y[ii] = GGML_F32xt_REDUCE_ONE(r1_vector);
 #else
@@ -9957,10 +9287,10 @@ static void ggml_compute_forward_ssm_scan_f32(
                         //       and also because expf is used within the loop.
                         // d_state
                         for (int i0 = 0; i0 < nc; ++i0) {
-                            const int i = i0 + ii*nc;
-                            const int ig = i0 + g*nc;
+                            const int i = i0 + ii * nc;
+                            const int ig = i0 + g * nc;
                             // state = prev_state * dA + dB * x
-                            const float state = (s0[i] * expf(dt_soft_plus * A[i0 + h*nc])) + (B[ig] * x_dt);
+                            const float state = (s0[i] * expf(dt_soft_plus * A[i0 + h * nc])) + (B[ig] * x_dt);
                             // y = rowwise_dotprod(state, C)
                             sumf += state * C[ig];
                             s[i] = state;
@@ -9976,58 +9306,52 @@ static void ggml_compute_forward_ssm_scan_f32(
     }
 }
 
-void ggml_compute_forward_ssm_scan(
-        const ggml_compute_params * params,
-        ggml_tensor * dst) {
+void ggml_compute_forward_ssm_scan(const ggml_compute_params* params, ggml_tensor* dst) {
     switch (dst->src[0]->type) {
-        case GGML_TYPE_F32:
-            {
-                ggml_compute_forward_ssm_scan_f32(params, dst);
-            } break;
-        default:
-            {
-                GGML_ABORT("fatal error");
-            }
+    case GGML_TYPE_F32: {
+        ggml_compute_forward_ssm_scan_f32(params, dst);
+    } break;
+    default: {
+        GGML_ABORT("fatal error");
+    }
     }
 }
 
 // ggml_compute_forward_win_part
 
-static void ggml_compute_forward_win_part_f32(
-        const ggml_compute_params * params,
-        ggml_tensor * dst) {
+static void ggml_compute_forward_win_part_f32(const ggml_compute_params* params, ggml_tensor* dst) {
     GGML_UNUSED(params);
 
-    const ggml_tensor * src0 = dst->src[0];
+    const ggml_tensor* src0 = dst->src[0];
 
     GGML_TENSOR_LOCALS(int64_t, ne0, src0, ne)
-    GGML_TENSOR_LOCALS(int64_t, ne,  dst,  ne)
+    GGML_TENSOR_LOCALS(int64_t, ne, dst, ne)
 
-    const int32_t nep0 = ((const int32_t *)(dst->op_params))[0];
-    const int32_t nep1 = ((const int32_t *)(dst->op_params))[1];
-    const int32_t w    = ((const int32_t *)(dst->op_params))[2];
+    const int32_t nep0 = ((const int32_t*)(dst->op_params))[0];
+    const int32_t nep1 = ((const int32_t*)(dst->op_params))[1];
+    const int32_t w = ((const int32_t*)(dst->op_params))[2];
 
     assert(ne00 == ne0);
-    assert(ne3  == nep0*nep1);
+    assert(ne3 == nep0 * nep1);
 
     // TODO: optimize / multi-thread
     for (int py = 0; py < nep1; ++py) {
         for (int px = 0; px < nep0; ++px) {
-            const int64_t i3 = py*nep0 + px;
+            const int64_t i3 = py * nep0 + px;
             for (int64_t i2 = 0; i2 < ne2; ++i2) {
                 for (int64_t i1 = 0; i1 < ne1; ++i1) {
                     for (int64_t i0 = 0; i0 < ne0; ++i0) {
-                        const int64_t i02 = py*w + i2;
-                        const int64_t i01 = px*w + i1;
+                        const int64_t i02 = py * w + i2;
+                        const int64_t i01 = px * w + i1;
                         const int64_t i00 = i0;
 
-                        const int64_t i = i3*ne2*ne1*ne0 + i2*ne1*ne0    + i1*ne0   + i0;
-                        const int64_t j =                  i02*ne01*ne00 + i01*ne00 + i00;
+                        const int64_t i = i3 * ne2 * ne1 * ne0 + i2 * ne1 * ne0 + i1 * ne0 + i0;
+                        const int64_t j = i02 * ne01 * ne00 + i01 * ne00 + i00;
 
-                        if (py*w + i2 >= ne02 || px*w + i1 >= ne01) {
-                            ((float *) dst->data)[i] = 0.0f;
+                        if (py * w + i2 >= ne02 || px * w + i1 >= ne01) {
+                            ((float*)dst->data)[i] = 0.0f;
                         } else {
-                            ((float *) dst->data)[i] = ((float *) src0->data)[j];
+                            ((float*)dst->data)[i] = ((float*)src0->data)[j];
                         }
                     }
                 }
@@ -10036,43 +9360,36 @@ static void ggml_compute_forward_win_part_f32(
     }
 }
 
-void ggml_compute_forward_win_part(
-        const ggml_compute_params * params,
-        ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
+void ggml_compute_forward_win_part(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
 
     switch (src0->type) {
-        case GGML_TYPE_F32:
-            {
-                ggml_compute_forward_win_part_f32(params, dst);
-            } break;
-        default:
-            {
-                GGML_ABORT("fatal error");
-            }
+    case GGML_TYPE_F32: {
+        ggml_compute_forward_win_part_f32(params, dst);
+    } break;
+    default: {
+        GGML_ABORT("fatal error");
+    }
     }
 }
 
 // ggml_compute_forward_win_unpart
 
-static void ggml_compute_forward_win_unpart_f32(
-        const ggml_compute_params * params,
-        ggml_tensor * dst) {
+static void ggml_compute_forward_win_unpart_f32(const ggml_compute_params* params, ggml_tensor* dst) {
     GGML_UNUSED(params);
 
-    const ggml_tensor * src0 = dst->src[0];
+    const ggml_tensor* src0 = dst->src[0];
 
     GGML_TENSOR_LOCALS(int64_t, ne0, src0, ne)
-    GGML_TENSOR_LOCALS(int64_t, ne,  dst,  ne)
+    GGML_TENSOR_LOCALS(int64_t, ne, dst, ne)
 
-    const int32_t w = ((const int32_t *)(dst->op_params))[0];
+    const int32_t w = ((const int32_t*)(dst->op_params))[0];
 
     // padding
-    const int px = (w - ne1%w)%w;
+    const int px = (w - ne1 % w) % w;
     //const int py = (w - ne2%w)%w;
 
-    const int npx = (px + ne1)/w;
+    const int npx = (px + ne1) / w;
     //const int npy = (py + ne2)/w;
 
     assert(ne0 == ne00);
@@ -10081,196 +9398,152 @@ static void ggml_compute_forward_win_unpart_f32(
     for (int64_t i2 = 0; i2 < ne2; ++i2) {
         for (int64_t i1 = 0; i1 < ne1; ++i1) {
             for (int64_t i0 = 0; i0 < ne0; ++i0) {
-                const int ip2 = i2/w;
-                const int ip1 = i1/w;
+                const int ip2 = i2 / w;
+                const int ip1 = i1 / w;
 
-                const int64_t i02 = i2%w;
-                const int64_t i01 = i1%w;
+                const int64_t i02 = i2 % w;
+                const int64_t i01 = i1 % w;
                 const int64_t i00 = i0;
 
-                const int64_t i = (ip2*npx + ip1)*ne02*ne01*ne00 + i02*ne01*ne00 + i01*ne00 + i00;
-                const int64_t j =                                  i2*ne1*ne0    + i1*ne0   + i0;
+                const int64_t i = (ip2 * npx + ip1) * ne02 * ne01 * ne00 + i02 * ne01 * ne00 + i01 * ne00 + i00;
+                const int64_t j = i2 * ne1 * ne0 + i1 * ne0 + i0;
 
-                ((float *) dst->data)[j] = ((float *) src0->data)[i];
+                ((float*)dst->data)[j] = ((float*)src0->data)[i];
             }
         }
     }
 }
 
-void ggml_compute_forward_win_unpart(
-        const ggml_compute_params * params,
-        ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
+void ggml_compute_forward_win_unpart(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
 
     switch (src0->type) {
-        case GGML_TYPE_F32:
-            {
-                ggml_compute_forward_win_unpart_f32(params, dst);
-            } break;
-        default:
-            {
-                GGML_ABORT("fatal error");
-            }
+    case GGML_TYPE_F32: {
+        ggml_compute_forward_win_unpart_f32(params, dst);
+    } break;
+    default: {
+        GGML_ABORT("fatal error");
+    }
     }
 }
 
 //ggml_compute_forward_unary
 
-void ggml_compute_forward_unary(
-        const ggml_compute_params * params,
-        ggml_tensor * dst) {
-
+void ggml_compute_forward_unary(const ggml_compute_params* params, ggml_tensor* dst) {
     const ggml_unary_op op = ggml_get_unary_op(dst);
 
     switch (op) {
-        case GGML_UNARY_OP_ABS:
-            {
-                ggml_compute_forward_abs(params, dst);
-            } break;
-        case GGML_UNARY_OP_SGN:
-            {
-                ggml_compute_forward_sgn(params, dst);
-            } break;
-        case GGML_UNARY_OP_NEG:
-            {
-                ggml_compute_forward_neg(params, dst);
-            } break;
-        case GGML_UNARY_OP_STEP:
-            {
-                ggml_compute_forward_step(params, dst);
-            } break;
-        case GGML_UNARY_OP_TANH:
-            {
-                ggml_compute_forward_tanh(params, dst);
-            } break;
-        case GGML_UNARY_OP_ELU:
-            {
-                ggml_compute_forward_elu(params, dst);
-            } break;
-        case GGML_UNARY_OP_RELU:
-            {
-                ggml_compute_forward_relu(params, dst);
-            } break;
-        case GGML_UNARY_OP_SIGMOID:
-            {
-                ggml_compute_forward_sigmoid(params, dst);
-            } break;
-        case GGML_UNARY_OP_GELU:
-            {
-                ggml_compute_forward_gelu(params, dst);
-            } break;
-        case GGML_UNARY_OP_GELU_ERF:
-            {
-                ggml_compute_forward_gelu_erf(params, dst);
-            } break;
-        case GGML_UNARY_OP_GELU_QUICK:
-            {
-                ggml_compute_forward_gelu_quick(params, dst);
-            } break;
-        case GGML_UNARY_OP_SILU:
-            {
-                ggml_compute_forward_silu(params, dst);
-            } break;
-        case GGML_UNARY_OP_HARDSWISH:
-            {
-                ggml_compute_forward_hardswish(params, dst);
-            } break;
-        case GGML_UNARY_OP_HARDSIGMOID:
-            {
-                ggml_compute_forward_hardsigmoid(params, dst);
-            } break;
-        case GGML_UNARY_OP_EXP:
-            {
-                ggml_compute_forward_exp(params, dst);
-            } break;
-        case GGML_UNARY_OP_FLOOR:
-            {
-                ggml_compute_forward_floor(params, dst);
-            } break;
-        case GGML_UNARY_OP_CEIL:
-            {
-                ggml_compute_forward_ceil(params, dst);
-            } break;
-        case GGML_UNARY_OP_ROUND:
-            {
-                ggml_compute_forward_round(params, dst);
-            } break;
-        case GGML_UNARY_OP_TRUNC:
-            {
-                ggml_compute_forward_trunc(params, dst);
-            } break;
-        case GGML_UNARY_OP_XIELU:
-            {
-                ggml_compute_forward_xielu(params, dst);
-            } break;
-        case GGML_UNARY_OP_EXPM1:
-            {
-                ggml_compute_forward_expm1(params, dst);
-            } break;
-        case GGML_UNARY_OP_SOFTPLUS:
-            {
-                ggml_compute_forward_softplus(params, dst);
-            } break;
-        default:
-            {
-                GGML_ABORT("fatal error");
-            }
+    case GGML_UNARY_OP_ABS: {
+        ggml_compute_forward_abs(params, dst);
+    } break;
+    case GGML_UNARY_OP_SGN: {
+        ggml_compute_forward_sgn(params, dst);
+    } break;
+    case GGML_UNARY_OP_NEG: {
+        ggml_compute_forward_neg(params, dst);
+    } break;
+    case GGML_UNARY_OP_STEP: {
+        ggml_compute_forward_step(params, dst);
+    } break;
+    case GGML_UNARY_OP_TANH: {
+        ggml_compute_forward_tanh(params, dst);
+    } break;
+    case GGML_UNARY_OP_ELU: {
+        ggml_compute_forward_elu(params, dst);
+    } break;
+    case GGML_UNARY_OP_RELU: {
+        ggml_compute_forward_relu(params, dst);
+    } break;
+    case GGML_UNARY_OP_SIGMOID: {
+        ggml_compute_forward_sigmoid(params, dst);
+    } break;
+    case GGML_UNARY_OP_GELU: {
+        ggml_compute_forward_gelu(params, dst);
+    } break;
+    case GGML_UNARY_OP_GELU_ERF: {
+        ggml_compute_forward_gelu_erf(params, dst);
+    } break;
+    case GGML_UNARY_OP_GELU_QUICK: {
+        ggml_compute_forward_gelu_quick(params, dst);
+    } break;
+    case GGML_UNARY_OP_SILU: {
+        ggml_compute_forward_silu(params, dst);
+    } break;
+    case GGML_UNARY_OP_HARDSWISH: {
+        ggml_compute_forward_hardswish(params, dst);
+    } break;
+    case GGML_UNARY_OP_HARDSIGMOID: {
+        ggml_compute_forward_hardsigmoid(params, dst);
+    } break;
+    case GGML_UNARY_OP_EXP: {
+        ggml_compute_forward_exp(params, dst);
+    } break;
+    case GGML_UNARY_OP_FLOOR: {
+        ggml_compute_forward_floor(params, dst);
+    } break;
+    case GGML_UNARY_OP_CEIL: {
+        ggml_compute_forward_ceil(params, dst);
+    } break;
+    case GGML_UNARY_OP_ROUND: {
+        ggml_compute_forward_round(params, dst);
+    } break;
+    case GGML_UNARY_OP_TRUNC: {
+        ggml_compute_forward_trunc(params, dst);
+    } break;
+    case GGML_UNARY_OP_XIELU: {
+        ggml_compute_forward_xielu(params, dst);
+    } break;
+    case GGML_UNARY_OP_EXPM1: {
+        ggml_compute_forward_expm1(params, dst);
+    } break;
+    case GGML_UNARY_OP_SOFTPLUS: {
+        ggml_compute_forward_softplus(params, dst);
+    } break;
+    default: {
+        GGML_ABORT("fatal error");
+    }
     }
 }
 
 //ggml_compute_forward_glu
 
-void ggml_compute_forward_glu(
-        const ggml_compute_params * params,
-        ggml_tensor * dst) {
-
+void ggml_compute_forward_glu(const ggml_compute_params* params, ggml_tensor* dst) {
     const ggml_glu_op op = ggml_get_glu_op(dst);
 
     switch (op) {
-        case GGML_GLU_OP_REGLU:
-            {
-                ggml_compute_forward_reglu(params, dst);
-            } break;
-        case GGML_GLU_OP_GEGLU:
-            {
-                ggml_compute_forward_geglu(params, dst);
-            } break;
-        case GGML_GLU_OP_SWIGLU:
-            {
-                ggml_compute_forward_swiglu(params, dst);
-            } break;
-        case GGML_GLU_OP_SWIGLU_OAI:
-            {
-                ggml_compute_forward_swiglu_oai(params, dst);
-            } break;
-        case GGML_GLU_OP_GEGLU_ERF:
-            {
-                ggml_compute_forward_geglu_erf(params, dst);
-            } break;
-        case GGML_GLU_OP_GEGLU_QUICK:
-            {
-                ggml_compute_forward_geglu_quick(params, dst);
-            } break;
-        case GGML_GLU_OP_SIGLU:
-            {
-                ggml_compute_forward_siglu(params, dst);
-            } break;
-        default:
-            {
-                GGML_ABORT("fatal error");
-            }
+    case GGML_GLU_OP_REGLU: {
+        ggml_compute_forward_reglu(params, dst);
+    } break;
+    case GGML_GLU_OP_GEGLU: {
+        ggml_compute_forward_geglu(params, dst);
+    } break;
+    case GGML_GLU_OP_SWIGLU: {
+        ggml_compute_forward_swiglu(params, dst);
+    } break;
+    case GGML_GLU_OP_SWIGLU_OAI: {
+        ggml_compute_forward_swiglu_oai(params, dst);
+    } break;
+    case GGML_GLU_OP_GEGLU_ERF: {
+        ggml_compute_forward_geglu_erf(params, dst);
+    } break;
+    case GGML_GLU_OP_GEGLU_QUICK: {
+        ggml_compute_forward_geglu_quick(params, dst);
+    } break;
+    case GGML_GLU_OP_SIGLU: {
+        ggml_compute_forward_siglu(params, dst);
+    } break;
+    default: {
+        GGML_ABORT("fatal error");
+    }
     }
 }
 
 // ggml_compute_forward_get_rel_pos
 
-static void ggml_compute_forward_get_rel_pos_f16(
-        const ggml_compute_params * params,
-        ggml_tensor * dst) {
+static void ggml_compute_forward_get_rel_pos_f16(const ggml_compute_params* params, ggml_tensor* dst) {
     GGML_UNUSED(params);
 
-    const ggml_tensor * src0 = dst->src[0];
+    const ggml_tensor* src0 = dst->src[0];
 
     // ref: https://github.com/facebookresearch/segment-anything/blob/main/segment_anything/modeling/image_encoder.py#L292-L322
 
@@ -10278,60 +9551,52 @@ static void ggml_compute_forward_get_rel_pos_f16(
 
     const int64_t w = ne1;
 
-    ggml_fp16_t * src0_data = (ggml_fp16_t *) src0->data;
-    ggml_fp16_t * dst_data  = (ggml_fp16_t *) dst->data;
+    ggml_fp16_t* src0_data = (ggml_fp16_t*)src0->data;
+    ggml_fp16_t* dst_data = (ggml_fp16_t*)dst->data;
 
     for (int64_t i2 = 0; i2 < ne2; ++i2) {
         for (int64_t i1 = 0; i1 < ne1; ++i1) {
             const int64_t pos = (w - i1 - 1) + i2;
             for (int64_t i0 = 0; i0 < ne0; ++i0) {
-                dst_data[i2*ne1*ne0 + i1*ne0 + i0] = src0_data[pos*ne00 + i0];
+                dst_data[i2 * ne1 * ne0 + i1 * ne0 + i0] = src0_data[pos * ne00 + i0];
             }
         }
     }
 }
 
-void ggml_compute_forward_get_rel_pos(
-        const ggml_compute_params * params,
-        ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
+void ggml_compute_forward_get_rel_pos(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
 
     switch (src0->type) {
-        case GGML_TYPE_F16:
-        case GGML_TYPE_BF16:
-            {
-                ggml_compute_forward_get_rel_pos_f16(params, dst);
-            } break;
-        default:
-            {
-                GGML_ABORT("fatal error");
-            }
+    case GGML_TYPE_F16:
+    case GGML_TYPE_BF16: {
+        ggml_compute_forward_get_rel_pos_f16(params, dst);
+    } break;
+    default: {
+        GGML_ABORT("fatal error");
+    }
     }
 }
 
 // ggml_compute_forward_add_rel_pos
 
-static void ggml_compute_forward_add_rel_pos_f32(
-        const ggml_compute_params * params,
-        ggml_tensor * dst) {
+static void ggml_compute_forward_add_rel_pos_f32(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
+    const ggml_tensor* src1 = dst->src[1];
+    const ggml_tensor* src2 = dst->src[2];
 
-    const ggml_tensor * src0 = dst->src[0];
-    const ggml_tensor * src1 = dst->src[1];
-    const ggml_tensor * src2 = dst->src[2];
-
-    const bool inplace = (bool) ((int32_t *) dst->op_params)[0];
+    const bool inplace = (bool)((int32_t*)dst->op_params)[0];
     if (!inplace) {
         if (params->ith == 0) {
-            memcpy((char *) dst->data, (char *) src0->data, ggml_nbytes(dst));
+            memcpy((char*)dst->data, (char*)src0->data, ggml_nbytes(dst));
         }
         ggml_barrier(params->threadpool);
     }
     // ref: https://github.com/facebookresearch/segment-anything/blob/main/segment_anything/modeling/image_encoder.py#L357-L359
 
-    float * src1_data = (float *) src1->data;
-    float * src2_data = (float *) src2->data;
-    float * dst_data  = (float *) dst->data;
+    float* src1_data = (float*)src1->data;
+    float* src2_data = (float*)src2->data;
+    float* dst_data = (float*)dst->data;
 
     const int64_t ne10 = src1->ne[0];
     const int64_t ne11 = src1->ne[1];
@@ -10345,18 +9610,18 @@ static void ggml_compute_forward_add_rel_pos_f32(
     const int np = ne13;
 
     // patches per thread
-    const int dp = (np + nth - 1)/nth;
+    const int dp = (np + nth - 1) / nth;
 
     // patch range for this thread
-    const int ip0 = dp*ith;
+    const int ip0 = dp * ith;
     const int ip1 = MIN(ip0 + dp, np);
 
     for (int64_t i13 = ip0; i13 < ip1; ++i13) {
         for (int64_t i12 = 0; i12 < ne12; ++i12) {
             for (int64_t i11 = 0; i11 < ne11; ++i11) {
-                const int64_t jp1 = i13*ne12*ne11*ne10 + i12*ne11*ne10 + i11*ne10;
+                const int64_t jp1 = i13 * ne12 * ne11 * ne10 + i12 * ne11 * ne10 + i11 * ne10;
                 for (int64_t i10 = 0; i10 < ne10; ++i10) {
-                    const int64_t jp0  = jp1 + i10;
+                    const int64_t jp0 = jp1 + i10;
                     const float src1_e = src1_data[jp0];
                     const float src2_e = src2_data[jp0];
 
@@ -10364,8 +9629,8 @@ static void ggml_compute_forward_add_rel_pos_f32(
                     const int64_t jdw = jdh - (ne10 - 1) * i10;
 
                     for (int64_t j = 0; j < ne10; ++j) {
-                        dst_data[jdh + j     ] += src2_e;
-                        dst_data[jdw + j*ne10] += src1_e;
+                        dst_data[jdh + j] += src2_e;
+                        dst_data[jdw + j * ne10] += src1_e;
                     }
                 }
             }
@@ -10373,50 +9638,42 @@ static void ggml_compute_forward_add_rel_pos_f32(
     }
 }
 
-void ggml_compute_forward_add_rel_pos(
-        const ggml_compute_params * params,
-        ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
+void ggml_compute_forward_add_rel_pos(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
 
     switch (src0->type) {
-        case GGML_TYPE_F32:
-            {
-                ggml_compute_forward_add_rel_pos_f32(params, dst);
-            } break;
-        default:
-            {
-                GGML_ABORT("fatal error");
-            }
+    case GGML_TYPE_F32: {
+        ggml_compute_forward_add_rel_pos_f32(params, dst);
+    } break;
+    default: {
+        GGML_ABORT("fatal error");
+    }
     }
 }
 
 // ggml_compute_forward_rwkv_wkv6
 
-static void ggml_compute_forward_rwkv_wkv6_f32(
-        const ggml_compute_params * params,
-        ggml_tensor * dst) {
+static void ggml_compute_forward_rwkv_wkv6_f32(const ggml_compute_params* params, ggml_tensor* dst) {
     const int64_t T = dst->src[1]->ne[2];
     const int64_t C = dst->ne[0];
     const int64_t HEADS = dst->src[1]->ne[1];
     const int64_t n_seqs = dst->src[5]->ne[1];
     const int64_t head_size = C / HEADS;
 
-    float * dst_data = (float *) dst->data;
-    float * state = ((float *) dst->data) + C * T;
+    float* dst_data = (float*)dst->data;
+    float* state = ((float*)dst->data) + C * T;
 
     const int ith = params->ith;
     const int nth = params->nth;
 
-    const int h_start =  (HEADS * (ith    )) / nth;
-    const int h_end   = ((HEADS * (ith + 1)) / nth < HEADS) ?
-                         (HEADS * (ith + 1)) / nth : HEADS;
+    const int h_start = (HEADS * (ith)) / nth;
+    const int h_end = ((HEADS * (ith + 1)) / nth < HEADS) ? (HEADS * (ith + 1)) / nth : HEADS;
 
-    float * k =          (float *) dst->src[0]->data;
-    float * v =          (float *) dst->src[1]->data;
-    float * r =          (float *) dst->src[2]->data;
-    float * time_faaaa = (float *) dst->src[3]->data;
-    float * time_decay = (float *) dst->src[4]->data;
+    float* k = (float*)dst->src[0]->data;
+    float* v = (float*)dst->src[1]->data;
+    float* r = (float*)dst->src[2]->data;
+    float* time_faaaa = (float*)dst->src[3]->data;
+    float* time_decay = (float*)dst->src[4]->data;
 
     size_t t_stride = HEADS * head_size; // Same to C
 
@@ -10430,184 +9687,177 @@ static void ggml_compute_forward_rwkv_wkv6_f32(
     ggml_barrier(params->threadpool);
 
 
-    #if defined(__AVX__) && !defined(__AVX512F__)
-        #define GGML_F32X GGML_F32x8
-        #define GGML_F32X_SET1 GGML_F32x8_SET1
-        #define GGML_F32X_LOAD GGML_F32x8_LOAD
-        #define GGML_F32X_STORE GGML_F32x8_STORE
-        #define GGML_F32X_MUL GGML_F32x8_MUL
-        #define GGML_F32X_FMA GGML_F32x8_FMA
-        #define WKV_VECTOR_SIZE 8
-    #elif defined(__AVX512F__)
-        #define GGML_F32X GGML_F32x16
-        #define GGML_F32X_SET1 GGML_F32x16_SET1
-        #define GGML_F32X_LOAD GGML_F32x16_LOAD
-        #define GGML_F32X_STORE GGML_F32x16_STORE
-        #define GGML_F32X_MUL GGML_F32x16_MUL
-        #define GGML_F32X_FMA GGML_F32x16_FMA
-        #define WKV_VECTOR_SIZE 16
-    #elif defined(__ARM_FEATURE_SVE) && defined(__aarch64__)
-        #define GGML_F32X GGML_F32xt
-        #define GGML_F32X_SET1 GGML_F32xt_SET1
-        #define GGML_F32X_LOAD GGML_F32xt_LOAD
-        #define GGML_F32X_STORE GGML_F32xt_STORE
-        #define GGML_F32X_MUL GGML_F32xt_MUL
-        #define GGML_F32X_FMA GGML_F32xt_FMA
-        #define WKV_VECTOR_SIZE 8
-    #elif defined(__ARM_NEON) && defined(__aarch64__)
-        #define GGML_F32X GGML_F32x4
-        #define GGML_F32X_SET1 GGML_F32x4_SET1
-        #define GGML_F32X_LOAD GGML_F32x4_LOAD
-        #define GGML_F32X_STORE GGML_F32x4_STORE
-        #define GGML_F32X_MUL GGML_F32x4_MUL
-        #define GGML_F32X_FMA GGML_F32x4_FMA
-        #define WKV_VECTOR_SIZE 4
-    #endif
+#if defined(__AVX__) && !defined(__AVX512F__)
+#define GGML_F32X GGML_F32x8
+#define GGML_F32X_SET1 GGML_F32x8_SET1
+#define GGML_F32X_LOAD GGML_F32x8_LOAD
+#define GGML_F32X_STORE GGML_F32x8_STORE
+#define GGML_F32X_MUL GGML_F32x8_MUL
+#define GGML_F32X_FMA GGML_F32x8_FMA
+#define WKV_VECTOR_SIZE 8
+#elif defined(__AVX512F__)
+#define GGML_F32X GGML_F32x16
+#define GGML_F32X_SET1 GGML_F32x16_SET1
+#define GGML_F32X_LOAD GGML_F32x16_LOAD
+#define GGML_F32X_STORE GGML_F32x16_STORE
+#define GGML_F32X_MUL GGML_F32x16_MUL
+#define GGML_F32X_FMA GGML_F32x16_FMA
+#define WKV_VECTOR_SIZE 16
+#elif defined(__ARM_FEATURE_SVE) && defined(__aarch64__)
+#define GGML_F32X GGML_F32xt
+#define GGML_F32X_SET1 GGML_F32xt_SET1
+#define GGML_F32X_LOAD GGML_F32xt_LOAD
+#define GGML_F32X_STORE GGML_F32xt_STORE
+#define GGML_F32X_MUL GGML_F32xt_MUL
+#define GGML_F32X_FMA GGML_F32xt_FMA
+#define WKV_VECTOR_SIZE 8
+#elif defined(__ARM_NEON) && defined(__aarch64__)
+#define GGML_F32X GGML_F32x4
+#define GGML_F32X_SET1 GGML_F32x4_SET1
+#define GGML_F32X_LOAD GGML_F32x4_LOAD
+#define GGML_F32X_STORE GGML_F32x4_STORE
+#define GGML_F32X_MUL GGML_F32x4_MUL
+#define GGML_F32X_FMA GGML_F32x4_FMA
+#define WKV_VECTOR_SIZE 4
+#endif
 
-    #ifdef WKV_VECTOR_SIZE
-        int wkv_vector_size;
-        #if defined(__ARM_FEATURE_SVE)
-            wkv_vector_size = svcntw();
-        #else
-            wkv_vector_size = WKV_VECTOR_SIZE;
-        #endif
-        const int64_t vec_count = head_size / wkv_vector_size;
+#ifdef WKV_VECTOR_SIZE
+    int wkv_vector_size;
+#if defined(__ARM_FEATURE_SVE)
+    wkv_vector_size = svcntw();
+#else
+    wkv_vector_size = WKV_VECTOR_SIZE;
+#endif
+    const int64_t vec_count = head_size / wkv_vector_size;
 
-        for (int64_t t = 0; t < T; t++) {
-            size_t t_offset = t * t_stride;
-            size_t state_offset = head_size * C * (t / (T / n_seqs));
-            float * state_cur = state + state_offset;
-            float * state_prev = t % (T / n_seqs) ? state_cur : (float*)dst->src[5]->data + state_offset;
+    for (int64_t t = 0; t < T; t++) {
+        size_t t_offset = t * t_stride;
+        size_t state_offset = head_size * C * (t / (T / n_seqs));
+        float* state_cur = state + state_offset;
+        float* state_prev = t % (T / n_seqs) ? state_cur : (float*)dst->src[5]->data + state_offset;
 
-            for (int64_t h = h_start; h < h_end; h++) {
-                size_t h_offset = h * h_stride;
-                size_t t_h_offset = t_offset + h_offset;
-                size_t h_2d_offset = h * h_stride_2d;
+        for (int64_t h = h_start; h < h_end; h++) {
+            size_t h_offset = h * h_stride;
+            size_t t_h_offset = t_offset + h_offset;
+            size_t h_2d_offset = h * h_stride_2d;
 
-                for (int64_t i = 0; i < head_size; i++) {
-                    size_t t_h_i_offset = t_h_offset + i;
-                    size_t h_i_offset = h_offset + i;
-                    size_t h_2d_i_offset = h_2d_offset + i * h_stride;
+            for (int64_t i = 0; i < head_size; i++) {
+                size_t t_h_i_offset = t_h_offset + i;
+                size_t h_i_offset = h_offset + i;
+                size_t h_2d_i_offset = h_2d_offset + i * h_stride;
 
-                    float k_val = k[t_h_i_offset];
-                    float r_val = r[t_h_i_offset];
-                    float time_faaaa_val = time_faaaa[h_i_offset];
-                    float time_decay_val = time_decay[t_h_i_offset];
+                float k_val = k[t_h_i_offset];
+                float r_val = r[t_h_i_offset];
+                float time_faaaa_val = time_faaaa[h_i_offset];
+                float time_decay_val = time_decay[t_h_i_offset];
 
-                    // Broadcast scalar values to vectors
-                    GGML_F32X k_vec = GGML_F32X_SET1(k_val);
-                    GGML_F32X r_vec = GGML_F32X_SET1(r_val);
-                    GGML_F32X time_faaaa_vec = GGML_F32X_SET1(time_faaaa_val);
-                    GGML_F32X time_decay_vec = GGML_F32X_SET1(time_decay_val);
+                // Broadcast scalar values to vectors
+                GGML_F32X k_vec = GGML_F32X_SET1(k_val);
+                GGML_F32X r_vec = GGML_F32X_SET1(r_val);
+                GGML_F32X time_faaaa_vec = GGML_F32X_SET1(time_faaaa_val);
+                GGML_F32X time_decay_vec = GGML_F32X_SET1(time_decay_val);
 
-                    for (int64_t j = 0; j < vec_count; j++) {
-                        size_t base_j = j * wkv_vector_size;
-                        size_t t_h_j_offset = t_h_offset + base_j;
-                        size_t h_2d_i_j_offset = h_2d_i_offset + base_j;
+                for (int64_t j = 0; j < vec_count; j++) {
+                    size_t base_j = j * wkv_vector_size;
+                    size_t t_h_j_offset = t_h_offset + base_j;
+                    size_t h_2d_i_j_offset = h_2d_i_offset + base_j;
 
-                        // Load x elements at once
-                        GGML_F32X v_vec = GGML_F32X_LOAD(&v[t_h_j_offset]);
-                        GGML_F32X prev_state_vec = GGML_F32X_LOAD(&state_prev[h_2d_i_j_offset]);
-                        GGML_F32X dst_vec = GGML_F32X_LOAD(&dst_data[t_h_j_offset]);
+                    // Load x elements at once
+                    GGML_F32X v_vec = GGML_F32X_LOAD(&v[t_h_j_offset]);
+                    GGML_F32X prev_state_vec = GGML_F32X_LOAD(&state_prev[h_2d_i_j_offset]);
+                    GGML_F32X dst_vec = GGML_F32X_LOAD(&dst_data[t_h_j_offset]);
 
-                        // Compute kv = v * k
-                        GGML_F32X kv_vec = GGML_F32X_MUL(v_vec, k_vec);
+                    // Compute kv = v * k
+                    GGML_F32X kv_vec = GGML_F32X_MUL(v_vec, k_vec);
 
-                        // Compute temp = kv * time_faaaa + prev_state
-                        GGML_F32X temp_vec = GGML_F32X_FMA(prev_state_vec, kv_vec, time_faaaa_vec);
+                    // Compute temp = kv * time_faaaa + prev_state
+                    GGML_F32X temp_vec = GGML_F32X_FMA(prev_state_vec, kv_vec, time_faaaa_vec);
 
-                        // Update dst: dst += temp * r
-                        dst_vec = GGML_F32X_FMA(dst_vec, temp_vec, r_vec);
-                        GGML_F32X_STORE(&dst_data[t_h_j_offset], dst_vec);
+                    // Update dst: dst += temp * r
+                    dst_vec = GGML_F32X_FMA(dst_vec, temp_vec, r_vec);
+                    GGML_F32X_STORE(&dst_data[t_h_j_offset], dst_vec);
 
-                        // Update state: state = prev_state * time_decay + kv
-                        GGML_F32X new_state_vec = GGML_F32X_FMA(kv_vec, prev_state_vec, time_decay_vec);
-                        GGML_F32X_STORE(&state_cur[h_2d_i_j_offset], new_state_vec);
-                    }
+                    // Update state: state = prev_state * time_decay + kv
+                    GGML_F32X new_state_vec = GGML_F32X_FMA(kv_vec, prev_state_vec, time_decay_vec);
+                    GGML_F32X_STORE(&state_cur[h_2d_i_j_offset], new_state_vec);
+                }
 
-                    // Handle remaining elements, this will not be used.
-                    for (int64_t j = vec_count * wkv_vector_size; j < head_size; j++) {
-                        size_t t_h_j_offset = t_h_offset + j;
-                        size_t h_2d_i_j_offset = h_2d_i_offset + j;
-                        float v_val = v[t_h_j_offset];
-                        float kv_val = v_val * k_val;
-                        float prev_state_val = state_prev[h_2d_i_j_offset];
-                        float temp_val = kv_val * time_faaaa_val + prev_state_val;
-                        dst_data[t_h_j_offset] += temp_val * r_val;
-                        state_cur[h_2d_i_j_offset] = prev_state_val * time_decay_val + kv_val;
-                    }
+                // Handle remaining elements, this will not be used.
+                for (int64_t j = vec_count * wkv_vector_size; j < head_size; j++) {
+                    size_t t_h_j_offset = t_h_offset + j;
+                    size_t h_2d_i_j_offset = h_2d_i_offset + j;
+                    float v_val = v[t_h_j_offset];
+                    float kv_val = v_val * k_val;
+                    float prev_state_val = state_prev[h_2d_i_j_offset];
+                    float temp_val = kv_val * time_faaaa_val + prev_state_val;
+                    dst_data[t_h_j_offset] += temp_val * r_val;
+                    state_cur[h_2d_i_j_offset] = prev_state_val * time_decay_val + kv_val;
                 }
             }
         }
+    }
 
-    #else
-        // basically fused operations:
-        // dst = r @ (time_faaaa * (k @ v) + state),
-        // state = time_decay * state + (k @ v),
-        // recursive through each token
-        for (int64_t t = 0; t < T; t++) {
-            size_t t_offset = t * t_stride;
-            size_t state_offset = head_size * C * (t / (T / n_seqs));
-            float * state_cur = state + state_offset;
-            float * state_prev = t % (T / n_seqs) ? state_cur : (float*)dst->src[5]->data + state_offset;
+#else
+    // basically fused operations:
+    // dst = r @ (time_faaaa * (k @ v) + state),
+    // state = time_decay * state + (k @ v),
+    // recursive through each token
+    for (int64_t t = 0; t < T; t++) {
+        size_t t_offset = t * t_stride;
+        size_t state_offset = head_size * C * (t / (T / n_seqs));
+        float* state_cur = state + state_offset;
+        float* state_prev = t % (T / n_seqs) ? state_cur : (float*)dst->src[5]->data + state_offset;
 
-            for (int64_t h = h_start; h < h_end; h++) {
-                size_t h_offset = h * h_stride;
-                size_t t_h_offset = t_offset + h_offset;
-                size_t h_2d_offset = h * h_stride_2d;
+        for (int64_t h = h_start; h < h_end; h++) {
+            size_t h_offset = h * h_stride;
+            size_t t_h_offset = t_offset + h_offset;
+            size_t h_2d_offset = h * h_stride_2d;
 
-                for (int64_t i = 0; i < head_size; i++) {
-                    size_t t_h_i_offset = t_h_offset + i;
-                    size_t h_i_offset = h_offset + i;
-                    size_t h_2d_i_offset = h_2d_offset + i * h_stride;
+            for (int64_t i = 0; i < head_size; i++) {
+                size_t t_h_i_offset = t_h_offset + i;
+                size_t h_i_offset = h_offset + i;
+                size_t h_2d_i_offset = h_2d_offset + i * h_stride;
 
-                    float k_val = k[t_h_i_offset];
-                    float r_val = r[t_h_i_offset];
-                    float time_faaaa_val = time_faaaa[h_i_offset];
-                    // RWKV v6: different time_decay for each token.
-                    float time_decay_val = time_decay[t_h_i_offset];
+                float k_val = k[t_h_i_offset];
+                float r_val = r[t_h_i_offset];
+                float time_faaaa_val = time_faaaa[h_i_offset];
+                // RWKV v6: different time_decay for each token.
+                float time_decay_val = time_decay[t_h_i_offset];
 
-                    for (int64_t j = 0; j < head_size; j++) {
-                        size_t t_h_j_offset = t_h_offset + j;
-                        size_t h_2d_i_j_offset = h_2d_i_offset + j;
+                for (int64_t j = 0; j < head_size; j++) {
+                    size_t t_h_j_offset = t_h_offset + j;
+                    size_t h_2d_i_j_offset = h_2d_i_offset + j;
 
-                        float v_val = v[t_h_j_offset];
-                        float kv_val = v_val * k_val;
-                        float prev_state_val = state_prev[h_2d_i_j_offset];
-                        float temp_val = kv_val * time_faaaa_val + prev_state_val;
-                        dst_data[t_h_j_offset] += temp_val * r_val;
-                        state_cur[h_2d_i_j_offset] = prev_state_val * time_decay_val + kv_val;
-                    }
+                    float v_val = v[t_h_j_offset];
+                    float kv_val = v_val * k_val;
+                    float prev_state_val = state_prev[h_2d_i_j_offset];
+                    float temp_val = kv_val * time_faaaa_val + prev_state_val;
+                    dst_data[t_h_j_offset] += temp_val * r_val;
+                    state_cur[h_2d_i_j_offset] = prev_state_val * time_decay_val + kv_val;
                 }
             }
         }
-    #endif
+    }
+#endif
 }
 
 
-void ggml_compute_forward_rwkv_wkv6(
-        const ggml_compute_params * params,
-        ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
+void ggml_compute_forward_rwkv_wkv6(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
 
     switch (src0->type) {
-        case GGML_TYPE_F32:
-            {
-                ggml_compute_forward_rwkv_wkv6_f32(params, dst);
-            } break;
-        default:
-            {
-                GGML_ABORT("fatal error");
-            }
+    case GGML_TYPE_F32: {
+        ggml_compute_forward_rwkv_wkv6_f32(params, dst);
+    } break;
+    default: {
+        GGML_ABORT("fatal error");
+    }
     }
 }
 
 // ggml_compute_forward_gla
 
-static void ggml_compute_forward_gla_f32(
-        const ggml_compute_params * params,
-        ggml_tensor * dst) {
+static void ggml_compute_forward_gla_f32(const ggml_compute_params* params, ggml_tensor* dst) {
     const int64_t T = dst->src[1]->ne[2];
     const int64_t C = dst->ne[0];
     const int64_t HEADS = dst->src[1]->ne[1];
@@ -10615,20 +9865,19 @@ static void ggml_compute_forward_gla_f32(
     const int64_t head_size = C / HEADS;
     const float scale = ggml_get_op_params_f32(dst, 0);
 
-    float * dst_data = (float *) dst->data;
-    float * state = ((float *) dst->data) + C * T;
+    float* dst_data = (float*)dst->data;
+    float* state = ((float*)dst->data) + C * T;
 
     const int ith = params->ith;
     const int nth = params->nth;
 
-    const int h_start =  (HEADS * (ith    )) / nth;
-    const int h_end   = ((HEADS * (ith + 1)) / nth < HEADS) ?
-                         (HEADS * (ith + 1)) / nth : HEADS;
+    const int h_start = (HEADS * (ith)) / nth;
+    const int h_end = ((HEADS * (ith + 1)) / nth < HEADS) ? (HEADS * (ith + 1)) / nth : HEADS;
 
-    float * k = (float *) dst->src[0]->data;
-    float * v = (float *) dst->src[1]->data;
-    float * q = (float *) dst->src[2]->data;
-    float * g = (float *) dst->src[3]->data;
+    float* k = (float*)dst->src[0]->data;
+    float* v = (float*)dst->src[1]->data;
+    float* q = (float*)dst->src[2]->data;
+    float* g = (float*)dst->src[3]->data;
 
     size_t t_stride = HEADS * head_size; // Same to C
 
@@ -10642,181 +9891,176 @@ static void ggml_compute_forward_gla_f32(
     ggml_barrier(params->threadpool);
 
 
-    #if defined(__AVX__) && !defined(__AVX512F__)
-        #define GGML_F32X GGML_F32x8
-        #define GGML_F32X_SET1 GGML_F32x8_SET1
-        #define GGML_F32X_LOAD GGML_F32x8_LOAD
-        #define GGML_F32X_STORE GGML_F32x8_STORE
-        #define GGML_F32X_MUL GGML_F32x8_MUL
-        #define GGML_F32X_FMA GGML_F32x8_FMA
-        #define GLA_VECTOR_SIZE 8
-    #elif defined(__AVX512F__)
-        #define GGML_F32X GGML_F32x16
-        #define GGML_F32X_SET1 GGML_F32x16_SET1
-        #define GGML_F32X_LOAD GGML_F32x16_LOAD
-        #define GGML_F32X_STORE GGML_F32x16_STORE
-        #define GGML_F32X_MUL GGML_F32x16_MUL
-        #define GGML_F32X_FMA GGML_F32x16_FMA
-        #define GLA_VECTOR_SIZE 16
-    #elif defined(__ARM_FEATURE_SVE) && defined(__aarch64__)
-        #define GGML_F32X GGML_F32xt
-        #define GGML_F32X_SET1 GGML_F32xt_SET1
-        #define GGML_F32X_LOAD GGML_F32xt_LOAD
-        #define GGML_F32X_STORE GGML_F32xt_STORE
-        #define GGML_F32X_MUL GGML_F32xt_MUL
-        #define GGML_F32X_FMA GGML_F32xt_FMA
-        #define GLA_VECTOR_SIZE 8
-    #elif defined(__ARM_NEON) && defined(__aarch64__)
-        #define GGML_F32X GGML_F32x4
-        #define GGML_F32X_SET1 GGML_F32x4_SET1
-        #define GGML_F32X_LOAD GGML_F32x4_LOAD
-        #define GGML_F32X_STORE GGML_F32x4_STORE
-        #define GGML_F32X_MUL GGML_F32x4_MUL
-        #define GGML_F32X_FMA GGML_F32x4_FMA
-        #define GLA_VECTOR_SIZE 4
-    #endif
+#if defined(__AVX__) && !defined(__AVX512F__)
+#define GGML_F32X GGML_F32x8
+#define GGML_F32X_SET1 GGML_F32x8_SET1
+#define GGML_F32X_LOAD GGML_F32x8_LOAD
+#define GGML_F32X_STORE GGML_F32x8_STORE
+#define GGML_F32X_MUL GGML_F32x8_MUL
+#define GGML_F32X_FMA GGML_F32x8_FMA
+#define GLA_VECTOR_SIZE 8
+#elif defined(__AVX512F__)
+#define GGML_F32X GGML_F32x16
+#define GGML_F32X_SET1 GGML_F32x16_SET1
+#define GGML_F32X_LOAD GGML_F32x16_LOAD
+#define GGML_F32X_STORE GGML_F32x16_STORE
+#define GGML_F32X_MUL GGML_F32x16_MUL
+#define GGML_F32X_FMA GGML_F32x16_FMA
+#define GLA_VECTOR_SIZE 16
+#elif defined(__ARM_FEATURE_SVE) && defined(__aarch64__)
+#define GGML_F32X GGML_F32xt
+#define GGML_F32X_SET1 GGML_F32xt_SET1
+#define GGML_F32X_LOAD GGML_F32xt_LOAD
+#define GGML_F32X_STORE GGML_F32xt_STORE
+#define GGML_F32X_MUL GGML_F32xt_MUL
+#define GGML_F32X_FMA GGML_F32xt_FMA
+#define GLA_VECTOR_SIZE 8
+#elif defined(__ARM_NEON) && defined(__aarch64__)
+#define GGML_F32X GGML_F32x4
+#define GGML_F32X_SET1 GGML_F32x4_SET1
+#define GGML_F32X_LOAD GGML_F32x4_LOAD
+#define GGML_F32X_STORE GGML_F32x4_STORE
+#define GGML_F32X_MUL GGML_F32x4_MUL
+#define GGML_F32X_FMA GGML_F32x4_FMA
+#define GLA_VECTOR_SIZE 4
+#endif
 
-    #ifdef GLA_VECTOR_SIZE
-        int gla_vector_size;
-        #if defined(__ARM_FEATURE_SVE)
-            gla_vector_size = svcntw();
-        #else
-            gla_vector_size = GLA_VECTOR_SIZE;
-        #endif
-        const int64_t vec_count = head_size / gla_vector_size;
+#ifdef GLA_VECTOR_SIZE
+    int gla_vector_size;
+#if defined(__ARM_FEATURE_SVE)
+    gla_vector_size = svcntw();
+#else
+    gla_vector_size = GLA_VECTOR_SIZE;
+#endif
+    const int64_t vec_count = head_size / gla_vector_size;
 
-        for (int64_t t = 0; t < T; t++) {
-            size_t t_offset = t * t_stride;
-            size_t state_offset = head_size * C * (t / (T / n_seqs));
-            float * state_cur = state + state_offset;
-            float * state_prev = t % (T / n_seqs) ? state_cur : (float*)dst->src[4]->data + state_offset;
+    for (int64_t t = 0; t < T; t++) {
+        size_t t_offset = t * t_stride;
+        size_t state_offset = head_size * C * (t / (T / n_seqs));
+        float* state_cur = state + state_offset;
+        float* state_prev = t % (T / n_seqs) ? state_cur : (float*)dst->src[4]->data + state_offset;
 
-            for (int64_t h = h_start; h < h_end; h++) {
-                size_t h_offset = h * h_stride;
-                size_t t_h_offset = t_offset + h_offset;
-                size_t h_2d_offset = h * h_stride_2d;
+        for (int64_t h = h_start; h < h_end; h++) {
+            size_t h_offset = h * h_stride;
+            size_t t_h_offset = t_offset + h_offset;
+            size_t h_2d_offset = h * h_stride_2d;
 
-                for (int64_t i = 0; i < head_size; i++) {
-                    size_t t_h_i_offset = t_h_offset + i;
-                    size_t h_2d_i_offset = h_2d_offset + i * h_stride;
+            for (int64_t i = 0; i < head_size; i++) {
+                size_t t_h_i_offset = t_h_offset + i;
+                size_t h_2d_i_offset = h_2d_offset + i * h_stride;
 
-                    float k_val = k[t_h_i_offset];
-                    float q_val = q[t_h_i_offset] * scale;
-                    float g_val = g[t_h_i_offset];
+                float k_val = k[t_h_i_offset];
+                float q_val = q[t_h_i_offset] * scale;
+                float g_val = g[t_h_i_offset];
 
-                    // Broadcast scalar values to vectors
-                    GGML_F32X k_vec = GGML_F32X_SET1(k_val);
-                    GGML_F32X q_vec = GGML_F32X_SET1(q_val);
-                    GGML_F32X g_vec = GGML_F32X_SET1(g_val);
+                // Broadcast scalar values to vectors
+                GGML_F32X k_vec = GGML_F32X_SET1(k_val);
+                GGML_F32X q_vec = GGML_F32X_SET1(q_val);
+                GGML_F32X g_vec = GGML_F32X_SET1(g_val);
 
-                    for (int64_t j = 0; j < vec_count; j++) {
-                        size_t base_j = j * gla_vector_size;
-                        size_t t_h_j_offset = t_h_offset + base_j;
-                        size_t h_2d_i_j_offset = h_2d_i_offset + base_j;
+                for (int64_t j = 0; j < vec_count; j++) {
+                    size_t base_j = j * gla_vector_size;
+                    size_t t_h_j_offset = t_h_offset + base_j;
+                    size_t h_2d_i_j_offset = h_2d_i_offset + base_j;
 
-                        // Load x elements at once
-                        GGML_F32X v_vec = GGML_F32X_LOAD(&v[t_h_j_offset]);
-                        GGML_F32X prev_state_vec = GGML_F32X_LOAD(&state_prev[h_2d_i_j_offset]);
-                        GGML_F32X dst_vec = GGML_F32X_LOAD(&dst_data[t_h_j_offset]);
+                    // Load x elements at once
+                    GGML_F32X v_vec = GGML_F32X_LOAD(&v[t_h_j_offset]);
+                    GGML_F32X prev_state_vec = GGML_F32X_LOAD(&state_prev[h_2d_i_j_offset]);
+                    GGML_F32X dst_vec = GGML_F32X_LOAD(&dst_data[t_h_j_offset]);
 
-                        // Compute kv = v * k
-                        GGML_F32X kv_vec = GGML_F32X_MUL(v_vec, k_vec);
+                    // Compute kv = v * k
+                    GGML_F32X kv_vec = GGML_F32X_MUL(v_vec, k_vec);
 
-                        // Compute temp = prev_state * g + kv
-                        GGML_F32X temp_vec = GGML_F32X_FMA(kv_vec, prev_state_vec, g_vec);
+                    // Compute temp = prev_state * g + kv
+                    GGML_F32X temp_vec = GGML_F32X_FMA(kv_vec, prev_state_vec, g_vec);
 
-                        // Update dst: dst += temp * q
-                        dst_vec = GGML_F32X_FMA(dst_vec, temp_vec, q_vec);
-                        GGML_F32X_STORE(&dst_data[t_h_j_offset], dst_vec);
+                    // Update dst: dst += temp * q
+                    dst_vec = GGML_F32X_FMA(dst_vec, temp_vec, q_vec);
+                    GGML_F32X_STORE(&dst_data[t_h_j_offset], dst_vec);
 
-                        // Update state
-                        GGML_F32X_STORE(&state_cur[h_2d_i_j_offset], temp_vec);
-                    }
+                    // Update state
+                    GGML_F32X_STORE(&state_cur[h_2d_i_j_offset], temp_vec);
+                }
 
-                    // Handle remaining elements, this will not be used.
-                    for (int64_t j = vec_count * gla_vector_size; j < head_size; j++) {
-                        size_t t_h_j_offset = t_h_offset + j;
-                        size_t h_2d_i_j_offset = h_2d_i_offset + j;
-                        float v_val = v[t_h_j_offset];
-                        float kv_val = v_val * k_val;
-                        float prev_state_val = state_prev[h_2d_i_j_offset];
-                        float temp_val = kv_val + prev_state_val * g_val;
-                        dst_data[t_h_j_offset] += temp_val * q_val;
-                        state_cur[h_2d_i_j_offset] = temp_val;
-                    }
+                // Handle remaining elements, this will not be used.
+                for (int64_t j = vec_count * gla_vector_size; j < head_size; j++) {
+                    size_t t_h_j_offset = t_h_offset + j;
+                    size_t h_2d_i_j_offset = h_2d_i_offset + j;
+                    float v_val = v[t_h_j_offset];
+                    float kv_val = v_val * k_val;
+                    float prev_state_val = state_prev[h_2d_i_j_offset];
+                    float temp_val = kv_val + prev_state_val * g_val;
+                    dst_data[t_h_j_offset] += temp_val * q_val;
+                    state_cur[h_2d_i_j_offset] = temp_val;
                 }
             }
         }
+    }
 
-    #else
-        for (int64_t t = 0; t < T; t++) {
-            size_t t_offset = t * t_stride;
-            size_t state_offset = head_size * C * (t / (T / n_seqs));
-            float * state_cur = state + state_offset;
-            float * state_prev = t % (T / n_seqs) ? state_cur : (float*)dst->src[4]->data + state_offset;
+#else
+    for (int64_t t = 0; t < T; t++) {
+        size_t t_offset = t * t_stride;
+        size_t state_offset = head_size * C * (t / (T / n_seqs));
+        float* state_cur = state + state_offset;
+        float* state_prev = t % (T / n_seqs) ? state_cur : (float*)dst->src[4]->data + state_offset;
 
-            for (int64_t h = h_start; h < h_end; h++) {
-                size_t h_offset = h * h_stride;
-                size_t t_h_offset = t_offset + h_offset;
-                size_t h_2d_offset = h * h_stride_2d;
+        for (int64_t h = h_start; h < h_end; h++) {
+            size_t h_offset = h * h_stride;
+            size_t t_h_offset = t_offset + h_offset;
+            size_t h_2d_offset = h * h_stride_2d;
 
-                for (int64_t i = 0; i < head_size; i++) {
-                    size_t t_h_i_offset = t_h_offset + i;
-                    size_t h_2d_i_offset = h_2d_offset + i * h_stride;
+            for (int64_t i = 0; i < head_size; i++) {
+                size_t t_h_i_offset = t_h_offset + i;
+                size_t h_2d_i_offset = h_2d_offset + i * h_stride;
 
-                    float k_val = k[t_h_i_offset];
-                    float q_val = q[t_h_i_offset] * scale;
-                    float g_val = g[t_h_i_offset];
+                float k_val = k[t_h_i_offset];
+                float q_val = q[t_h_i_offset] * scale;
+                float g_val = g[t_h_i_offset];
 
-                    for (int64_t j = 0; j < head_size; j++) {
-                        size_t t_h_j_offset = t_h_offset + j;
-                        size_t h_2d_i_j_offset = h_2d_i_offset + j;
+                for (int64_t j = 0; j < head_size; j++) {
+                    size_t t_h_j_offset = t_h_offset + j;
+                    size_t h_2d_i_j_offset = h_2d_i_offset + j;
 
-                        float v_val = v[t_h_j_offset];
-                        float kv_val = v_val * k_val;
-                        float prev_state_val = state_prev[h_2d_i_j_offset];
-                        float temp_val = prev_state_val * g_val + kv_val;
-                        dst_data[t_h_j_offset] += temp_val * q_val;
-                        state_cur[h_2d_i_j_offset] = temp_val;
-                    }
+                    float v_val = v[t_h_j_offset];
+                    float kv_val = v_val * k_val;
+                    float prev_state_val = state_prev[h_2d_i_j_offset];
+                    float temp_val = prev_state_val * g_val + kv_val;
+                    dst_data[t_h_j_offset] += temp_val * q_val;
+                    state_cur[h_2d_i_j_offset] = temp_val;
                 }
             }
         }
-    #endif
+    }
+#endif
 }
 
 
-void ggml_compute_forward_gla(
-        const ggml_compute_params * params,
-        ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
+void ggml_compute_forward_gla(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
 
     switch (src0->type) {
-        case GGML_TYPE_F32:
-            {
-                ggml_compute_forward_gla_f32(params, dst);
-            } break;
-        default:
-            {
-                GGML_ABORT("fatal error");
-            }
+    case GGML_TYPE_F32: {
+        ggml_compute_forward_gla_f32(params, dst);
+    } break;
+    default: {
+        GGML_ABORT("fatal error");
+    }
     }
 }
 
-static void ggml_compute_forward_solve_tri_f32(const struct ggml_compute_params * params, struct ggml_tensor * dst) {
-    const struct ggml_tensor * src0 = dst->src[0];  // A (lower triangular)
-    const struct ggml_tensor * src1 = dst->src[1];  // B (RHS)
+static void ggml_compute_forward_solve_tri_f32(const struct ggml_compute_params* params, struct ggml_tensor* dst) {
+    const struct ggml_tensor* src0 = dst->src[0]; // A (lower triangular)
+    const struct ggml_tensor* src1 = dst->src[1]; // B (RHS)
 
     GGML_TENSOR_BINARY_OP_LOCALS;
 
     GGML_ASSERT(src0->type == GGML_TYPE_F32);
     GGML_ASSERT(src1->type == GGML_TYPE_F32);
-    GGML_ASSERT(dst->type  == GGML_TYPE_F32);
+    GGML_ASSERT(dst->type == GGML_TYPE_F32);
 
     GGML_ASSERT(ne00 == ne01); // A must be square
-    GGML_ASSERT(ne0  == ne10); // solution cols == B cols
-    GGML_ASSERT(ne1  == ne11); // solution rows == B rows
+    GGML_ASSERT(ne0 == ne10);  // solution cols == B cols
+    GGML_ASSERT(ne1 == ne11);  // solution rows == B rows
 
     GGML_ASSERT(ne02 == ne12 && ne12 == ne2);
     GGML_ASSERT(ne03 == ne13 && ne13 == ne3);
@@ -10824,30 +10068,30 @@ static void ggml_compute_forward_solve_tri_f32(const struct ggml_compute_params 
     const int ith = params->ith;
     const int nth = params->nth;
 
-    const int64_t k = ne10;   // number of RHS columns
-    const int64_t n = ne11;   // A is n×n
+    const int64_t k = ne10;             // number of RHS columns
+    const int64_t n = ne11;             // A is n×n
     const int64_t nr = ne02 * ne03 * k; // we're parallelizing on columns here, so seq x token x column will be the unit
 
     // chunks per thread
-    const int64_t dr = (nr + nth - 1)/nth;
+    const int64_t dr = (nr + nth - 1) / nth;
 
     // chunk range for this thread
-    const int64_t ir0 = dr*ith;
+    const int64_t ir0 = dr * ith;
     const int64_t ir1 = MIN(ir0 + dr, nr);
 
-    const float * A = (const float *) src0->data;  // [n, n, B1, B2]
-    const float * B = (const float *) src1->data;  // [n, k, B1, B2]
-          float * X = (      float *) dst->data;   // [n, k, B1, B2]
+    const float* A = (const float*)src0->data; // [n, n, B1, B2]
+    const float* B = (const float*)src1->data; // [n, k, B1, B2]
+    float* X = (float*)dst->data;              // [n, k, B1, B2]
 
     for (int64_t ir = ir0; ir < ir1; ++ir) {
-        const int64_t i03 = ir/(ne02*k);
-        const int64_t i02 = (ir - i03*ne02*k)/k;
-        const int64_t i01 = (ir - i03*ne02*k - i02*k);
+        const int64_t i03 = ir / (ne02 * k);
+        const int64_t i02 = (ir - i03 * ne02 * k) / k;
+        const int64_t i01 = (ir - i03 * ne02 * k - i02 * k);
 
-        const float * A_batch = A + i02 * nb02 / sizeof(float) + i03 * nb03 / sizeof(float);
-        const float * B_batch = B + i02 * nb12 / sizeof(float) + i03 * nb13 / sizeof(float);
+        const float* A_batch = A + i02 * nb02 / sizeof(float) + i03 * nb03 / sizeof(float);
+        const float* B_batch = B + i02 * nb12 / sizeof(float) + i03 * nb13 / sizeof(float);
 
-        float * X_batch = X + i02 * nb2 / sizeof(float) + i03 * nb3 / sizeof(float);
+        float* X_batch = X + i02 * nb2 / sizeof(float) + i03 * nb3 / sizeof(float);
 
         for (int64_t i00 = 0; i00 < n; ++i00) {
             float sum = 0.0f;
@@ -10863,9 +10107,9 @@ static void ggml_compute_forward_solve_tri_f32(const struct ggml_compute_params 
     }
 }
 
-void ggml_compute_forward_solve_tri(const struct ggml_compute_params * params, struct ggml_tensor * dst) {
-    const ggml_tensor * src0 = dst->src[0];
-    const ggml_tensor * src1 = dst->src[1];
+void ggml_compute_forward_solve_tri(const struct ggml_compute_params* params, struct ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
+    const ggml_tensor* src1 = dst->src[1];
 
     if (src0->type == GGML_TYPE_F32 && src1->type == GGML_TYPE_F32) {
         ggml_compute_forward_solve_tri_f32(params, dst);
@@ -10875,23 +10119,19 @@ void ggml_compute_forward_solve_tri(const struct ggml_compute_params * params, s
 }
 
 // ggml_compute_forward_gated_delta_net
-static void ggml_compute_forward_gated_delta_net_one_chunk(
-    const ggml_compute_params * params,
-    ggml_tensor * dst,
-    int64_t ir0,
-    int64_t ir1) {
+static void ggml_compute_forward_gated_delta_net_one_chunk(const ggml_compute_params* params, ggml_tensor* dst,
+                                                           int64_t ir0, int64_t ir1) {
+    ggml_tensor* src_q = dst->src[0];
+    ggml_tensor* src_k = dst->src[1];
+    ggml_tensor* src_v = dst->src[2];
+    ggml_tensor* src_g = dst->src[3];
+    ggml_tensor* src_beta = dst->src[4];
+    ggml_tensor* src_state = dst->src[5];
 
-    ggml_tensor * src_q     = dst->src[0];
-    ggml_tensor * src_k     = dst->src[1];
-    ggml_tensor * src_v     = dst->src[2];
-    ggml_tensor * src_g     = dst->src[3];
-    ggml_tensor * src_beta  = dst->src[4];
-    ggml_tensor * src_state = dst->src[5];
-
-    const int64_t S_v      = src_v->ne[0];
-    const int64_t H        = src_v->ne[1];
+    const int64_t S_v = src_v->ne[0];
+    const int64_t H = src_v->ne[1];
     const int64_t n_tokens = src_v->ne[2];
-    const int64_t n_seqs   = src_v->ne[3];
+    const int64_t n_seqs = src_v->ne[3];
 
     GGML_ASSERT(ggml_is_contiguous_rows(src_q));
     GGML_ASSERT(ggml_is_contiguous_rows(src_k));
@@ -10904,14 +10144,14 @@ static void ggml_compute_forward_gated_delta_net_one_chunk(
     GGML_ASSERT(src_beta->ne[0] == 1);
 
     GGML_TENSOR_LOCALS(int64_t, neq, src_q, ne);
-    GGML_TENSOR_LOCALS(size_t,  nbq, src_q, nb);
+    GGML_TENSOR_LOCALS(size_t, nbq, src_q, nb);
     GGML_TENSOR_LOCALS(int64_t, nek, src_k, ne);
-    GGML_TENSOR_LOCALS(size_t,  nbk, src_k, nb);
+    GGML_TENSOR_LOCALS(size_t, nbk, src_k, nb);
     GGML_TENSOR_LOCALS(int64_t, nev, src_v, ne);
-    GGML_TENSOR_LOCALS(size_t,  nbv, src_v, nb);
+    GGML_TENSOR_LOCALS(size_t, nbv, src_v, nb);
     GGML_TENSOR_LOCALS(int64_t, neg, src_g, ne);
-    GGML_TENSOR_LOCALS(size_t,  nbg, src_g, nb);
-    GGML_TENSOR_LOCALS(size_t,  nbb, src_beta, nb);
+    GGML_TENSOR_LOCALS(size_t, nbg, src_g, nb);
+    GGML_TENSOR_LOCALS(size_t, nbb, src_beta, nb);
 
     const bool kda = (neg0 == S_v);
 
@@ -10919,23 +10159,23 @@ static void ggml_compute_forward_gated_delta_net_one_chunk(
     const int64_t scratch_per_thread = S_v;
     const int ith = params->ith;
 
-    float * delta = (float *)params->wdata + ith * scratch_per_thread + CACHE_LINE_SIZE_F32;
+    float* delta = (float*)params->wdata + ith * scratch_per_thread + CACHE_LINE_SIZE_F32;
 
     // output layout: [attn_scores | new_states]
     // attn_scores: S_v * H * n_tokens * n_seqs floats
     // new_states:  S_v * S_v * H * n_seqs floats
     const int64_t attn_score_elems = S_v * H * n_tokens * n_seqs;
-    float * attn_out_base  = (float *)dst->data;
-    float * state_out_base = (float *)dst->data + attn_score_elems;
+    float* attn_out_base = (float*)dst->data;
+    float* state_out_base = (float*)dst->data + attn_score_elems;
 
-    const float * state_in_base = (const float *)src_state->data;
+    const float* state_in_base = (const float*)src_state->data;
 
-  //const int64_t rq1 = nev1 / neq1;
-  //const int64_t rk1 = nev1 / nek1;
+    //const int64_t rq1 = nev1 / neq1;
+    //const int64_t rk1 = nev1 / nek1;
     const int64_t rq3 = nev3 / neq3;
     const int64_t rk3 = nev3 / nek3;
 
-    const float scale = 1.0f / sqrtf((float) S_v);
+    const float scale = 1.0f / sqrtf((float)S_v);
 
     for (int64_t ir = ir0; ir < ir1; ++ir) {
         const int64_t iv1 = ir % H; // head_index
@@ -10947,22 +10187,22 @@ static void ggml_compute_forward_gated_delta_net_one_chunk(
         const int64_t iq3 = iv3 / rq3;
         const int64_t ik3 = iv3 / rk3;
 
-        float * s_out = state_out_base + (iv3 * H + iv1) * S_v * S_v;
+        float* s_out = state_out_base + (iv3 * H + iv1) * S_v * S_v;
 
         // copy input state into output buffer and operate in-place
-        const float * s_in = state_in_base + (iv3 * H + iv1) * S_v * S_v;
+        const float* s_in = state_in_base + (iv3 * H + iv1) * S_v * S_v;
         memcpy(s_out, s_in, S_v * S_v * sizeof(float));
 
         // attn output pointer for first token of this (head, seq)
-        float * attn_data = attn_out_base + (iv3 * n_tokens * H + iv1) * S_v;
+        float* attn_data = attn_out_base + (iv3 * n_tokens * H + iv1) * S_v;
 
         for (int64_t t = 0; t < n_tokens; t++) {
-            const float * q_d = (const float *)((const char *)src_q->data + iq3 * nbq3 + t * nbq2 + iq1 * nbq1);
-            const float * k_d = (const float *)((const char *)src_k->data + ik3 * nbk3 + t * nbk2 + ik1 * nbk1);
-            const float * v_d = (const float *)((const char *)src_v->data + iv3 * nbv3 + t * nbv2 + iv1 * nbv1);
+            const float* q_d = (const float*)((const char*)src_q->data + iq3 * nbq3 + t * nbq2 + iq1 * nbq1);
+            const float* k_d = (const float*)((const char*)src_k->data + ik3 * nbk3 + t * nbk2 + ik1 * nbk1);
+            const float* v_d = (const float*)((const char*)src_v->data + iv3 * nbv3 + t * nbv2 + iv1 * nbv1);
 
-            const float beta_val = *(const float *)((const char *)src_beta->data + iv3 * nbb3 + t * nbb2 + iv1 * nbb1);
-            const float * g_d    =  (const float *)((const char *)src_g->data    + iv3 * nbg3 + t * nbg2 + iv1 * nbg1);
+            const float beta_val = *(const float*)((const char*)src_beta->data + iv3 * nbb3 + t * nbb2 + iv1 * nbb1);
+            const float* g_d = (const float*)((const char*)src_g->data + iv3 * nbg3 + t * nbg2 + iv1 * nbg1);
 
             // state is stored transposed: s_out[j*S_v + i] = S[i][j]
             // so row j of s_out = column j of S (contiguous access)
@@ -11005,11 +10245,8 @@ static void ggml_compute_forward_gated_delta_net_one_chunk(
 }
 
 
-static void ggml_compute_forward_gated_delta_net_f32(
-        const ggml_compute_params * params,
-        ggml_tensor * dst) {
-
-    ggml_tensor * V = dst->src[2];
+static void ggml_compute_forward_gated_delta_net_f32(const ggml_compute_params* params, ggml_tensor* dst) {
+    ggml_tensor* V = dst->src[2];
     int64_t nr = V->ne[1] * V->ne[3];
 
     // disable for NUMA
@@ -11021,14 +10258,14 @@ static void ggml_compute_forward_gated_delta_net_f32(
     // 4x chunks per thread
     int nth_scaled = nth * 4;
     int64_t chunk_size = (nr + nth_scaled - 1) / nth_scaled;
-    int64_t nchunk     = (nr + chunk_size - 1) / chunk_size;
+    int64_t nchunk = (nr + chunk_size - 1) / chunk_size;
 
     if (nth == 1 || nchunk < nth || disable_chunking) {
-      nchunk = nth;
+        nchunk = nth;
     }
 
     if (ith == 0) {
-      ggml_threadpool_chunk_set(params->threadpool, nth);
+        ggml_threadpool_chunk_set(params->threadpool, nth);
     }
 
     ggml_barrier(params->threadpool);
@@ -11046,50 +10283,43 @@ static void ggml_compute_forward_gated_delta_net_f32(
     }
 }
 
-void ggml_compute_forward_gated_delta_net(
-        const ggml_compute_params * params,
-        ggml_tensor * dst) {
-    const ggml_tensor * src0 = dst->src[0];
+void ggml_compute_forward_gated_delta_net(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
 
     switch (src0->type) {
-        case GGML_TYPE_F32:
-            {
-                ggml_compute_forward_gated_delta_net_f32(params, dst);
-            } break;
-        default:
-            {
-                GGML_ABORT("fatal error");
-            }
+    case GGML_TYPE_F32: {
+        ggml_compute_forward_gated_delta_net_f32(params, dst);
+    } break;
+    default: {
+        GGML_ABORT("fatal error");
+    }
     }
 }
 
 // ggml_compute_forward_rwkv_wkv7
 
-static void ggml_compute_forward_rwkv_wkv7_f32(
-        const ggml_compute_params * params,
-        ggml_tensor * dst) {
+static void ggml_compute_forward_rwkv_wkv7_f32(const ggml_compute_params* params, ggml_tensor* dst) {
     const int64_t T = dst->src[1]->ne[2];
     const int64_t C = dst->ne[0];
     const int64_t HEADS = dst->src[1]->ne[1];
     const int64_t n_seqs = dst->src[6]->ne[1];
     const int64_t head_size = C / HEADS;
 
-    float * dst_data = (float *) dst->data;
-    float * state = ((float *) dst->data) + C * T;
+    float* dst_data = (float*)dst->data;
+    float* state = ((float*)dst->data) + C * T;
 
     const int ith = params->ith;
     const int nth = params->nth;
 
-    const int h_start =  (HEADS * (ith    )) / nth;
-    const int h_end   = ((HEADS * (ith + 1)) / nth < HEADS) ?
-                         (HEADS * (ith + 1)) / nth : HEADS;
+    const int h_start = (HEADS * (ith)) / nth;
+    const int h_end = ((HEADS * (ith + 1)) / nth < HEADS) ? (HEADS * (ith + 1)) / nth : HEADS;
 
-    float * r = (float *) dst->src[0]->data;
-    float * w = (float *) dst->src[1]->data;
-    float * k = (float *) dst->src[2]->data;
-    float * v = (float *) dst->src[3]->data;
-    float * a = (float *) dst->src[4]->data;
-    float * b = (float *) dst->src[5]->data;
+    float* r = (float*)dst->src[0]->data;
+    float* w = (float*)dst->src[1]->data;
+    float* k = (float*)dst->src[2]->data;
+    float* v = (float*)dst->src[3]->data;
+    float* a = (float*)dst->src[4]->data;
+    float* b = (float*)dst->src[5]->data;
 
     int64_t t_stride = HEADS * head_size; // Same to C
 
@@ -11097,196 +10327,188 @@ static void ggml_compute_forward_rwkv_wkv7_f32(
     GGML_ASSERT(C % HEADS == 0); // C must be divisible by HEADS
     int64_t h_stride_2d = head_size * head_size;
 
-    #if defined(GGML_SIMD)
-        #if defined(__ARM_FEATURE_SVE) || defined(__riscv_v_intrinsic)
-            // scalar Route to scalar implementation       //TODO: Write SVE code and RVV code
-            for (int64_t t = 0; t < T; t++) {
-                int64_t t_offset = t * t_stride;
-                int64_t state_offset = head_size * C * (t / (T / n_seqs));
-                float * state_cur = state + state_offset;
-                float * state_prev = t % (T / n_seqs) ? state_cur : (float*)dst->src[6]->data + state_offset;
+#if defined(GGML_SIMD)
+#if defined(__ARM_FEATURE_SVE) || defined(__riscv_v_intrinsic)
+    // scalar Route to scalar implementation       //TODO: Write SVE code and RVV code
+    for (int64_t t = 0; t < T; t++) {
+        int64_t t_offset = t * t_stride;
+        int64_t state_offset = head_size * C * (t / (T / n_seqs));
+        float* state_cur = state + state_offset;
+        float* state_prev = t % (T / n_seqs) ? state_cur : (float*)dst->src[6]->data + state_offset;
 
-                for (int64_t h = h_start; h < h_end; h++) {
-                    int64_t h_offset = h * h_stride;
-                    int64_t t_h_offset = t_offset + h_offset;
-                    int64_t h_2d_offset = h * h_stride_2d;
+        for (int64_t h = h_start; h < h_end; h++) {
+            int64_t h_offset = h * h_stride;
+            int64_t t_h_offset = t_offset + h_offset;
+            int64_t h_2d_offset = h * h_stride_2d;
 
-                    for (int64_t i = 0; i < head_size; i++) {
-                        int64_t t_h_i_offset = t_h_offset + i;
-                        int64_t h_2d_i_offset = h_2d_offset + i * h_stride;
+            for (int64_t i = 0; i < head_size; i++) {
+                int64_t t_h_i_offset = t_h_offset + i;
+                int64_t h_2d_i_offset = h_2d_offset + i * h_stride;
 
-                        float v_val = v[t_h_i_offset];
+                float v_val = v[t_h_i_offset];
 
-                        float sa = 0, result = 0;
-                        for (int64_t j = 0; j < head_size; j++) {
-                            sa += a[t_h_offset + j] * state_prev[h_2d_i_offset + j];
+                float sa = 0, result = 0;
+                for (int64_t j = 0; j < head_size; j++) {
+                    sa += a[t_h_offset + j] * state_prev[h_2d_i_offset + j];
+                }
+
+                for (int64_t j = 0; j < head_size; j++) {
+                    int64_t t_h_j_offset = t_h_offset + j;
+                    int64_t h_2d_i_j_offset = h_2d_i_offset + j;
+
+                    float r_val = r[t_h_j_offset];
+                    float w_val = w[t_h_j_offset];
+                    float k_val = k[t_h_j_offset];
+                    float b_val = b[t_h_j_offset];
+                    float kv_val = v_val * k_val;
+                    float prev_state_val = state_prev[h_2d_i_j_offset];
+                    state_cur[h_2d_i_j_offset] = prev_state_val * w_val + kv_val + sa * b_val;
+                    result += state_cur[h_2d_i_j_offset] * r_val;
+                }
+                dst_data[t_h_i_offset] = result;
+            }
+        }
+    }
+#else
+    for (int64_t t = 0; t < T; t++) {
+        int64_t t_offset = t * t_stride;
+        int64_t state_offset = head_size * C * (t / (T / n_seqs));
+        float* state_cur = state + state_offset;
+        float* state_prev = t % (T / n_seqs) ? state_cur : (float*)dst->src[6]->data + state_offset;
+
+        for (int64_t h = h_start; h < h_end; h++) {
+            int64_t h_offset = h * h_stride;
+            int64_t t_h_offset = t_offset + h_offset;
+            int64_t h_2d_offset = h * h_stride_2d;
+
+            for (int64_t ii = 0; ii < head_size; ii++) {
+                int64_t t_h_i_offset = t_h_offset + ii;
+                int64_t h_2d_i_offset = h_2d_offset + ii * h_stride;
+
+                GGML_F32_VEC v_vec = GGML_F32_VEC_SET1(v[t_h_i_offset]);
+
+                float sa = 0;
+                {
+                    GGML_F32_VEC sum[GGML_F32_ARR] = {GGML_F32_VEC_ZERO};
+                    GGML_F32_VEC ax[GGML_F32_ARR];
+                    GGML_F32_VEC ay[GGML_F32_ARR];
+                    for (int64_t j = 0; j < head_size; j += GGML_F32_STEP) {
+                        for (int64_t kk = 0; kk < GGML_F32_ARR; kk++) {
+                            ax[kk] = GGML_F32_VEC_LOAD(&a[t_h_offset + j + kk * GGML_F32_EPR]);
+                            ay[kk] = GGML_F32_VEC_LOAD(&state_prev[h_2d_i_offset + j + kk * GGML_F32_EPR]);
+                            sum[kk] = GGML_F32_VEC_FMA(sum[kk], ax[kk], ay[kk]);
                         }
+                    }
+                    GGML_F32_VEC_REDUCE(sa, sum);
+                }
 
-                        for (int64_t j = 0; j < head_size; j++) {
-                            int64_t t_h_j_offset = t_h_offset + j;
-                            int64_t h_2d_i_j_offset = h_2d_i_offset + j;
+                GGML_F32_VEC sa_vec = GGML_F32_VEC_SET1(sa);
 
-                            float r_val = r[t_h_j_offset];
-                            float w_val = w[t_h_j_offset];
-                            float k_val = k[t_h_j_offset];
-                            float b_val = b[t_h_j_offset];
-                            float kv_val = v_val * k_val;
-                            float prev_state_val = state_prev[h_2d_i_j_offset];
-                            state_cur[h_2d_i_j_offset] = prev_state_val * w_val + kv_val + sa * b_val;
-                            result += state_cur[h_2d_i_j_offset] * r_val;
-                        }
-                        dst_data[t_h_i_offset] = result;
+                int64_t j = 0;
+                GGML_F32_VEC result_vec[GGML_F32_ARR] = {GGML_F32_VEC_ZERO};
+                for (; j < head_size; j += GGML_F32_STEP) {
+                    for (int64_t kk = 0; kk < GGML_F32_ARR; kk++) {
+                        int64_t t_h_j_offset = t_h_offset + j + kk * GGML_F32_EPR;
+                        int64_t h_2d_i_j_offset = h_2d_i_offset + j + kk * GGML_F32_EPR;
+
+                        GGML_F32_VEC r_vec = GGML_F32_VEC_LOAD(&r[t_h_j_offset]);
+                        GGML_F32_VEC w_vec = GGML_F32_VEC_LOAD(&w[t_h_j_offset]);
+                        GGML_F32_VEC k_vec = GGML_F32_VEC_LOAD(&k[t_h_j_offset]);
+                        GGML_F32_VEC b_vec = GGML_F32_VEC_LOAD(&b[t_h_j_offset]);
+
+                        k_vec = GGML_F32_VEC_MUL(v_vec, k_vec);
+
+                        GGML_F32_VEC state_vec = GGML_F32_VEC_LOAD(&state_prev[h_2d_i_j_offset]);
+                        // kv + s * decay + sa * b
+                        state_vec = GGML_F32_VEC_FMA(k_vec, state_vec, w_vec);
+                        state_vec = GGML_F32_VEC_FMA(state_vec, sa_vec, b_vec);
+                        GGML_F32_VEC_STORE(&state_cur[h_2d_i_j_offset], state_vec);
+
+                        result_vec[kk] = GGML_F32_VEC_FMA(result_vec[kk], state_vec, r_vec);
                     }
                 }
-            }
-        #else
-            for (int64_t t = 0; t < T; t++) {
-                int64_t t_offset = t * t_stride;
-                int64_t state_offset = head_size * C * (t / (T / n_seqs));
-                float * state_cur = state + state_offset;
-                float * state_prev = t % (T / n_seqs) ? state_cur : (float*)dst->src[6]->data + state_offset;
+                GGML_F32_VEC_REDUCE(dst_data[t_h_i_offset], result_vec);
 
-                for (int64_t h = h_start; h < h_end; h++) {
-                    int64_t h_offset = h * h_stride;
-                    int64_t t_h_offset = t_offset + h_offset;
-                    int64_t h_2d_offset = h * h_stride_2d;
+                // There shouldn't be left-overs though.
+                for (; j < head_size; j++) {
+                    int64_t t_h_j_offset = t_h_offset + j;
+                    int64_t h_2d_i_j_offset = h_2d_i_offset + j;
 
-                    for (int64_t ii = 0; ii < head_size; ii++) {
-                        int64_t t_h_i_offset = t_h_offset + ii;
-                        int64_t h_2d_i_offset = h_2d_offset + ii * h_stride;
+                    float r_val = r[t_h_j_offset];
+                    float w_val = w[t_h_j_offset];
+                    float k_val = k[t_h_j_offset];
+                    float b_val = b[t_h_j_offset];
+                    float kv_val = v[t_h_i_offset] * k_val;
 
-                        GGML_F32_VEC v_vec = GGML_F32_VEC_SET1(v[t_h_i_offset]);
-
-                        float sa = 0;
-                        {
-                            GGML_F32_VEC sum[GGML_F32_ARR] = { GGML_F32_VEC_ZERO };
-                            GGML_F32_VEC ax[GGML_F32_ARR];
-                            GGML_F32_VEC ay[GGML_F32_ARR];
-                            for (int64_t j = 0; j < head_size; j += GGML_F32_STEP) {
-                                for (int64_t kk = 0; kk < GGML_F32_ARR; kk++) {
-                                    ax[kk] = GGML_F32_VEC_LOAD(&a[t_h_offset + j + kk * GGML_F32_EPR]);
-                                    ay[kk] = GGML_F32_VEC_LOAD(&state_prev[h_2d_i_offset + j + kk * GGML_F32_EPR]);
-                                    sum[kk] = GGML_F32_VEC_FMA(sum[kk], ax[kk], ay[kk]);
-                                }
-                            }
-                            GGML_F32_VEC_REDUCE(sa, sum);
-                        }
-
-                        GGML_F32_VEC sa_vec = GGML_F32_VEC_SET1(sa);
-
-                        int64_t j = 0;
-                        GGML_F32_VEC result_vec[GGML_F32_ARR] = { GGML_F32_VEC_ZERO };
-                        for (; j < head_size; j += GGML_F32_STEP) {
-                            for (int64_t kk = 0; kk < GGML_F32_ARR; kk++) {
-                                int64_t t_h_j_offset = t_h_offset + j + kk * GGML_F32_EPR;
-                                int64_t h_2d_i_j_offset = h_2d_i_offset + j + kk * GGML_F32_EPR;
-
-                                GGML_F32_VEC r_vec = GGML_F32_VEC_LOAD(&r[t_h_j_offset]);
-                                GGML_F32_VEC w_vec = GGML_F32_VEC_LOAD(&w[t_h_j_offset]);
-                                GGML_F32_VEC k_vec = GGML_F32_VEC_LOAD(&k[t_h_j_offset]);
-                                GGML_F32_VEC b_vec = GGML_F32_VEC_LOAD(&b[t_h_j_offset]);
-
-                                k_vec = GGML_F32_VEC_MUL(v_vec, k_vec);
-
-                                GGML_F32_VEC state_vec = GGML_F32_VEC_LOAD(&state_prev[h_2d_i_j_offset]);
-                                // kv + s * decay + sa * b
-                                state_vec = GGML_F32_VEC_FMA(k_vec, state_vec, w_vec);
-                                state_vec = GGML_F32_VEC_FMA(state_vec, sa_vec, b_vec);
-                                GGML_F32_VEC_STORE(&state_cur[h_2d_i_j_offset], state_vec);
-
-                                result_vec[kk] = GGML_F32_VEC_FMA(result_vec[kk], state_vec, r_vec);
-                            }
-                        }
-                        GGML_F32_VEC_REDUCE(dst_data[t_h_i_offset], result_vec);
-
-                        // There shouldn't be left-overs though.
-                        for (; j < head_size; j++) {
-                            int64_t t_h_j_offset = t_h_offset + j;
-                            int64_t h_2d_i_j_offset = h_2d_i_offset + j;
-
-                            float r_val = r[t_h_j_offset];
-                            float w_val = w[t_h_j_offset];
-                            float k_val = k[t_h_j_offset];
-                            float b_val = b[t_h_j_offset];
-                            float kv_val = v[t_h_i_offset] * k_val;
-
-                            float prev_state_val = state_prev[h_2d_i_j_offset];
-                            state_cur[h_2d_i_j_offset] = prev_state_val * w_val + kv_val + sa * b_val;
-                            dst_data[t_h_i_offset] += state_cur[h_2d_i_j_offset] * r_val;
-                        }
-                    }
-                }
-            }
-        #endif
-    #else
-        for (int64_t t = 0; t < T; t++) {
-            int64_t t_offset = t * t_stride;
-            int64_t state_offset = head_size * C * (t / (T / n_seqs));
-            float * state_cur = state + state_offset;
-            float * state_prev = t % (T / n_seqs) ? state_cur : (float*)dst->src[6]->data + state_offset;
-
-            for (int64_t h = h_start; h < h_end; h++) {
-                int64_t h_offset = h * h_stride;
-                int64_t t_h_offset = t_offset + h_offset;
-                int64_t h_2d_offset = h * h_stride_2d;
-
-                for (int64_t i = 0; i < head_size; i++) {
-                    int64_t t_h_i_offset = t_h_offset + i;
-                    int64_t h_2d_i_offset = h_2d_offset + i * h_stride;
-
-                    float v_val = v[t_h_i_offset];
-
-                    float sa = 0, result = 0;
-                    for (int64_t j = 0; j < head_size; j++) {
-                        sa += a[t_h_offset + j] * state_prev[h_2d_i_offset + j];
-                    }
-
-                    for (int64_t j = 0; j < head_size; j++) {
-                        int64_t t_h_j_offset = t_h_offset + j;
-                        int64_t h_2d_i_j_offset = h_2d_i_offset + j;
-
-                        float r_val = r[t_h_j_offset];
-                        float w_val = w[t_h_j_offset];
-                        float k_val = k[t_h_j_offset];
-                        float b_val = b[t_h_j_offset];
-                        float kv_val = v_val * k_val;
-                        float prev_state_val = state_prev[h_2d_i_j_offset];
-                        state_cur[h_2d_i_j_offset] = prev_state_val * w_val + kv_val + sa * b_val;
-                        result += state_cur[h_2d_i_j_offset] * r_val;
-                    }
-                    dst_data[t_h_i_offset] = result;
+                    float prev_state_val = state_prev[h_2d_i_j_offset];
+                    state_cur[h_2d_i_j_offset] = prev_state_val * w_val + kv_val + sa * b_val;
+                    dst_data[t_h_i_offset] += state_cur[h_2d_i_j_offset] * r_val;
                 }
             }
         }
-    #endif
+    }
+#endif
+#else
+    for (int64_t t = 0; t < T; t++) {
+        int64_t t_offset = t * t_stride;
+        int64_t state_offset = head_size * C * (t / (T / n_seqs));
+        float* state_cur = state + state_offset;
+        float* state_prev = t % (T / n_seqs) ? state_cur : (float*)dst->src[6]->data + state_offset;
+
+        for (int64_t h = h_start; h < h_end; h++) {
+            int64_t h_offset = h * h_stride;
+            int64_t t_h_offset = t_offset + h_offset;
+            int64_t h_2d_offset = h * h_stride_2d;
+
+            for (int64_t i = 0; i < head_size; i++) {
+                int64_t t_h_i_offset = t_h_offset + i;
+                int64_t h_2d_i_offset = h_2d_offset + i * h_stride;
+
+                float v_val = v[t_h_i_offset];
+
+                float sa = 0, result = 0;
+                for (int64_t j = 0; j < head_size; j++) {
+                    sa += a[t_h_offset + j] * state_prev[h_2d_i_offset + j];
+                }
+
+                for (int64_t j = 0; j < head_size; j++) {
+                    int64_t t_h_j_offset = t_h_offset + j;
+                    int64_t h_2d_i_j_offset = h_2d_i_offset + j;
+
+                    float r_val = r[t_h_j_offset];
+                    float w_val = w[t_h_j_offset];
+                    float k_val = k[t_h_j_offset];
+                    float b_val = b[t_h_j_offset];
+                    float kv_val = v_val * k_val;
+                    float prev_state_val = state_prev[h_2d_i_j_offset];
+                    state_cur[h_2d_i_j_offset] = prev_state_val * w_val + kv_val + sa * b_val;
+                    result += state_cur[h_2d_i_j_offset] * r_val;
+                }
+                dst_data[t_h_i_offset] = result;
+            }
+        }
+    }
+#endif
 }
 
 
-void ggml_compute_forward_rwkv_wkv7(
-        const ggml_compute_params * params,
-        ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
+void ggml_compute_forward_rwkv_wkv7(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
 
     switch (src0->type) {
-        case GGML_TYPE_F32:
-            {
-                ggml_compute_forward_rwkv_wkv7_f32(params, dst);
-            } break;
-        default:
-            {
-                GGML_ABORT("fatal error");
-            }
+    case GGML_TYPE_F32: {
+        ggml_compute_forward_rwkv_wkv7_f32(params, dst);
+    } break;
+    default: {
+        GGML_ABORT("fatal error");
+    }
     }
 }
 
 // ggml_compute_forward_map_custom1
 
-void ggml_compute_forward_map_custom1(
-        const ggml_compute_params * params,
-              ggml_tensor * dst) {
-
-    const ggml_tensor * a = dst->src[0];
+void ggml_compute_forward_map_custom1(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* a = dst->src[0];
 
     struct ggml_map_custom1_op_params p;
     memcpy(&p, dst->op_params, sizeof(p));
@@ -11296,12 +10518,9 @@ void ggml_compute_forward_map_custom1(
 
 // ggml_compute_forward_map_custom2
 
-void ggml_compute_forward_map_custom2(
-        const ggml_compute_params * params,
-              ggml_tensor * dst) {
-
-    const ggml_tensor * a = dst->src[0];
-    const ggml_tensor * b = dst->src[1];
+void ggml_compute_forward_map_custom2(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* a = dst->src[0];
+    const ggml_tensor* b = dst->src[1];
 
     struct ggml_map_custom2_op_params p;
     memcpy(&p, dst->op_params, sizeof(p));
@@ -11311,13 +10530,10 @@ void ggml_compute_forward_map_custom2(
 
 // ggml_compute_forward_map_custom3
 
-void ggml_compute_forward_map_custom3(
-        const ggml_compute_params * params,
-              ggml_tensor * dst) {
-
-    const ggml_tensor * a = dst->src[0];
-    const ggml_tensor * b = dst->src[1];
-    const ggml_tensor * c = dst->src[2];
+void ggml_compute_forward_map_custom3(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* a = dst->src[0];
+    const ggml_tensor* b = dst->src[1];
+    const ggml_tensor* c = dst->src[2];
 
     struct ggml_map_custom3_op_params p;
     memcpy(&p, dst->op_params, sizeof(p));
@@ -11327,10 +10543,7 @@ void ggml_compute_forward_map_custom3(
 
 // ggml_compute_forward_custom
 
-void ggml_compute_forward_custom(
-    const struct ggml_compute_params * params,
-          struct ggml_tensor * dst) {
-
+void ggml_compute_forward_custom(const struct ggml_compute_params* params, struct ggml_tensor* dst) {
     struct ggml_custom_op_params p;
     memcpy(&p, dst->op_params, sizeof(p));
 
@@ -11339,12 +10552,9 @@ void ggml_compute_forward_custom(
 
 // ggml_compute_forward_cross_entropy_loss
 
-static void ggml_compute_forward_cross_entropy_loss_f32(
-        const ggml_compute_params * params,
-        ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
-    const ggml_tensor * src1 = dst->src[1];
+static void ggml_compute_forward_cross_entropy_loss_f32(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
+    const ggml_tensor* src1 = dst->src[1];
 
     GGML_ASSERT(src0->type == GGML_TYPE_F32);
     GGML_ASSERT(src1->type == GGML_TYPE_F32);
@@ -11361,22 +10571,22 @@ static void ggml_compute_forward_cross_entropy_loss_f32(
     const int ith = params->ith;
     const int nth = params->nth;
 
-    float * sums =  (float *) params->wdata;
-    float * st   = ((float *) params->wdata) + nth + ith*nc;
+    float* sums = (float*)params->wdata;
+    float* st = ((float*)params->wdata) + nth + ith * nc;
     float sum_thread = 0.0f;
 
     GGML_ASSERT(params->wsize >= sizeof(float) * (nth + nth * nc));
 
     // rows per thread
-    const int64_t dr = (nr + nth - 1)/nth;
+    const int64_t dr = (nr + nth - 1) / nth;
 
     // row range for this thread
-    const int64_t ir0 = dr*ith;
+    const int64_t ir0 = dr * ith;
     const int64_t ir1 = MIN(ir0 + dr, nr);
 
     for (int64_t i1 = ir0; i1 < ir1; ++i1) {
-        const float * s0 = (const float *)((const char *) src0->data + i1*src0->nb[1]);
-        const float * s1 = (const float *)((const char *) src1->data + i1*src1->nb[1]);
+        const float* s0 = (const float*)((const char*)src0->data + i1 * src0->nb[1]);
+        const float* s1 = (const float*)((const char*)src1->data + i1 * src1->nb[1]);
 
 #ifndef NDEBUG
         for (int64_t i = 0; i < nc; ++i) {
@@ -11409,39 +10619,31 @@ static void ggml_compute_forward_cross_entropy_loss_f32(
     ggml_barrier(params->threadpool);
 
     if (ith == 0) {
-        float * dp = (float *) dst->data;
+        float* dp = (float*)dst->data;
         ggml_vec_sum_f32(nth, dp, sums);
-        dp[0] *= -1.0f / (float) nr;
+        dp[0] *= -1.0f / (float)nr;
     }
 }
 
-void ggml_compute_forward_cross_entropy_loss(
-        const ggml_compute_params * params,
-        ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
+void ggml_compute_forward_cross_entropy_loss(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
 
     switch (src0->type) {
-        case GGML_TYPE_F32:
-            {
-                ggml_compute_forward_cross_entropy_loss_f32(params, dst);
-            } break;
-        default:
-            {
-                GGML_ABORT("fatal error");
-            }
+    case GGML_TYPE_F32: {
+        ggml_compute_forward_cross_entropy_loss_f32(params, dst);
+    } break;
+    default: {
+        GGML_ABORT("fatal error");
+    }
     }
 }
 
 // ggml_compute_forward_cross_entropy_loss_back
 
-static void ggml_compute_forward_cross_entropy_loss_back_f32(
-        const ggml_compute_params * params,
-        ggml_tensor * dst) {
-
-    const ggml_tensor * grad  = dst->src[0]; // gradient of forward pass output
-    const ggml_tensor * src0f = dst->src[1]; // src0 of forward pass
-    const ggml_tensor * src1f = dst->src[2]; // src1 of forward pass
+static void ggml_compute_forward_cross_entropy_loss_back_f32(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* grad = dst->src[0];  // gradient of forward pass output
+    const ggml_tensor* src0f = dst->src[1]; // src0 of forward pass
+    const ggml_tensor* src1f = dst->src[2]; // src1 of forward pass
 
     GGML_ASSERT(ggml_is_contiguous(dst));
     GGML_ASSERT(ggml_is_contiguous(src0f));
@@ -11457,18 +10659,18 @@ static void ggml_compute_forward_cross_entropy_loss_back_f32(
     const int64_t nr = ggml_nrows(src0f);
 
     // rows per thread
-    const int64_t dr = (nr + nth - 1)/nth;
+    const int64_t dr = (nr + nth - 1) / nth;
 
     // row range for this thread
-    const int64_t ir0 = dr*ith;
+    const int64_t ir0 = dr * ith;
     const int64_t ir1 = MIN(ir0 + dr, nr);
 
-    const float d_by_nr = ((const float *) grad->data)[0] / (float) nr;
+    const float d_by_nr = ((const float*)grad->data)[0] / (float)nr;
 
     for (int64_t i1 = ir0; i1 < ir1; i1++) {
-        float       * ds0 = (float       *)((char       *) dst->data   + i1*dst->nb[1]);
-        const float * s0  = (const float *)((const char *) src0f->data + i1*src0f->nb[1]);
-        const float * s1  = (const float *)((const char *) src1f->data + i1*src1f->nb[1]);
+        float* ds0 = (float*)((char*)dst->data + i1 * dst->nb[1]);
+        const float* s0 = (const float*)((const char*)src0f->data + i1 * src0f->nb[1]);
+        const float* s1 = (const float*)((const char*)src1f->data + i1 * src1f->nb[1]);
 
 #ifndef NDEBUG
         for (int64_t i = 0; i < nc; ++i) {
@@ -11483,7 +10685,7 @@ static void ggml_compute_forward_cross_entropy_loss_back_f32(
         ggml_vec_max_f32(nc, &max, s0);
         const ggml_float sum = ggml_vec_soft_max_f32(nc, ds0, s0, max);
         assert(sum > 0.0);
-        ggml_vec_scale_f32(nc, ds0, 1.0/sum);
+        ggml_vec_scale_f32(nc, ds0, 1.0 / sum);
 
         // grad(src0f) = (softmax(src0f) - src1f) * grad(cross_entropy_loss(src0f, src1f)) / nr
         ggml_vec_sub_f32(nc, ds0, ds0, s1);
@@ -11498,33 +10700,25 @@ static void ggml_compute_forward_cross_entropy_loss_back_f32(
     }
 }
 
-void ggml_compute_forward_cross_entropy_loss_back(
-        const ggml_compute_params * params,
-        ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
+void ggml_compute_forward_cross_entropy_loss_back(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
 
     switch (src0->type) {
-        case GGML_TYPE_F32:
-            {
-                ggml_compute_forward_cross_entropy_loss_back_f32(params, dst);
-            } break;
-        default:
-            {
-                GGML_ABORT("fatal error");
-            }
+    case GGML_TYPE_F32: {
+        ggml_compute_forward_cross_entropy_loss_back_f32(params, dst);
+    } break;
+    default: {
+        GGML_ABORT("fatal error");
+    }
     }
 }
 
-static void ggml_compute_forward_opt_step_adamw_f32(
-        const ggml_compute_params * params,
-        ggml_tensor * dst) {
-
-    const ggml_tensor * src0         = dst->src[0];
-    const ggml_tensor * src0_grad    = dst->src[1];
-    const ggml_tensor * src0_grad_m  = dst->src[2];
-    const ggml_tensor * src0_grad_v  = dst->src[3];
-    const ggml_tensor * adamw_params = dst->src[4];
+static void ggml_compute_forward_opt_step_adamw_f32(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
+    const ggml_tensor* src0_grad = dst->src[1];
+    const ggml_tensor* src0_grad_m = dst->src[2];
+    const ggml_tensor* src0_grad_v = dst->src[3];
+    const ggml_tensor* adamw_params = dst->src[4];
 
     GGML_ASSERT(ggml_are_same_shape(src0, src0_grad));
     GGML_ASSERT(ggml_are_same_shape(src0, src0_grad_m));
@@ -11534,46 +10728,46 @@ static void ggml_compute_forward_opt_step_adamw_f32(
     const int ith = params->ith;
     const int nth = params->nth;
 
-    const int nr  = ggml_nrows(src0);
+    const int nr = ggml_nrows(src0);
 
     GGML_TENSOR_UNARY_OP_LOCALS
     GGML_ASSERT(nb00 == sizeof(float));
 
     // rows per thread
-    const int dr = (nr + nth - 1)/nth;
+    const int dr = (nr + nth - 1) / nth;
 
     // row range for this thread
-    const int ir0 = dr*ith;
+    const int ir0 = dr * ith;
     const int ir1 = MIN(ir0 + dr, nr);
 
-    const float * adamw_params_ptr = ggml_get_data_f32(adamw_params);
+    const float* adamw_params_ptr = ggml_get_data_f32(adamw_params);
 
-    const float alpha  = adamw_params_ptr[0];
-    const float beta1  = adamw_params_ptr[1];
-    const float beta2  = adamw_params_ptr[2];
-    const float eps    = adamw_params_ptr[3];
-    const float wd     = adamw_params_ptr[4];
+    const float alpha = adamw_params_ptr[0];
+    const float beta1 = adamw_params_ptr[1];
+    const float beta2 = adamw_params_ptr[2];
+    const float eps = adamw_params_ptr[3];
+    const float wd = adamw_params_ptr[4];
     const float beta1h = adamw_params_ptr[5];
     const float beta2h = adamw_params_ptr[6];
-    const float keep   = 1.f - alpha * wd;
+    const float keep = 1.f - alpha * wd;
     for (int ir = ir0; ir < ir1; ++ir) {
-        const int64_t i03 = ir/(ne02*ne01);
-        const int64_t i02 = (ir - i03*ne02*ne01)/ne01;
-        const int64_t i01 = (ir - i03*ne02*ne01 - i02*ne01);
+        const int64_t i03 = ir / (ne02 * ne01);
+        const int64_t i02 = (ir - i03 * ne02 * ne01) / ne01;
+        const int64_t i01 = (ir - i03 * ne02 * ne01 - i02 * ne01);
 
-        const size_t offset = i03*nb03 + i02*nb02 + i01*nb01;
+        const size_t offset = i03 * nb03 + i02 * nb02 + i01 * nb01;
 
-        float       * w = (float       *) ((char       *) src0->data        + offset); // weight
-        const float * g = (const float *) ((const char *) src0_grad->data   + offset); // grad
-        float       * m = (float       *) ((char       *) src0_grad_m->data + offset);
-        float       * v = (float       *) ((char       *) src0_grad_v->data + offset);
+        float* w = (float*)((char*)src0->data + offset);                        // weight
+        const float* g = (const float*)((const char*)src0_grad->data + offset); // grad
+        float* m = (float*)((char*)src0_grad_m->data + offset);
+        float* v = (float*)((char*)src0_grad_v->data + offset);
 
         for (int i00 = 0; i00 < ne00; ++i00) {
-            m[i00] = m[i00]*beta1 +        g[i00]*(1.0f - beta1);
-            v[i00] = v[i00]*beta2 + g[i00]*g[i00]*(1.0f - beta2);
+            m[i00] = m[i00] * beta1 + g[i00] * (1.0f - beta1);
+            v[i00] = v[i00] * beta2 + g[i00] * g[i00] * (1.0f - beta2);
 
-            const float mh =       m[i00]*beta1h;
-            const float vh = sqrtf(v[i00]*beta2h) + eps;
+            const float mh = m[i00] * beta1h;
+            const float vh = sqrtf(v[i00] * beta2h) + eps;
 
             // The weight decay is applied independently of the Adam momenta m and v.
             // This is NOT equivalent to l2 regularization that adds w[i00]*w[i00] to the loss.
@@ -11583,28 +10777,23 @@ static void ggml_compute_forward_opt_step_adamw_f32(
     }
 }
 
-void ggml_compute_forward_opt_step_adamw(
-        const ggml_compute_params * params,
-        ggml_tensor * dst) {
-
-    const ggml_tensor * src0 = dst->src[0];
+void ggml_compute_forward_opt_step_adamw(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
 
     switch (src0->type) {
-        case GGML_TYPE_F32:
-            {
-                ggml_compute_forward_opt_step_adamw_f32(params, dst);
-            } break;
-        default:
-            {
-                GGML_ABORT("fatal error");
-            }
+    case GGML_TYPE_F32: {
+        ggml_compute_forward_opt_step_adamw_f32(params, dst);
+    } break;
+    default: {
+        GGML_ABORT("fatal error");
+    }
     }
 }
 
-static void ggml_compute_forward_opt_step_sgd_f32(const ggml_compute_params * params, ggml_tensor * dst) {
-    const ggml_tensor * src0       = dst->src[0];
-    const ggml_tensor * src0_grad  = dst->src[1];
-    const ggml_tensor * sgd_params = dst->src[2];
+static void ggml_compute_forward_opt_step_sgd_f32(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
+    const ggml_tensor* src0_grad = dst->src[1];
+    const ggml_tensor* sgd_params = dst->src[2];
 
     GGML_ASSERT(ggml_are_same_shape(src0, src0_grad));
     GGML_ASSERT(ggml_nelements(sgd_params) == 2);
@@ -11625,9 +10814,9 @@ static void ggml_compute_forward_opt_step_sgd_f32(const ggml_compute_params * pa
     const int ir1 = MIN(ir0 + dr, nr);
 
     // using adamw param subset we care about - alpha, wd - could have a separate struct
-    const float * sgd_params_ptr   = ggml_get_data_f32(sgd_params);
-    const float   alpha            = sgd_params_ptr[0];
-    const float   keep             = 1.f - alpha * sgd_params_ptr[1];
+    const float* sgd_params_ptr = ggml_get_data_f32(sgd_params);
+    const float alpha = sgd_params_ptr[0];
+    const float keep = 1.f - alpha * sgd_params_ptr[1];
 
     for (int ir = ir0; ir < ir1; ++ir) {
         const int64_t i03 = ir / (ne02 * ne01);
@@ -11636,8 +10825,8 @@ static void ggml_compute_forward_opt_step_sgd_f32(const ggml_compute_params * pa
 
         const size_t offset = i03 * nb03 + i02 * nb02 + i01 * nb01;
 
-        float *       w = (float *) ((char *) src0->data + offset);                   // weight
-        const float * g = (const float *) ((const char *) src0_grad->data + offset);  // grad
+        float* w = (float*)((char*)src0->data + offset);                        // weight
+        const float* g = (const float*)((const char*)src0_grad->data + offset); // grad
 
         for (int i00 = 0; i00 < ne00; ++i00) {
             w[i00] = w[i00] * keep - alpha * g[i00];
@@ -11645,18 +10834,15 @@ static void ggml_compute_forward_opt_step_sgd_f32(const ggml_compute_params * pa
     }
 }
 
-void ggml_compute_forward_opt_step_sgd(const ggml_compute_params * params, ggml_tensor * dst) {
-    const ggml_tensor * src0 = dst->src[0];
+void ggml_compute_forward_opt_step_sgd(const ggml_compute_params* params, ggml_tensor* dst) {
+    const ggml_tensor* src0 = dst->src[0];
 
     switch (src0->type) {
-        case GGML_TYPE_F32:
-            {
-                ggml_compute_forward_opt_step_sgd_f32(params, dst);
-            }
-            break;
-        default:
-            {
-                GGML_ABORT("fatal error - sgd is F32 only");
-            }
+    case GGML_TYPE_F32: {
+        ggml_compute_forward_opt_step_sgd_f32(params, dst);
+    } break;
+    default: {
+        GGML_ABORT("fatal error - sgd is F32 only");
+    }
     }
 }

--- a/ggml/src/ggml-cpu/ops.cpp
+++ b/ggml/src/ggml-cpu/ops.cpp
@@ -5125,7 +5125,7 @@ static void ggml_compute_forward_soft_max_ext_back_f32(const ggml_compute_params
             assert(!isnan(dy[i]));
             assert(!isnan(y[i]));
         }
-#endif // NDEBUG                                                                                                       \
+#endif // NDEBUG
     // Jii = yi - yi*yi                                                                                                \
     // Jij = -yi*yj                                                                                                    \
     // J = diag(y)-y.T*y                                                                                               \

--- a/ggml/src/ggml-cpu/ops.h
+++ b/ggml/src/ggml-cpu/ops.h
@@ -65,6 +65,7 @@ void ggml_compute_forward_rope(const struct ggml_compute_params * params, struct
 void ggml_compute_forward_rope_back(const struct ggml_compute_params * params, struct ggml_tensor * dst);
 void ggml_compute_forward_clamp(const struct ggml_compute_params * params, struct ggml_tensor * dst);
 void ggml_compute_forward_conv_transpose_1d(const struct ggml_compute_params * params, struct ggml_tensor * dst);
+void ggml_compute_forward_col2im_1d(const struct ggml_compute_params * params, struct ggml_tensor * dst);
 // CrispASR patch (PR #07-metal-aa-snake-beta) — MUST RE-APPLY after ggml bump.
 void ggml_compute_forward_aa_snake_beta(const struct ggml_compute_params * params, struct ggml_tensor * dst);
 void ggml_compute_forward_im2col(const struct ggml_compute_params * params, struct ggml_tensor * dst);

--- a/ggml/src/ggml-cuda/col2im-1d.cu
+++ b/ggml/src/ggml-cuda/col2im-1d.cu
@@ -1,0 +1,78 @@
+#include "col2im-1d.cuh"
+#include "convert.cuh"
+
+// col2im_1d: scatter-add GEMM columns to 1D signal (gather approach)
+// columns: [K*OC, T_in]  ->  output: [T_out, OC]
+// Supports F32, F16, BF16 data with F32 accumulator.
+
+template <typename T>
+static __global__ void col2im_1d_kernel(
+        const T * __restrict__ col,
+        T       * __restrict__ dst,
+        const int T_in, const int T_out,
+        const int OC, const int K, const int K_OC,
+        const int s0, const int p0, const int total) {
+
+    const int idx = threadIdx.x + blockIdx.x * blockDim.x;
+    if (idx >= total) return;
+
+    // dst layout: [T_out, OC], ne[0]=T_out fastest
+    const int t_out = idx % T_out;
+    const int oc    = idx / T_out;
+    const int t_abs = t_out + p0;  // absolute position in uncropped signal
+
+    // Gather: find all (t_in, k) where t_in*s + k == t_abs, 0 <= k < K
+    int t_in_min = (t_abs - K + s0) / s0;  // ceil((t_abs - K + 1) / s)
+    if (t_in_min < 0) t_in_min = 0;
+    int t_in_max = t_abs / s0;
+    if (t_in_max >= T_in) t_in_max = T_in - 1;
+
+    float sum = 0.0f;
+    for (int t_in = t_in_min; t_in <= t_in_max; t_in++) {
+        const int k = t_abs - t_in * s0;
+        // col layout: [K*OC, T_in], column index = oc * K + k
+        sum += ggml_cuda_cast<float>(col[(oc * K + k) + t_in * K_OC]);
+    }
+
+    dst[idx] = ggml_cuda_cast<T>(sum);
+}
+
+void ggml_cuda_op_col2im_1d(ggml_backend_cuda_context & ctx, ggml_tensor * dst) {
+    const ggml_tensor * src0 = dst->src[0];
+    cudaStream_t stream = ctx.stream();
+
+    GGML_ASSERT(ggml_is_contiguous(src0));
+
+    const int32_t s0 = ((const int32_t *)(dst->op_params))[0];
+    const int32_t OC = ((const int32_t *)(dst->op_params))[1];
+    const int32_t p0 = ((const int32_t *)(dst->op_params))[2];
+
+    const int K_OC = (int) src0->ne[0];
+    const int T_in = (int) src0->ne[1];
+    const int K    = K_OC / OC;
+    const int T_out = (int) dst->ne[0];
+
+    const int total = T_out * OC;
+    const int block_size = 256;
+    const int num_blocks = (total + block_size - 1) / block_size;
+
+    switch (src0->type) {
+        case GGML_TYPE_F32: {
+            col2im_1d_kernel<<<num_blocks, block_size, 0, stream>>>(
+                (const float *)src0->data, (float *)dst->data,
+                T_in, T_out, OC, K, K_OC, s0, p0, total);
+        } break;
+        case GGML_TYPE_F16: {
+            col2im_1d_kernel<<<num_blocks, block_size, 0, stream>>>(
+                (const half *)src0->data, (half *)dst->data,
+                T_in, T_out, OC, K, K_OC, s0, p0, total);
+        } break;
+        case GGML_TYPE_BF16: {
+            col2im_1d_kernel<<<num_blocks, block_size, 0, stream>>>(
+                (const nv_bfloat16 *)src0->data, (nv_bfloat16 *)dst->data,
+                T_in, T_out, OC, K, K_OC, s0, p0, total);
+        } break;
+        default:
+            GGML_ABORT("col2im_1d: unsupported type");
+    }
+}

--- a/ggml/src/ggml-cuda/col2im-1d.cuh
+++ b/ggml/src/ggml-cuda/col2im-1d.cuh
@@ -1,0 +1,3 @@
+#include "common.cuh"
+
+void ggml_cuda_op_col2im_1d(ggml_backend_cuda_context & ctx, ggml_tensor * dst);

--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -12,6 +12,7 @@
 #include "ggml-cuda/clamp.cuh"
 #include "ggml-cuda/concat.cuh"
 #include "ggml-cuda/conv-transpose-1d.cuh"
+#include "ggml-cuda/col2im-1d.cuh"
 #include "ggml-cuda/conv2d.cuh"
 #include "ggml-cuda/conv2d-dw.cuh"
 #include "ggml-cuda/conv2d-transpose.cuh"
@@ -2953,6 +2954,9 @@ static bool ggml_cuda_compute_forward(ggml_backend_cuda_context & ctx, struct gg
         case GGML_OP_CONV_TRANSPOSE_1D:
             ggml_cuda_op_conv_transpose_1d(ctx,dst);
             break;
+        case GGML_OP_COL2IM_1D:
+            ggml_cuda_op_col2im_1d(ctx, dst);
+            break;
         case GGML_OP_POOL_2D:
             ggml_cuda_op_pool2d(ctx, dst);
             break;
@@ -5161,6 +5165,14 @@ static bool ggml_backend_cuda_device_supports_op(ggml_backend_dev_t dev, const g
                 ggml_type src0_type = op->src[0]->type;
                 ggml_type src1_type = op->src[1]->type;
                 if ((src0_type == GGML_TYPE_F32 || src0_type == GGML_TYPE_F16) && src1_type == GGML_TYPE_F32) {
+                    return true;
+                }
+                return false;
+            } break;
+        case GGML_OP_COL2IM_1D:
+            {
+                ggml_type src0_type = op->src[0]->type;
+                if (src0_type == GGML_TYPE_F32 || src0_type == GGML_TYPE_F16 || src0_type == GGML_TYPE_BF16) {
                     return true;
                 }
                 return false;

--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -1029,6 +1029,7 @@ static const char * GGML_OP_NAME[GGML_OP_COUNT] = {
     "ROPE_BACK",
     "CLAMP",
     "CONV_TRANSPOSE_1D",
+    "COL2IM_1D",
     "IM2COL",
     "IM2COL_BACK",
     "IM2COL_3D",
@@ -1084,7 +1085,7 @@ static const char * GGML_OP_NAME[GGML_OP_COUNT] = {
     "AA_SNAKE_BETA",
 };
 
-static_assert(GGML_OP_COUNT == 98, "GGML_OP_COUNT != 98");
+static_assert(GGML_OP_COUNT == 99, "GGML_OP_COUNT != 99");
 
 static const char * GGML_OP_SYMBOL[GGML_OP_COUNT] = {
     "none",
@@ -1143,6 +1144,7 @@ static const char * GGML_OP_SYMBOL[GGML_OP_COUNT] = {
     "rope_back(x)",
     "clamp(x)",
     "conv_transpose_1d(x)",
+    "col2im_1d(x)",
     "im2col(x)",
     "im2col_back(x)",
     "im2col_3d(x)",
@@ -1198,7 +1200,7 @@ static const char * GGML_OP_SYMBOL[GGML_OP_COUNT] = {
     "aa_snake_beta(x, log_a, log_b, usf, dsf)",
 };
 
-static_assert(GGML_OP_COUNT == 98, "GGML_OP_COUNT != 98");
+static_assert(GGML_OP_COUNT == 99, "GGML_OP_COUNT != 99");
 
 static_assert(GGML_OP_POOL_COUNT == 2, "GGML_OP_POOL_COUNT != 2");
 
@@ -4632,6 +4634,35 @@ GGML_API struct ggml_tensor * ggml_conv_transpose_1d(
     result->op     = GGML_OP_CONV_TRANSPOSE_1D;
     result->src[0] = a;
     result->src[1] = b;
+
+    return result;
+}
+
+// ggml_col2im_1d
+
+GGML_API struct ggml_tensor * ggml_col2im_1d(
+        struct ggml_context * ctx,
+        struct ggml_tensor  * col,
+        int                   s0,
+        int                   oc,
+        int                   p0) {
+    GGML_ASSERT(ggml_is_matrix(col));
+    GGML_ASSERT(col->ne[0] % oc == 0);
+    GGML_ASSERT(col->type == GGML_TYPE_F32 || col->type == GGML_TYPE_F16 || col->type == GGML_TYPE_BF16);
+
+    const int K_OC = (int)col->ne[0];
+    const int T_in = (int)col->ne[1];
+    const int K    = K_OC / oc;
+    const int T_out = (T_in - 1) * s0 + K - p0;
+
+    const int64_t ne[4] = { T_out, oc, 1, 1 };
+    struct ggml_tensor * result = ggml_new_tensor(ctx, GGML_TYPE_F32, 4, ne);
+
+    int32_t params[] = { s0, oc, p0 };
+    ggml_set_op_params(result, params, sizeof(params));
+
+    result->op     = GGML_OP_COL2IM_1D;
+    result->src[0] = col;
 
     return result;
 }

--- a/src/core/conv.h
+++ b/src/core/conv.h
@@ -132,4 +132,44 @@ static inline ggml_tensor* convt1d_crop(ggml_context* ctx, ggml_tensor* x, ggml_
     return y;
 }
 
+// Causal ConvTranspose1d via decomposed mul_mat + col2im.
+// Uses pre-permuted weights w_perm [IC, K*OC] and the new col2im_1d op.
+// Replaces ggml_conv_transpose_1d without touching the old op.
+//
+// Inputs:
+//   x      : (Cin, T_in)  F32, channel-major.
+//   w_perm : (IC, K*OC)   F32, weight pre-permuted at load time.
+//   b      : (Cout,)      F32 or nullptr.
+//   stride : positive integer.
+//   K      : kernel size.
+//
+// Output: (Cout, T_in * stride) F32 (causal right-trim applied).
+static inline ggml_tensor* convt1d_causal_decomp(ggml_context* ctx, ggml_tensor* x, ggml_tensor* w_perm, ggml_tensor* b,
+                                                  int stride, int K) {
+    const int OC = (int)w_perm->ne[1] / K;
+
+    // x: [Cin, T_in] channels-first → ne[0]=Cin=IC already matches w_perm's ne[0]=IC.
+    // mul_mat contracts IC → col: [K*OC, T_in]
+    ggml_tensor* col = ggml_mul_mat(ctx, w_perm, x);
+
+    // col2im: [K*OC, T_in] → [T_raw, OC]  (GATHER)
+    ggml_tensor* y = ggml_col2im_1d(ctx, col, stride, OC, 0);
+
+    // Causal right-trim: T_raw - (K-stride) = T_in * stride
+    const int trim = K - stride;
+    if (trim > 0) {
+        const int64_t T_keep = y->ne[0] - trim;
+        y = ggml_view_2d(ctx, y, T_keep, y->ne[1], y->nb[1], 0);
+        y = ggml_cont(ctx, y);
+    }
+
+    // [T_out, OC] → [OC, T_out]  (back to channels-first)
+    y = ggml_cont(ctx, ggml_transpose(ctx, y));
+
+    if (b) {
+        y = ggml_add(ctx, y, b);
+    }
+    return y;
+}
+
 } // namespace core_convt

--- a/src/core/conv.h
+++ b/src/core/conv.h
@@ -145,7 +145,7 @@ static inline ggml_tensor* convt1d_crop(ggml_context* ctx, ggml_tensor* x, ggml_
 //
 // Output: (Cout, T_in * stride) F32 (causal right-trim applied).
 static inline ggml_tensor* convt1d_causal_decomp(ggml_context* ctx, ggml_tensor* x, ggml_tensor* w_perm, ggml_tensor* b,
-                                                  int stride, int K) {
+                                                 int stride, int K) {
     const int OC = (int)w_perm->ne[1] / K;
 
     // x: [Cin, T_in] channels-first → ne[0]=Cin=IC already matches w_perm's ne[0]=IC.

--- a/src/qwen3_tts.cpp
+++ b/src/qwen3_tts.cpp
@@ -541,7 +541,7 @@ struct g3t_codec_xfmr_layer {
 
 struct g3t_codec_up_stage {
     ggml_tensor* tconv_w = nullptr;
-    ggml_tensor* tconv_w_perm = nullptr;  // pre-permuted [IC, K*OC] for causal-trans-conv
+    ggml_tensor* tconv_w_perm = nullptr; // pre-permuted [IC, K*OC] for causal-trans-conv
     ggml_tensor* tconv_b = nullptr;
     ggml_tensor* dw_w = nullptr;
     ggml_tensor* dw_b = nullptr;
@@ -569,7 +569,7 @@ struct g3t_codec_dec_block {
     ggml_tensor* snake_a = nullptr;
     ggml_tensor* snake_b = nullptr;
     ggml_tensor* tconv_w = nullptr;
-    ggml_tensor* tconv_w_perm = nullptr;  // pre-permuted [IC, K*OC] for causal-trans-conv
+    ggml_tensor* tconv_w_perm = nullptr; // pre-permuted [IC, K*OC] for causal-trans-conv
     ggml_tensor* tconv_b = nullptr;
     g3t_codec_res_unit res[3];
 };
@@ -687,7 +687,7 @@ struct qwen3_tts_context {
     // independently of params.use_gpu. Talker / code_predictor still use
     // `sched` (GPU-accelerated when available).
     ggml_backend_sched_t codec_sched = nullptr;
-    ggml_backend_sched_t codec_sched_gpu = nullptr;  // dedicated GPU scheduler
+    ggml_backend_sched_t codec_sched_gpu = nullptr; // dedicated GPU scheduler
 
     ggml_context* ctx_w = nullptr;
     ggml_backend_buffer_t buf_w = nullptr;
@@ -758,8 +758,8 @@ struct qwen3_tts_context {
     ggml_backend_buffer_t vp_buf_w = nullptr;
     int vp_active = -1; // index into vp_names; -1 = none selected
 
-    int language_id = -1; // codec language id (-1 = auto / nothink path)
-    bool xvec_only = false;  // ECAPA-only, skip ref codes (cross-lingual)
+    int language_id = -1;   // codec language id (-1 = auto / nothink path)
+    bool xvec_only = false; // ECAPA-only, skip ref codes (cross-lingual)
 
     std::string codec_path;
     std::string voice_prompt_path;
@@ -3774,7 +3774,7 @@ static bool load_codec(qwen3_tts_context* c, const char* path) {
     {
         const int n_perm = 6;
         const size_t meta_bytes = ggml_tensor_overhead() * (size_t)n_perm + ggml_graph_overhead() + 4096;
-        struct ggml_init_params pparams = { meta_bytes, nullptr, true };
+        struct ggml_init_params pparams = {meta_bytes, nullptr, true};
         codec.ctx_perm = ggml_init(pparams);
         if (!codec.ctx_perm) {
             fprintf(stderr, "qwen3_tts: codec: failed to init permuted weight context\n");
@@ -3785,7 +3785,7 @@ static bool load_codec(qwen3_tts_context* c, const char* path) {
         // the F32 float buffer holding the result. The tensor is created with
         // data=NULL so ggml_backend_alloc_ctx_tensors can allocate it.
         auto permute = [&](ggml_tensor* src, std::unique_ptr<float[]>& out_buf) -> ggml_tensor* {
-            int K  = (int)src->ne[0];
+            int K = (int)src->ne[0];
             int OC = (int)src->ne[1];
             int IC = (int)src->ne[2];
 
@@ -3808,8 +3808,7 @@ static bool load_codec(qwen3_tts_context* c, const char* path) {
                 for (int ic = 0; ic < IC; ic++)
                     for (int oc = 0; oc < OC; oc++)
                         for (int k = 0; k < K; k++)
-                            dp[(oc * K + k) * IC + ic] =
-                                ggml_fp16_to_fp32(src_buf[ic * OC * K + oc * K + k]);
+                            dp[(oc * K + k) * IC + ic] = ggml_fp16_to_fp32(src_buf[ic * OC * K + oc * K + k]);
             }
             return dst; // data == NULL, backend buffer will own the memory
         };
@@ -3880,20 +3879,21 @@ struct codec_trace_state {
 static bool codec_trace_eval_cb(struct ggml_tensor* t, bool ask, void* user_data) {
     auto* s = (codec_trace_state*)user_data;
     if (ask) {
-        if (s->first) { s->t0 = std::chrono::steady_clock::now(); s->first = false; }
+        if (s->first) {
+            s->t0 = std::chrono::steady_clock::now();
+            s->first = false;
+        }
         s->t0 = std::chrono::steady_clock::now();
         return true;
     }
     // Post-execute: sync + time
-    double dt = std::chrono::duration<double, std::milli>(
-        std::chrono::steady_clock::now() - s->t0).count();
+    double dt = std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - s->t0).count();
     ggml_backend_t be = ggml_backend_sched_get_tensor_backend(s->sched, t);
     const char* be_name = be ? ggml_backend_name(be) : "?";
     char shape[64];
     snprintf(shape, sizeof(shape), "[%lld,%lld,%lld,%lld]", (long long)t->ne[0], (long long)t->ne[1],
              (long long)t->ne[2], (long long)t->ne[3]);
-    fprintf(stderr, "  [%4d/%4d] %7.1fms %-22s %-32s %-22s -> %s\n",
-            s->idx, s->total, dt, ggml_op_name(t->op),
+    fprintf(stderr, "  [%4d/%4d] %7.1fms %-22s %-32s %-22s -> %s\n", s->idx, s->total, dt, ggml_op_name(t->op),
             t->name[0] ? t->name : "(unnamed)", shape, be_name);
     fflush(stderr);
     if (be) {
@@ -3970,14 +3970,16 @@ static float* codec_decode_codes(qwen3_tts_context* c, const int32_t* codes, int
     ggml_cgraph* gf = build_graph_codec_decode(c, T_codec);
     ggml_backend_sched_t sched = codec_pick_sched(c);
 
-    fprintf(stderr, "qwen3_tts: codec: sched_alloc...\n"); fflush(stderr);
+    fprintf(stderr, "qwen3_tts: codec: sched_alloc...\n");
+    fflush(stderr);
     ggml_backend_sched_reset(sched);
     if (!ggml_backend_sched_alloc_graph(sched, gf)) {
         fprintf(stderr, "qwen3_tts: codec: graph alloc failed\n");
         return nullptr;
     }
 
-    fprintf(stderr, "qwen3_tts: codec: tensor_set...\n"); fflush(stderr);
+    fprintf(stderr, "qwen3_tts: codec: tensor_set...\n");
+    fflush(stderr);
     ggml_backend_tensor_set(ggml_graph_get_tensor(gf, "codec_codes"), codes_t.data(), 0,
                             codes_t.size() * sizeof(int32_t));
     ggml_backend_tensor_set(ggml_graph_get_tensor(gf, "codec_positions"), pos.data(), 0, pos.size() * sizeof(int32_t));
@@ -3986,7 +3988,8 @@ static float* codec_decode_codes(qwen3_tts_context* c, const int32_t* codes, int
                                 mask_data.size() * sizeof(ggml_fp16_t));
     }
 
-    fprintf(stderr, "qwen3_tts: codec: compute...\n"); fflush(stderr);
+    fprintf(stderr, "qwen3_tts: codec: compute...\n");
+    fflush(stderr);
     codec_trace_state ts{sched, 0, ggml_graph_n_nodes(gf)};
     if (std::getenv("QWEN3_TTS_CODEC_TRACE")) {
         fprintf(stderr, "qwen3_tts: codec: tracing %d nodes\n", ts.total);
@@ -4000,22 +4003,26 @@ static float* codec_decode_codes(qwen3_tts_context* c, const int32_t* codes, int
     // command-buffer pile-up across repeated Python interop cycles.
     {
         int n = ggml_backend_sched_get_n_backends(sched);
-        if (n > 0) ggml_backend_synchronize(ggml_backend_sched_get_backend(sched, 0));
+        if (n > 0)
+            ggml_backend_synchronize(ggml_backend_sched_get_backend(sched, 0));
     }
-    fprintf(stderr, "qwen3_tts: codec: compute done (status=%d)\n", (int)st); fflush(stderr);
+    fprintf(stderr, "qwen3_tts: codec: compute done (status=%d)\n", (int)st);
+    fflush(stderr);
     if (st != GGML_STATUS_SUCCESS) {
         return nullptr;
     }
 
     ggml_tensor* out = ggml_graph_get_tensor(gf, "pcm");
     int n_samples = (int)ggml_nelements(out);
-    fprintf(stderr, "qwen3_tts: codec: n_samples=%d, malloc...\n", n_samples); fflush(stderr);
+    fprintf(stderr, "qwen3_tts: codec: n_samples=%d, malloc...\n", n_samples);
+    fflush(stderr);
     float* pcm = (float*)malloc((size_t)n_samples * sizeof(float));
     if (!pcm) {
         return nullptr;
     }
     ggml_backend_tensor_get(out, pcm, 0, (size_t)n_samples * sizeof(float));
-    fprintf(stderr, "qwen3_tts: codec: done\n"); fflush(stderr);
+    fprintf(stderr, "qwen3_tts: codec: done\n");
+    fflush(stderr);
     if (out_n_samples) {
         *out_n_samples = n_samples;
     }
@@ -5909,8 +5916,8 @@ extern "C" int32_t* qwen3_tts_synthesize_codes(struct qwen3_tts_context* ctx, co
     } else {
         // Base: need either a voice pack, a runtime voice prompt with ref_codes,
         // or an xvec_only prompt (speaker embedding only, no ref codes).
-        if (ctx->vp_active < 0 && ctx->runtime_ref_codes.empty()
-            && !(ctx->xvec_only && (int)ctx->runtime_spk_emb.size() == (int)ctx->hp.d_model)) {
+        if (ctx->vp_active < 0 && ctx->runtime_ref_codes.empty() &&
+            !(ctx->xvec_only && (int)ctx->runtime_spk_emb.size() == (int)ctx->hp.d_model)) {
             fprintf(stderr, "qwen3_tts: no voice — call qwen3_tts_load_voice_pack or qwen3_tts_set_voice_prompt\n");
             return nullptr;
         }
@@ -5959,10 +5966,11 @@ extern "C" int32_t* qwen3_tts_synthesize_codes(struct qwen3_tts_context* ctx, co
         }
         if (ref_text.empty()) {
             if (ctx->xvec_only) {
-                ref_text = ".";  // xvec_only: dummy ref_text, ICL fusion is skipped
+                ref_text = "."; // xvec_only: dummy ref_text, ICL fusion is skipped
             } else {
-                fprintf(stderr,
-                        "qwen3_tts: no ref_text — call qwen3_tts_set_voice_prompt with ref_text or load a voice pack\n");
+                fprintf(
+                    stderr,
+                    "qwen3_tts: no ref_text — call qwen3_tts_set_voice_prompt with ref_text or load a voice pack\n");
                 return nullptr;
             }
         }
@@ -6381,8 +6389,9 @@ extern "C" float* qwen3_tts_synthesize(struct qwen3_tts_context* ctx, const char
         double code_ms = t_codes - t_total0;
         double codec_ms = t_total1 - t_codes;
         double total_ms = t_total1 - t_total0;
-        fprintf(stderr, "qwen3_tts: perf — codes=%.0f ms  codec=%.0f ms  total=%.0f ms  "
-                        "audio=%.1f s  rtf=%.3f\n",
+        fprintf(stderr,
+                "qwen3_tts: perf — codes=%.0f ms  codec=%.0f ms  total=%.0f ms  "
+                "audio=%.1f s  rtf=%.3f\n",
                 code_ms, codec_ms, total_ms, dur, (total_ms / 1000.0) / dur);
     }
     return pcm;
@@ -6393,9 +6402,11 @@ extern "C" void qwen3_tts_pcm_free(float* pcm) {
 }
 
 extern "C" void qwen3_tts_sync(struct qwen3_tts_context* ctx) {
-    if (!ctx) return;
+    if (!ctx)
+        return;
     auto sync_sched = [](ggml_backend_sched_t sched) {
-        if (!sched) return;
+        if (!sched)
+            return;
         int n = ggml_backend_sched_get_n_backends(sched);
         for (int i = 0; i < n; i++)
             ggml_backend_synchronize(ggml_backend_sched_get_backend(sched, i));

--- a/src/qwen3_tts.cpp
+++ b/src/qwen3_tts.cpp
@@ -82,6 +82,7 @@
 #include <array>
 #include <chrono>
 #include <cmath>
+#include <memory>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -540,6 +541,7 @@ struct g3t_codec_xfmr_layer {
 
 struct g3t_codec_up_stage {
     ggml_tensor* tconv_w = nullptr;
+    ggml_tensor* tconv_w_perm = nullptr;  // pre-permuted [IC, K*OC] for causal-trans-conv
     ggml_tensor* tconv_b = nullptr;
     ggml_tensor* dw_w = nullptr;
     ggml_tensor* dw_b = nullptr;
@@ -567,6 +569,7 @@ struct g3t_codec_dec_block {
     ggml_tensor* snake_a = nullptr;
     ggml_tensor* snake_b = nullptr;
     ggml_tensor* tconv_w = nullptr;
+    ggml_tensor* tconv_w_perm = nullptr;  // pre-permuted [IC, K*OC] for causal-trans-conv
     ggml_tensor* tconv_b = nullptr;
     g3t_codec_res_unit res[3];
 };
@@ -601,6 +604,8 @@ struct g3t_codec {
 
     ggml_context* ctx_w = nullptr;
     ggml_backend_buffer_t buf_w = nullptr;
+    ggml_context* ctx_perm = nullptr;
+    ggml_backend_buffer_t buf_perm = nullptr;
     std::map<std::string, ggml_tensor*> tensors;
 
     bool loaded = false;
@@ -682,6 +687,7 @@ struct qwen3_tts_context {
     // independently of params.use_gpu. Talker / code_predictor still use
     // `sched` (GPU-accelerated when available).
     ggml_backend_sched_t codec_sched = nullptr;
+    ggml_backend_sched_t codec_sched_gpu = nullptr;  // dedicated GPU scheduler
 
     ggml_context* ctx_w = nullptr;
     ggml_backend_buffer_t buf_w = nullptr;
@@ -753,6 +759,7 @@ struct qwen3_tts_context {
     int vp_active = -1; // index into vp_names; -1 = none selected
 
     int language_id = -1; // codec language id (-1 = auto / nothink path)
+    bool xvec_only = false;  // ECAPA-only, skip ref codes (cross-lingual)
 
     std::string codec_path;
     std::string voice_prompt_path;
@@ -2722,6 +2729,12 @@ bool build_icl_prefill_embeds(qwen3_tts_context* c, const std::string& syn_text,
         const int n_total = (int)c->runtime_ref_codes.size();
         T_codec = n_total / n_groups;
         ref_code_TC = c->runtime_ref_codes; // already [T, n_q] row-major
+    } else if (c->xvec_only && (int)c->runtime_spk_emb.size() == d) {
+        // xvec_only path: ECAPA embedding only, no ref codes.
+        // T_codec stays 0 → codec_lens=1 → only codec_bos in fusion.
+        spk_buf = c->runtime_spk_emb;
+        T_codec = 0;
+        ref_code_TC.clear();
     } else {
         // Voice pack path (original behavior).
         if (c->vp_active < 0) {
@@ -2755,7 +2768,8 @@ bool build_icl_prefill_embeds(qwen3_tts_context* c, const std::string& syn_text,
 
     // ---- tokenise ----
     auto syn_ids = tokenise_assistant_text(c, syn_text);
-    auto ref_ids = tokenise_ref_text(c, ref_text);
+    // xvec_only: ref_text may be empty (no transcription needed).
+    auto ref_ids = tokenise_ref_text(c, c->xvec_only && ref_text.empty() ? "." : ref_text);
     if ((int)syn_ids.size() < 8 || (int)ref_ids.size() < 5) {
         fprintf(stderr, "qwen3_tts: prompt too short (syn=%zu ref=%zu)\n", syn_ids.size(), ref_ids.size());
         return false;
@@ -2849,8 +2863,8 @@ bool build_icl_prefill_embeds(qwen3_tts_context* c, const std::string& syn_text,
     // ---- codec_embed (codec_bos + per-frame sum of 16 codebooks) ----
     int32_t codec_bos = (int32_t)hp.codec_bos_id;
     float* codec_bos_emb = lookup_rows(c, c->talker.token_embd_w, &codec_bos, 1);
-    float* codec_sum = sum_codec_embeds(c, ref_code_TC.data(), T_codec);
-    if (!codec_bos_emb || !codec_sum) {
+    float* codec_sum = (T_codec > 0) ? sum_codec_embeds(c, ref_code_TC.data(), T_codec) : nullptr;
+    if (!codec_bos_emb || (T_codec > 0 && !codec_sum)) {
         free(tts_special_emb);
         free(role_emb);
         free(codec_bos_emb);
@@ -3392,10 +3406,17 @@ static ggml_tensor* codec_dw_causal_conv1d(ggml_context* ctx, ggml_tensor* x, gg
     return x;
 }
 
-// Causal transposed conv1d for upsampling — thin wrapper that trims the
-// right tail by (K - stride) samples so T_out = T_in · stride.
-static inline ggml_tensor* codec_transposed_conv1d(ggml_context* ctx, ggml_tensor* x, ggml_tensor* w, ggml_tensor* b,
-                                                   int stride) {
+// Causal transposed conv1d for upsampling.
+// If w_perm (pre-permuted weight [IC, K*OC]) is available, uses the new
+// mul_mat + col2im GPU path; otherwise falls back to the old
+// ggml_conv_transpose_1d path (stable on CPU, also used by the legacy DLL).
+static inline ggml_tensor* codec_transposed_conv1d(ggml_context* ctx, ggml_tensor* x, ggml_tensor* w,
+                                                   ggml_tensor* w_perm, ggml_tensor* b, int stride) {
+    if (w_perm) {
+        const int K = (int)w->ne[0];
+        return core_convt::convt1d_causal_decomp(ctx, x, w_perm, b, stride, K);
+    }
+    // Old path — stable, works on CPU without the col2im op.
     const int K = (int)w->ne[0];
     const int crop_right = (K > stride) ? (K - stride) : 0;
     return core_convt::convt1d_crop(ctx, x, w, b, stride, /*crop_left=*/0, crop_right);
@@ -3451,7 +3472,7 @@ static ggml_tensor* codec_res_unit(ggml_context* ctx, ggml_tensor* x, const g3t_
 // ---------------------------------------------------------------------------
 static ggml_tensor* codec_dec_block(ggml_context* ctx, ggml_tensor* x, const g3t_codec_dec_block& blk, int stride) {
     x = codec_snake_beta(ctx, x, blk.snake_a, blk.snake_b);
-    x = codec_transposed_conv1d(ctx, x, blk.tconv_w, blk.tconv_b, stride);
+    x = codec_transposed_conv1d(ctx, x, blk.tconv_w, blk.tconv_w_perm, blk.tconv_b, stride);
     static const int dilations[3] = {1, 3, 9};
     for (int u = 0; u < 3; u++) {
         x = codec_res_unit(ctx, x, blk.res[u], dilations[u]);
@@ -3569,7 +3590,7 @@ static ggml_cgraph* build_graph_codec_decode(qwen3_tts_context* c, int T) {
 
     // ── Step 4: ConvNeXt upsample (2 stages, each 2×) ──────────────────────
     for (int s = 0; s < 2; s++) {
-        h = codec_transposed_conv1d(ctx0, h, codec.up[s].tconv_w, codec.up[s].tconv_b, 2);
+        h = codec_transposed_conv1d(ctx0, h, codec.up[s].tconv_w, codec.up[s].tconv_w_perm, codec.up[s].tconv_b, 2);
         h = codec_convnext_block(ctx0, h, codec.up[s]);
         char uname[32];
         snprintf(uname, sizeof(uname), "codec_up%d_out", s);
@@ -3749,6 +3770,73 @@ static bool load_codec(qwen3_tts_context* c, const char* path) {
     codec.out_conv_w = req("codec.dec.out_conv_w");
     codec.out_conv_b = req("codec.dec.out_conv_b");
 
+    // ---------- permute tconv weights for causal-trans-conv (mul_mat + col2im) ----------
+    {
+        const int n_perm = 6;
+        const size_t meta_bytes = ggml_tensor_overhead() * (size_t)n_perm + ggml_graph_overhead() + 4096;
+        struct ggml_init_params pparams = { meta_bytes, nullptr, true };
+        codec.ctx_perm = ggml_init(pparams);
+        if (!codec.ctx_perm) {
+            fprintf(stderr, "qwen3_tts: codec: failed to init permuted weight context\n");
+            return false;
+        }
+
+        // Helper: permute PyTorch weight (K, OC, IC) → w_perm (IC, K*OC), return
+        // the F32 float buffer holding the result. The tensor is created with
+        // data=NULL so ggml_backend_alloc_ctx_tensors can allocate it.
+        auto permute = [&](ggml_tensor* src, std::unique_ptr<float[]>& out_buf) -> ggml_tensor* {
+            int K  = (int)src->ne[0];
+            int OC = (int)src->ne[1];
+            int IC = (int)src->ne[2];
+
+            ggml_tensor* dst = ggml_new_tensor_2d(codec.ctx_perm, GGML_TYPE_F32, IC, K * OC);
+
+            size_t n_elems = (size_t)K * OC * IC;
+            out_buf = std::make_unique<float[]>((size_t)IC * K * OC);
+            float* dp = out_buf.get();
+
+            if (src->type == GGML_TYPE_F32) {
+                auto src_buf = std::make_unique<float[]>(n_elems);
+                ggml_backend_tensor_get(src, src_buf.get(), 0, n_elems * sizeof(float));
+                for (int ic = 0; ic < IC; ic++)
+                    for (int oc = 0; oc < OC; oc++)
+                        for (int k = 0; k < K; k++)
+                            dp[(oc * K + k) * IC + ic] = src_buf[ic * OC * K + oc * K + k];
+            } else {
+                auto src_buf = std::make_unique<ggml_fp16_t[]>(n_elems);
+                ggml_backend_tensor_get(src, src_buf.get(), 0, n_elems * sizeof(ggml_fp16_t));
+                for (int ic = 0; ic < IC; ic++)
+                    for (int oc = 0; oc < OC; oc++)
+                        for (int k = 0; k < K; k++)
+                            dp[(oc * K + k) * IC + ic] =
+                                ggml_fp16_to_fp32(src_buf[ic * OC * K + oc * K + k]);
+            }
+            return dst; // data == NULL, backend buffer will own the memory
+        };
+
+        std::unique_ptr<float[]> up_wp_buf[2];
+        std::unique_ptr<float[]> blk_wp_buf[4];
+        for (int s = 0; s < 2; s++)
+            codec.up[s].tconv_w_perm = permute(codec.up[s].tconv_w, up_wp_buf[s]);
+        for (int b = 0; b < 4; b++)
+            codec.blocks[b].tconv_w_perm = permute(codec.blocks[b].tconv_w, blk_wp_buf[b]);
+
+        // Allocate backend buffer (GPU or CPU) for the permuted tensors.
+        codec.buf_perm = ggml_backend_alloc_ctx_tensors(codec.ctx_perm, weight_backend);
+        if (!codec.buf_perm) {
+            fprintf(stderr, "qwen3_tts: codec: failed to alloc permuted weight buffer\n");
+            return false;
+        }
+
+        // Upload the permuted data into the freshly allocated backend buffer.
+        for (int s = 0; s < 2; s++)
+            ggml_backend_tensor_set(codec.up[s].tconv_w_perm, up_wp_buf[s].get(), 0,
+                                    ggml_nbytes(codec.up[s].tconv_w_perm));
+        for (int b = 0; b < 4; b++)
+            ggml_backend_tensor_set(codec.blocks[b].tconv_w_perm, blk_wp_buf[b].get(), 0,
+                                    ggml_nbytes(codec.blocks[b].tconv_w_perm));
+    }
+
     // Codec compute metadata
     c->codec_compute_meta.resize(ggml_tensor_overhead() * 8192 + ggml_graph_overhead_custom(8192, false));
 
@@ -3785,23 +3873,29 @@ struct codec_trace_state {
     ggml_backend_sched_t sched = nullptr;
     int idx = 0;
     int total = 0;
+    std::chrono::steady_clock::time_point t0;
+    bool first = true;
 };
 
 static bool codec_trace_eval_cb(struct ggml_tensor* t, bool ask, void* user_data) {
     auto* s = (codec_trace_state*)user_data;
     if (ask) {
-        ggml_backend_t be = ggml_backend_sched_get_tensor_backend(s->sched, t);
-        const char* be_name = be ? ggml_backend_name(be) : "?";
-        char shape[64];
-        snprintf(shape, sizeof(shape), "[%lld,%lld,%lld,%lld]", (long long)t->ne[0], (long long)t->ne[1],
-                 (long long)t->ne[2], (long long)t->ne[3]);
-        fprintf(stderr, "  [%4d/%4d] %-22s %-32s %-22s -> %s\n", s->idx, s->total, ggml_op_name(t->op),
-                t->name[0] ? t->name : "(unnamed)", shape, be_name);
-        fflush(stderr);
+        if (s->first) { s->t0 = std::chrono::steady_clock::now(); s->first = false; }
+        s->t0 = std::chrono::steady_clock::now();
         return true;
     }
-    // Post-execute: synchronize so a Metal hang is attributed to *this* op.
+    // Post-execute: sync + time
+    double dt = std::chrono::duration<double, std::milli>(
+        std::chrono::steady_clock::now() - s->t0).count();
     ggml_backend_t be = ggml_backend_sched_get_tensor_backend(s->sched, t);
+    const char* be_name = be ? ggml_backend_name(be) : "?";
+    char shape[64];
+    snprintf(shape, sizeof(shape), "[%lld,%lld,%lld,%lld]", (long long)t->ne[0], (long long)t->ne[1],
+             (long long)t->ne[2], (long long)t->ne[3]);
+    fprintf(stderr, "  [%4d/%4d] %7.1fms %-22s %-32s %-22s -> %s\n",
+            s->idx, s->total, dt, ggml_op_name(t->op),
+            t->name[0] ? t->name : "(unnamed)", shape, be_name);
+    fflush(stderr);
     if (be) {
         ggml_backend_synchronize(be);
     }
@@ -3818,7 +3912,14 @@ static bool codec_trace_eval_cb(struct ggml_tensor* t, bool ask, void* user_data
 //                                   hang does not apply.
 static ggml_backend_sched_t codec_pick_sched(qwen3_tts_context* c) {
     if (std::getenv("QWEN3_TTS_CODEC_FORCE_METAL") || std::getenv("QWEN3_TTS_CODEC_GPU")) {
-        return c->sched;
+        // Dedicated GPU scheduler — isolates codec memory pool from talker/main
+        // to prevent VRAM fragmentation across repeated Python interop cycles.
+        if (!c->codec_sched_gpu) {
+            ggml_backend_t backends[2] = {c->backend, c->backend_cpu};
+            int n_be = (c->backend && c->backend != c->backend_cpu) ? 2 : 1;
+            c->codec_sched_gpu = ggml_backend_sched_new(backends, nullptr, n_be, 8192, false, false);
+        }
+        return c->codec_sched_gpu;
     }
     return c->codec_sched;
 }
@@ -3868,12 +3969,15 @@ static float* codec_decode_codes(qwen3_tts_context* c, const int32_t* codes, int
 
     ggml_cgraph* gf = build_graph_codec_decode(c, T_codec);
     ggml_backend_sched_t sched = codec_pick_sched(c);
+
+    fprintf(stderr, "qwen3_tts: codec: sched_alloc...\n"); fflush(stderr);
     ggml_backend_sched_reset(sched);
     if (!ggml_backend_sched_alloc_graph(sched, gf)) {
         fprintf(stderr, "qwen3_tts: codec: graph alloc failed\n");
         return nullptr;
     }
 
+    fprintf(stderr, "qwen3_tts: codec: tensor_set...\n"); fflush(stderr);
     ggml_backend_tensor_set(ggml_graph_get_tensor(gf, "codec_codes"), codes_t.data(), 0,
                             codes_t.size() * sizeof(int32_t));
     ggml_backend_tensor_set(ggml_graph_get_tensor(gf, "codec_positions"), pos.data(), 0, pos.size() * sizeof(int32_t));
@@ -3882,30 +3986,36 @@ static float* codec_decode_codes(qwen3_tts_context* c, const int32_t* codes, int
                                 mask_data.size() * sizeof(ggml_fp16_t));
     }
 
+    fprintf(stderr, "qwen3_tts: codec: compute...\n"); fflush(stderr);
     codec_trace_state ts{sched, 0, ggml_graph_n_nodes(gf)};
-    const bool trace = std::getenv("QWEN3_TTS_CODEC_TRACE") || std::getenv("QWEN3_TTS_CODEC_FORCE_METAL");
-    if (trace) {
-        fprintf(stderr, "qwen3_tts: codec: tracing %d nodes (sched=%s)\n", ts.total,
-                sched == c->codec_sched ? "codec_cpu" : "main");
+    if (std::getenv("QWEN3_TTS_CODEC_TRACE")) {
+        fprintf(stderr, "qwen3_tts: codec: tracing %d nodes\n", ts.total);
         ggml_backend_sched_set_eval_callback(sched, codec_trace_eval_cb, &ts);
     }
-
     ggml_status st = ggml_backend_sched_graph_compute(sched, gf);
-    if (trace) {
+    if (std::getenv("QWEN3_TTS_CODEC_TRACE")) {
         ggml_backend_sched_set_eval_callback(sched, nullptr, nullptr);
     }
+    // Sync GPU to drain the command queue before reading back; also prevents
+    // command-buffer pile-up across repeated Python interop cycles.
+    {
+        int n = ggml_backend_sched_get_n_backends(sched);
+        if (n > 0) ggml_backend_synchronize(ggml_backend_sched_get_backend(sched, 0));
+    }
+    fprintf(stderr, "qwen3_tts: codec: compute done (status=%d)\n", (int)st); fflush(stderr);
     if (st != GGML_STATUS_SUCCESS) {
-        fprintf(stderr, "qwen3_tts: codec: compute failed (status=%d, last_op_idx=%d)\n", (int)st, ts.idx);
         return nullptr;
     }
 
     ggml_tensor* out = ggml_graph_get_tensor(gf, "pcm");
-    const int n_samples = (int)ggml_nelements(out);
+    int n_samples = (int)ggml_nelements(out);
+    fprintf(stderr, "qwen3_tts: codec: n_samples=%d, malloc...\n", n_samples); fflush(stderr);
     float* pcm = (float*)malloc((size_t)n_samples * sizeof(float));
     if (!pcm) {
         return nullptr;
     }
     ggml_backend_tensor_get(out, pcm, 0, (size_t)n_samples * sizeof(float));
+    fprintf(stderr, "qwen3_tts: codec: done\n"); fflush(stderr);
     if (out_n_samples) {
         *out_n_samples = n_samples;
     }
@@ -4891,6 +5001,40 @@ static void build_embd_caches(qwen3_tts_context* c) {
         c->codec_embd_cache[i].init(cp.codec_embd[i]);
 }
 
+extern "C" struct qwen3_tts_context* qwen3_tts_init_codec_only(const char* codec_path,
+                                                               struct qwen3_tts_context_params params) {
+    auto* c = new qwen3_tts_context();
+    c->params = params;
+    c->n_threads = params.n_threads > 0 ? params.n_threads : 4;
+
+    c->backend_cpu = ggml_backend_cpu_init();
+    if (!c->backend_cpu) {
+        fprintf(stderr, "qwen3_tts: failed to init CPU backend\n");
+        delete c;
+        return nullptr;
+    }
+    ggml_backend_cpu_set_n_threads(c->backend_cpu, c->n_threads);
+    c->backend = params.use_gpu ? ggml_backend_init_best() : c->backend_cpu;
+    if (!c->backend) {
+        c->backend = c->backend_cpu;
+    }
+
+    if (!load_codec(c, codec_path)) {
+        fprintf(stderr, "qwen3_tts: codec-only init: failed to load codec\n");
+        qwen3_tts_free(c);
+        return nullptr;
+    }
+
+    // Create main scheduler — codec_pick_sched() returns c->sched for GPU path.
+    // ggml_backend_sched_new requires last backend to be CPU.
+    {
+        ggml_backend_t backends[2] = {c->backend, c->backend_cpu};
+        c->sched = ggml_backend_sched_new(backends, nullptr, 2, 16384, false, false);
+    }
+
+    return c;
+}
+
 extern "C" struct qwen3_tts_context* qwen3_tts_init_from_file(const char* path_model,
                                                               struct qwen3_tts_context_params params) {
     auto* c = new qwen3_tts_context();
@@ -5312,10 +5456,31 @@ extern "C" int qwen3_tts_set_voice_prompt_with_text(struct qwen3_tts_context* ct
     if (!ctx) {
         return -1;
     }
+    ctx->xvec_only = false;
     if (ref_text) {
         ctx->runtime_ref_text = ref_text;
     }
     return qwen3_tts_set_voice_prompt(ctx, wav_path);
+}
+
+extern "C" int qwen3_tts_set_voice_prompt_xvec_only(struct qwen3_tts_context* ctx, const char* wav_path) {
+    if (!ctx) {
+        return -1;
+    }
+    // Use the same WAV loading + ECAPA pipeline as set_voice_prompt.
+    int rc = qwen3_tts_set_voice_prompt(ctx, wav_path);
+    if (rc != 0) {
+        return rc;
+    }
+    // Keep the speaker embedding, but clear the reference codes so the
+    // ICL prefill builder skips ref_code fusion — only the codec BOS
+    // token is injected, producing x_vector_only behaviour.
+    ctx->runtime_ref_codes.clear();
+    ctx->xvec_only = true;
+    if (ctx->params.verbosity >= 1) {
+        fprintf(stderr, "qwen3_tts: voice prompt (xvec_only) set from '%s'\n", wav_path);
+    }
+    return 0;
 }
 
 // Debug: get the runtime ref codes (for diff harness / comparison).
@@ -5742,8 +5907,10 @@ extern "C" int32_t* qwen3_tts_synthesize_codes(struct qwen3_tts_context* ctx, co
             return nullptr;
         }
     } else {
-        // Base: need either a voice pack OR a runtime voice prompt.
-        if (ctx->vp_active < 0 && ctx->runtime_ref_codes.empty()) {
+        // Base: need either a voice pack, a runtime voice prompt with ref_codes,
+        // or an xvec_only prompt (speaker embedding only, no ref codes).
+        if (ctx->vp_active < 0 && ctx->runtime_ref_codes.empty()
+            && !(ctx->xvec_only && (int)ctx->runtime_spk_emb.size() == (int)ctx->hp.d_model)) {
             fprintf(stderr, "qwen3_tts: no voice — call qwen3_tts_load_voice_pack or qwen3_tts_set_voice_prompt\n");
             return nullptr;
         }
@@ -5791,9 +5958,13 @@ extern "C" int32_t* qwen3_tts_synthesize_codes(struct qwen3_tts_context* ctx, co
             ref_text = ctx->vp_ref_texts[ctx->vp_active];
         }
         if (ref_text.empty()) {
-            fprintf(stderr,
-                    "qwen3_tts: no ref_text — call qwen3_tts_set_voice_prompt with ref_text or load a voice pack\n");
-            return nullptr;
+            if (ctx->xvec_only) {
+                ref_text = ".";  // xvec_only: dummy ref_text, ICL fusion is skipped
+            } else {
+                fprintf(stderr,
+                        "qwen3_tts: no ref_text — call qwen3_tts_set_voice_prompt with ref_text or load a voice pack\n");
+                return nullptr;
+            }
         }
         if (!build_icl_prefill_embeds(ctx, text, ref_text, prefill, T_pre, trailing, M_trail)) {
             return nullptr;
@@ -6120,8 +6291,10 @@ extern "C" float* qwen3_tts_synthesize(struct qwen3_tts_context* ctx, const char
         fprintf(stderr, "qwen3_tts: synthesize() requires the codec — call qwen3_tts_set_codec_path() first.\n");
         return nullptr;
     }
+    const double t_total0 = now_ms();
     int n_codes = 0;
     int32_t* codes = qwen3_tts_synthesize_codes(ctx, text, &n_codes);
+    const double t_codes = now_ms();
     if (!codes || n_codes <= 0) {
         free(codes);
         return nullptr;
@@ -6202,11 +6375,37 @@ extern "C" float* qwen3_tts_synthesize(struct qwen3_tts_context* ctx, const char
     }
 
     free(codes);
+    const double t_total1 = now_ms();
+    if (out_n_samples && *out_n_samples > 0) {
+        double dur = (double)(*out_n_samples) / 24000.0;
+        double code_ms = t_codes - t_total0;
+        double codec_ms = t_total1 - t_codes;
+        double total_ms = t_total1 - t_total0;
+        fprintf(stderr, "qwen3_tts: perf — codes=%.0f ms  codec=%.0f ms  total=%.0f ms  "
+                        "audio=%.1f s  rtf=%.3f\n",
+                code_ms, codec_ms, total_ms, dur, (total_ms / 1000.0) / dur);
+    }
     return pcm;
 }
 
 extern "C" void qwen3_tts_pcm_free(float* pcm) {
     free(pcm);
+}
+
+extern "C" void qwen3_tts_sync(struct qwen3_tts_context* ctx) {
+    if (!ctx) return;
+    auto sync_sched = [](ggml_backend_sched_t sched) {
+        if (!sched) return;
+        int n = ggml_backend_sched_get_n_backends(sched);
+        for (int i = 0; i < n; i++)
+            ggml_backend_synchronize(ggml_backend_sched_get_backend(sched, i));
+    };
+    sync_sched(ctx->sched);
+    sync_sched(ctx->codec_sched);
+    sync_sched(ctx->codec_sched_gpu);
+    sync_sched(ctx->talker_step_sched);
+    sync_sched(ctx->cp_sched);
+    sync_sched(ctx->cp_step0_sched);
 }
 
 extern "C" void qwen3_tts_free(struct qwen3_tts_context* ctx) {
@@ -6215,6 +6414,9 @@ extern "C" void qwen3_tts_free(struct qwen3_tts_context* ctx) {
     }
     if (ctx->codec_sched) {
         ggml_backend_sched_free(ctx->codec_sched);
+    }
+    if (ctx->codec_sched_gpu) {
+        ggml_backend_sched_free(ctx->codec_sched_gpu);
     }
     if (ctx->cp_sched) {
         ggml_backend_sched_free(ctx->cp_sched);
@@ -6271,6 +6473,12 @@ extern "C" void qwen3_tts_free(struct qwen3_tts_context* ctx) {
     }
     if (ctx->codec.ctx_w) {
         ggml_free(ctx->codec.ctx_w);
+    }
+    if (ctx->codec.buf_perm) {
+        ggml_backend_buffer_free(ctx->codec.buf_perm);
+    }
+    if (ctx->codec.ctx_perm) {
+        ggml_free(ctx->codec.ctx_perm);
     }
     if (ctx->vp_buf_w) {
         ggml_backend_buffer_free(ctx->vp_buf_w);

--- a/src/qwen3_tts.h
+++ b/src/qwen3_tts.h
@@ -19,18 +19,6 @@
 
 #include <stdint.h>
 
-// DLL export/import plumbing. Define QWEN3_TTS_SHARED when building the
-// shared library; consumers that dlopen / LoadLibrary the DLL can leave
-// everything undefed (the public functions use extern "C" linkage and
-// are trivially resolvable by name).
-#if defined(_WIN32) && defined(QWEN3_TTS_SHARED)
-#define QWEN3_TTS_API __declspec(dllexport)
-#elif defined(_WIN32) && defined(QWEN3_TTS_IMPORT)
-#define QWEN3_TTS_API __declspec(dllimport)
-#else
-#define QWEN3_TTS_API
-#endif
-
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -47,20 +35,20 @@ struct qwen3_tts_context_params {
     bool flash_attn;     // PLAN #89 plumbing — Qwen3 talker SA blocks.
 };
 
-QWEN3_TTS_API struct qwen3_tts_context_params qwen3_tts_context_default_params(void);
+struct qwen3_tts_context_params qwen3_tts_context_default_params(void);
 
 // Initialise from the talker LM GGUF file.
-QWEN3_TTS_API struct qwen3_tts_context* qwen3_tts_init_from_file(const char* path_model,
+struct qwen3_tts_context* qwen3_tts_init_from_file(const char* path_model,
                                                                  struct qwen3_tts_context_params params);
 
 // Initialise a codec-only context — no talker / code_predictor / speaker encoder.
 // Only loads the codec GGUF and sets up a backend.
-QWEN3_TTS_API struct qwen3_tts_context* qwen3_tts_init_codec_only(const char* codec_path,
+struct qwen3_tts_context* qwen3_tts_init_codec_only(const char* codec_path,
                                                                   struct qwen3_tts_context_params params);
 
 // Point the runtime at the codec GGUF (cstr/qwen3-tts-tokenizer-12hz-GGUF).
 // Required before the first `qwen3_tts_synthesize` call. Returns 0 on success.
-QWEN3_TTS_API int qwen3_tts_set_codec_path(struct qwen3_tts_context* ctx, const char* path);
+int qwen3_tts_set_codec_path(struct qwen3_tts_context* ctx, const char* path);
 
 // Set a reference voice from a 24 kHz mono WAV plus its transcription.
 // Computes both the ECAPA speaker embedding AND the RVQ codec codes from
@@ -68,28 +56,28 @@ QWEN3_TTS_API int qwen3_tts_set_codec_path(struct qwen3_tts_context* ctx, const 
 // the transcription of wav_path — required for the ICL prefill to match
 // the reference audio with text. Pass nullptr / "" to clear the prompt.
 // Returns 0 on success.
-QWEN3_TTS_API int qwen3_tts_set_voice_prompt(struct qwen3_tts_context* ctx, const char* wav_path);
+int qwen3_tts_set_voice_prompt(struct qwen3_tts_context* ctx, const char* wav_path);
 
 // Same as set_voice_prompt but also stores the reference transcription.
 // Required for synthesis when no voice pack is loaded.
-QWEN3_TTS_API int qwen3_tts_set_voice_prompt_with_text(struct qwen3_tts_context* ctx, const char* wav_path,
+int qwen3_tts_set_voice_prompt_with_text(struct qwen3_tts_context* ctx, const char* wav_path,
                                                        const char* ref_text);
 
 // ECAPA-only voice prompt: computes the speaker embedding but skips the
 // codec encode. Used for cross-lingual cloning (e.g. Japanese reference
 // → Chinese output) where the reference audio's speech codes would
 // interfere with the target language. Returns 0 on success.
-QWEN3_TTS_API int qwen3_tts_set_voice_prompt_xvec_only(struct qwen3_tts_context* ctx, const char* wav_path);
+int qwen3_tts_set_voice_prompt_xvec_only(struct qwen3_tts_context* ctx, const char* wav_path);
 
 // Debug: get the runtime ref codes after set_voice_prompt. Returns pointer
 // to internal int32 buffer of *out_n elements ([T_codec, 16] row-major).
 // Do NOT free — buffer is owned by ctx.
-QWEN3_TTS_API const int32_t* qwen3_tts_get_runtime_ref_codes(struct qwen3_tts_context* ctx, int* out_n);
+const int32_t* qwen3_tts_get_runtime_ref_codes(struct qwen3_tts_context* ctx, int* out_n);
 
 // Read-only pointer to the currently active runtime speaker embedding
 // (set by qwen3_tts_set_voice_prompt[_with_text]). Returns nullptr if no
 // runtime prompt is active. Buffer is owned by ctx; do not free.
-QWEN3_TTS_API const float* qwen3_tts_get_runtime_spk_emb(struct qwen3_tts_context* ctx, int* out_n);
+const float* qwen3_tts_get_runtime_spk_emb(struct qwen3_tts_context* ctx, int* out_n);
 
 // Run the codec encoder graph on `audio` (24 kHz mono float32) and extract
 // a named intermediate tensor by `stage_name`. Stage names match those set
@@ -99,7 +87,7 @@ QWEN3_TTS_API const float* qwen3_tts_get_runtime_spk_emb(struct qwen3_tts_contex
 //   "cenc_ds_out"      — After stride-2 downsample [T_frames, 512]
 //   "enc_emb"          — Final embeddings (channels-first) [512, T_frames]
 // Returns malloc'd float[*out_n] array. Caller frees with free().
-QWEN3_TTS_API float* qwen3_tts_cenc_extract_stage(struct qwen3_tts_context* ctx, const float* audio, int n_samples,
+float* qwen3_tts_cenc_extract_stage(struct qwen3_tts_context* ctx, const float* audio, int n_samples,
                                                   const char* stage_name, int* out_n);
 
 // Load a voice pack GGUF (produced by `models/bake-qwen3-tts-voice-pack.py`)
@@ -107,22 +95,22 @@ QWEN3_TTS_API float* qwen3_tts_cenc_extract_stage(struct qwen3_tts_context* ctx,
 // the official qwen-tts package. Required for voice-clone synthesis
 // until the runtime ECAPA speaker_encoder + codec encoder forwards
 // land.  Returns 0 on success.
-QWEN3_TTS_API int qwen3_tts_load_voice_pack(struct qwen3_tts_context* ctx, const char* path);
+int qwen3_tts_load_voice_pack(struct qwen3_tts_context* ctx, const char* path);
 
 // Select an active voice from the loaded voice pack by name.
 // Returns 0 on success, -1 if no voice pack is loaded, -2 if the
 // name is not in the pack.
-QWEN3_TTS_API int qwen3_tts_select_voice(struct qwen3_tts_context* ctx, const char* name);
+int qwen3_tts_select_voice(struct qwen3_tts_context* ctx, const char* name);
 
 // Set the synthesis language: 0=auto (no language hint, "nothink"
 // path), >0 = codec_language_id from the model config (e.g. English=2050,
 // Chinese=2055, Japanese=2058 — see the `codec_language_id` field in the
 // HF config.json's talker_config). Returns 0 on success.
-QWEN3_TTS_API int qwen3_tts_set_language(struct qwen3_tts_context* ctx, int codec_language_id);
+int qwen3_tts_set_language(struct qwen3_tts_context* ctx, int codec_language_id);
 
 // Set language by name (case-insensitive, e.g. "chinese", "japanese", "auto").
 // Looks up the name in the qwen3tts.codec_language_names table loaded from GGUF.
-QWEN3_TTS_API int qwen3_tts_set_language_by_name(struct qwen3_tts_context* ctx, const char* name);
+int qwen3_tts_set_language_by_name(struct qwen3_tts_context* ctx, const char* name);
 
 // ---------------------------------------------------------------------------
 // CustomVoice (fixed-speaker fine-tunes — Qwen3-TTS-CustomVoice variants)
@@ -139,11 +127,11 @@ QWEN3_TTS_API int qwen3_tts_set_language_by_name(struct qwen3_tts_context* ctx, 
 // Returns the number of fixed speakers in the loaded model (0 if the
 // model isn't CustomVoice). Pass into qwen3_tts_get_speaker_name to
 // enumerate them.
-QWEN3_TTS_API int qwen3_tts_n_speakers(struct qwen3_tts_context* ctx);
+int qwen3_tts_n_speakers(struct qwen3_tts_context* ctx);
 
 // Returns the i-th fixed speaker name. Buffer is owned by ctx; do not
 // free. Returns nullptr for out-of-range indices.
-QWEN3_TTS_API const char* qwen3_tts_get_speaker_name(struct qwen3_tts_context* ctx, int i);
+const char* qwen3_tts_get_speaker_name(struct qwen3_tts_context* ctx, int i);
 
 // Select a fixed CustomVoice speaker by name (case-insensitive). Sets
 // the runtime speaker_embed by lifting `talker.token_embd[spk_id]` (no
@@ -153,10 +141,10 @@ QWEN3_TTS_API const char* qwen3_tts_get_speaker_name(struct qwen3_tts_context* c
 //
 // Returns 0 on success, -1 if the loaded model is not CustomVoice, -2
 // if the name is unknown.
-QWEN3_TTS_API int qwen3_tts_set_speaker_by_name(struct qwen3_tts_context* ctx, const char* name);
+int qwen3_tts_set_speaker_by_name(struct qwen3_tts_context* ctx, const char* name);
 
 // Returns true if the loaded model is a CustomVoice variant.
-QWEN3_TTS_API int qwen3_tts_is_custom_voice(struct qwen3_tts_context* ctx);
+int qwen3_tts_is_custom_voice(struct qwen3_tts_context* ctx);
 
 // ---------------------------------------------------------------------------
 // VoiceDesign (instruct-tuned variants — Qwen3-TTS-VoiceDesign)
@@ -171,13 +159,13 @@ QWEN3_TTS_API int qwen3_tts_is_custom_voice(struct qwen3_tts_context* ctx);
 // The codec bridge omits the speaker frame entirely.
 
 // Returns true if the loaded model is a VoiceDesign variant.
-QWEN3_TTS_API int qwen3_tts_is_voice_design(struct qwen3_tts_context* ctx);
+int qwen3_tts_is_voice_design(struct qwen3_tts_context* ctx);
 
 // Set the natural-language voice description used as the instruct
 // prompt. Required before qwen3_tts_synthesize / synthesize_codes when
 // the loaded model is VoiceDesign. Re-callable; latest call wins.
 // Returns 0 on success, -1 if the loaded model is not VoiceDesign.
-QWEN3_TTS_API int qwen3_tts_set_instruct(struct qwen3_tts_context* ctx, const char* instruct);
+int qwen3_tts_set_instruct(struct qwen3_tts_context* ctx, const char* instruct);
 
 // Set a style-control instruction for CustomVoice synthesis (issue #91).
 // CustomVoice combines a fixed speaker (--voice <name>) with an optional
@@ -190,7 +178,7 @@ QWEN3_TTS_API int qwen3_tts_set_instruct(struct qwen3_tts_context* ctx, const ch
 // Pass nullptr or "" to clear any previously set style.
 // Re-callable; latest call wins.
 // Returns 0 on success, -1 if the loaded model is not CustomVoice.
-QWEN3_TTS_API int qwen3_tts_set_cv_style_instruct(struct qwen3_tts_context* ctx, const char* instruct);
+int qwen3_tts_set_cv_style_instruct(struct qwen3_tts_context* ctx, const char* instruct);
 
 // ---------------------------------------------------------------------------
 // Diff-harness stage APIs (PLAN #52 step 4)
@@ -208,7 +196,7 @@ QWEN3_TTS_API int qwen3_tts_set_cv_style_instruct(struct qwen3_tts_context* ctx,
 // Pure-text path that doesn't depend on the speaker_embed / codec
 // splice, so a numerical mismatch here implicates only the
 // text_embedding lookup or the text_proj fc1/fc2.
-QWEN3_TTS_API float* qwen3_tts_run_text_proj(struct qwen3_tts_context* ctx, const int32_t* ids, int n_tokens,
+float* qwen3_tts_run_text_proj(struct qwen3_tts_context* ctx, const int32_t* ids, int n_tokens,
                                              int* out_T, int* out_d);
 
 // Run the talker prefill on a caller-supplied embedding tensor of shape
@@ -219,7 +207,7 @@ QWEN3_TTS_API float* qwen3_tts_run_text_proj(struct qwen3_tts_context* ctx, cons
 // Decouples "is the talker graph numerically correct" from "is the
 // prefill builder semantically correct" — feed in a PyTorch-prebuilt
 // embedding, expect bit-equivalent logits at the tail.
-QWEN3_TTS_API float* qwen3_tts_run_talker_with_embeds(struct qwen3_tts_context* ctx, const float* embeds, int n_tokens,
+float* qwen3_tts_run_talker_with_embeds(struct qwen3_tts_context* ctx, const float* embeds, int n_tokens,
                                                       int* out_vocab);
 
 // Run a single code-predictor AR step against caller-supplied embeds.
@@ -240,7 +228,7 @@ QWEN3_TTS_API float* qwen3_tts_run_talker_with_embeds(struct qwen3_tts_context* 
 // 0..14 to drive a full AR frame. Returns malloc'd float[*out_vocab]
 // logits (last-position only). *out_vocab is set to cp_vocab_size on
 // success. Caller frees with free().
-QWEN3_TTS_API float* qwen3_tts_run_code_pred_step(struct qwen3_tts_context* ctx, const float* embeds, int n_tokens,
+float* qwen3_tts_run_code_pred_step(struct qwen3_tts_context* ctx, const float* embeds, int n_tokens,
                                                   int n_past, int lm_head_idx, int* out_vocab);
 
 // Build the full ICL prefill embedding from a (syn_text, ref_text) pair
@@ -250,7 +238,7 @@ QWEN3_TTS_API float* qwen3_tts_run_code_pred_step(struct qwen3_tts_context* ctx,
 //
 // Mirrors `Qwen3TTSForConditionalGeneration.generate_icl_prompt` for
 // the non_streaming_mode=False voice-clone Base path.
-QWEN3_TTS_API float* qwen3_tts_build_icl_prefill(struct qwen3_tts_context* ctx, const char* syn_text,
+float* qwen3_tts_build_icl_prefill(struct qwen3_tts_context* ctx, const char* syn_text,
                                                  const char* ref_text, int* out_T);
 
 // Run the talker on `text`, AR-decode codebook-0 until <eos> or the
@@ -261,15 +249,15 @@ QWEN3_TTS_API float* qwen3_tts_build_icl_prefill(struct qwen3_tts_context* ctx, 
 // This is the path you can use today even without the codec — the
 // codes are valid Qwen3-TTS codec inputs; you can render them via the
 // HF python codec for audio.
-QWEN3_TTS_API int32_t* qwen3_tts_synthesize_codes(struct qwen3_tts_context* ctx, const char* text, int* out_n_codes);
+int32_t* qwen3_tts_synthesize_codes(struct qwen3_tts_context* ctx, const char* text, int* out_n_codes);
 
-QWEN3_TTS_API void qwen3_tts_codes_free(int32_t* codes);
+void qwen3_tts_codes_free(int32_t* codes);
 
 // Decode a flat code array (T_frames * 16 codes, row-major [T, 16]) to
 // 24 kHz mono float32 PCM. Requires `qwen3_tts_set_codec_path` to have
 // been called first. Caller frees with `qwen3_tts_pcm_free`.
 // *out_n_samples is set on success; returns nullptr on failure.
-QWEN3_TTS_API float* qwen3_tts_decode_codes(struct qwen3_tts_context* ctx, const int32_t* codes, int n_codes,
+float* qwen3_tts_decode_codes(struct qwen3_tts_context* ctx, const int32_t* codes, int n_codes,
                                             int* out_n_samples);
 
 // Run the codec graph on `codes` and extract a named intermediate tensor
@@ -279,41 +267,41 @@ QWEN3_TTS_API float* qwen3_tts_decode_codes(struct qwen3_tts_context* ctx, const
 //   "codec_up0_out", "codec_up1_out", "codec_in_conv_out",
 //   "codec_blk0_out", "pcm"
 // Returns malloc'd float array of *out_n elements. Caller frees with free().
-QWEN3_TTS_API float* qwen3_tts_codec_extract_stage(struct qwen3_tts_context* ctx, const int32_t* codes, int n_codes,
+float* qwen3_tts_codec_extract_stage(struct qwen3_tts_context* ctx, const int32_t* codes, int n_codes,
                                                    const char* stage_name, int* out_n);
 
 // Synthesise text → 24 kHz mono float32 PCM. Caller frees with
 // `qwen3_tts_pcm_free`. *out_n_samples is set on success.
 //
 // Returns nullptr until the codec decoder lands (PLAN #52 step 3).
-QWEN3_TTS_API float* qwen3_tts_synthesize(struct qwen3_tts_context* ctx, const char* text, int* out_n_samples);
+float* qwen3_tts_synthesize(struct qwen3_tts_context* ctx, const char* text, int* out_n_samples);
 
-QWEN3_TTS_API void qwen3_tts_pcm_free(float* pcm);
+void qwen3_tts_pcm_free(float* pcm);
 
-QWEN3_TTS_API void qwen3_tts_free(struct qwen3_tts_context* ctx);
+void qwen3_tts_free(struct qwen3_tts_context* ctx);
 
 // Drain the GPU command queue — blocks until all previously submitted
 // work completes. Call between repeated DLL invocations (e.g. per-sentence
 // in a Python read-aloud loop) to prevent HIP driver command-buffer pile-up.
-QWEN3_TTS_API void qwen3_tts_sync(struct qwen3_tts_context* ctx);
+void qwen3_tts_sync(struct qwen3_tts_context* ctx);
 
-QWEN3_TTS_API void qwen3_tts_set_n_threads(struct qwen3_tts_context* ctx, int n_threads);
+void qwen3_tts_set_n_threads(struct qwen3_tts_context* ctx, int n_threads);
 
 // Runtime sampling temperature for the code-predictor's top-k sampler
 // (default 0.9 — pass 0.0 to revert to that default; pass any other
 // non-zero value to override).
-QWEN3_TTS_API void qwen3_tts_set_temperature(struct qwen3_tts_context* ctx, float temperature);
-QWEN3_TTS_API void qwen3_tts_set_seed(struct qwen3_tts_context* ctx, uint64_t seed);
+void qwen3_tts_set_temperature(struct qwen3_tts_context* ctx, float temperature);
+void qwen3_tts_set_seed(struct qwen3_tts_context* ctx, uint64_t seed);
 
 // Compute the 128-mel log-mel spectrogram used by the speaker encoder
 // from 24 kHz mono audio. Returns malloc'd (T_mel × 128) row-major float32.
 // *out_T_mel is set to the number of mel frames. Caller frees with free().
-QWEN3_TTS_API float* qwen3_tts_compute_speaker_mel(struct qwen3_tts_context* ctx, const float* audio, int n_samples,
+float* qwen3_tts_compute_speaker_mel(struct qwen3_tts_context* ctx, const float* audio, int n_samples,
                                                    int* out_T_mel, int* out_n_mels);
 
 // Run the ECAPA speaker encoder on a pre-computed mel spectrogram.
 // mel is (T_mel × n_mels=128) row-major float32. Returns malloc'd float[1024].
-QWEN3_TTS_API float* qwen3_tts_run_speaker_enc_on_mel(struct qwen3_tts_context* ctx, const float* mel, int T_mel,
+float* qwen3_tts_run_speaker_enc_on_mel(struct qwen3_tts_context* ctx, const float* mel, int T_mel,
                                                       int* out_dim);
 
 // Compute a 1024-d speaker embedding from 24 kHz mono float32 audio
@@ -321,7 +309,7 @@ QWEN3_TTS_API float* qwen3_tts_run_speaker_enc_on_mel(struct qwen3_tts_context* 
 // array that the caller frees with free(). Returns nullptr on failure.
 // Does NOT set the context's active voice — call qwen3_tts_set_voice_prompt
 // to both compute and activate the embedding for synthesis.
-QWEN3_TTS_API float* qwen3_tts_compute_speaker_embedding(struct qwen3_tts_context* ctx, const float* audio,
+float* qwen3_tts_compute_speaker_embedding(struct qwen3_tts_context* ctx, const float* audio,
                                                          int n_samples, int* out_dim);
 
 #ifdef __cplusplus

--- a/src/qwen3_tts.h
+++ b/src/qwen3_tts.h
@@ -50,11 +50,13 @@ struct qwen3_tts_context_params {
 QWEN3_TTS_API struct qwen3_tts_context_params qwen3_tts_context_default_params(void);
 
 // Initialise from the talker LM GGUF file.
-QWEN3_TTS_API struct qwen3_tts_context* qwen3_tts_init_from_file(const char* path_model, struct qwen3_tts_context_params params);
+QWEN3_TTS_API struct qwen3_tts_context* qwen3_tts_init_from_file(const char* path_model,
+                                                                 struct qwen3_tts_context_params params);
 
 // Initialise a codec-only context — no talker / code_predictor / speaker encoder.
 // Only loads the codec GGUF and sets up a backend.
-QWEN3_TTS_API struct qwen3_tts_context* qwen3_tts_init_codec_only(const char* codec_path, struct qwen3_tts_context_params params);
+QWEN3_TTS_API struct qwen3_tts_context* qwen3_tts_init_codec_only(const char* codec_path,
+                                                                  struct qwen3_tts_context_params params);
 
 // Point the runtime at the codec GGUF (cstr/qwen3-tts-tokenizer-12hz-GGUF).
 // Required before the first `qwen3_tts_synthesize` call. Returns 0 on success.
@@ -70,7 +72,8 @@ QWEN3_TTS_API int qwen3_tts_set_voice_prompt(struct qwen3_tts_context* ctx, cons
 
 // Same as set_voice_prompt but also stores the reference transcription.
 // Required for synthesis when no voice pack is loaded.
-QWEN3_TTS_API int qwen3_tts_set_voice_prompt_with_text(struct qwen3_tts_context* ctx, const char* wav_path, const char* ref_text);
+QWEN3_TTS_API int qwen3_tts_set_voice_prompt_with_text(struct qwen3_tts_context* ctx, const char* wav_path,
+                                                       const char* ref_text);
 
 // ECAPA-only voice prompt: computes the speaker embedding but skips the
 // codec encode. Used for cross-lingual cloning (e.g. Japanese reference
@@ -97,7 +100,7 @@ QWEN3_TTS_API const float* qwen3_tts_get_runtime_spk_emb(struct qwen3_tts_contex
 //   "enc_emb"          — Final embeddings (channels-first) [512, T_frames]
 // Returns malloc'd float[*out_n] array. Caller frees with free().
 QWEN3_TTS_API float* qwen3_tts_cenc_extract_stage(struct qwen3_tts_context* ctx, const float* audio, int n_samples,
-                                    const char* stage_name, int* out_n);
+                                                  const char* stage_name, int* out_n);
 
 // Load a voice pack GGUF (produced by `models/bake-qwen3-tts-voice-pack.py`)
 // containing one or more `(spk_embedding, ref_code)` pairs extracted via
@@ -205,7 +208,8 @@ QWEN3_TTS_API int qwen3_tts_set_cv_style_instruct(struct qwen3_tts_context* ctx,
 // Pure-text path that doesn't depend on the speaker_embed / codec
 // splice, so a numerical mismatch here implicates only the
 // text_embedding lookup or the text_proj fc1/fc2.
-QWEN3_TTS_API float* qwen3_tts_run_text_proj(struct qwen3_tts_context* ctx, const int32_t* ids, int n_tokens, int* out_T, int* out_d);
+QWEN3_TTS_API float* qwen3_tts_run_text_proj(struct qwen3_tts_context* ctx, const int32_t* ids, int n_tokens,
+                                             int* out_T, int* out_d);
 
 // Run the talker prefill on a caller-supplied embedding tensor of shape
 // (n_tokens, hidden_size). Returns the codec_head logits at the LAST
@@ -216,7 +220,7 @@ QWEN3_TTS_API float* qwen3_tts_run_text_proj(struct qwen3_tts_context* ctx, cons
 // prefill builder semantically correct" — feed in a PyTorch-prebuilt
 // embedding, expect bit-equivalent logits at the tail.
 QWEN3_TTS_API float* qwen3_tts_run_talker_with_embeds(struct qwen3_tts_context* ctx, const float* embeds, int n_tokens,
-                                        int* out_vocab);
+                                                      int* out_vocab);
 
 // Run a single code-predictor AR step against caller-supplied embeds.
 // Mirrors the per-step calls inside `code_pred_generate_15`, but exposes
@@ -236,8 +240,8 @@ QWEN3_TTS_API float* qwen3_tts_run_talker_with_embeds(struct qwen3_tts_context* 
 // 0..14 to drive a full AR frame. Returns malloc'd float[*out_vocab]
 // logits (last-position only). *out_vocab is set to cp_vocab_size on
 // success. Caller frees with free().
-QWEN3_TTS_API float* qwen3_tts_run_code_pred_step(struct qwen3_tts_context* ctx, const float* embeds, int n_tokens, int n_past,
-                                    int lm_head_idx, int* out_vocab);
+QWEN3_TTS_API float* qwen3_tts_run_code_pred_step(struct qwen3_tts_context* ctx, const float* embeds, int n_tokens,
+                                                  int n_past, int lm_head_idx, int* out_vocab);
 
 // Build the full ICL prefill embedding from a (syn_text, ref_text) pair
 // using the active voice pack's spk_embedding + ref_code. Returns a
@@ -246,8 +250,8 @@ QWEN3_TTS_API float* qwen3_tts_run_code_pred_step(struct qwen3_tts_context* ctx,
 //
 // Mirrors `Qwen3TTSForConditionalGeneration.generate_icl_prompt` for
 // the non_streaming_mode=False voice-clone Base path.
-QWEN3_TTS_API float* qwen3_tts_build_icl_prefill(struct qwen3_tts_context* ctx, const char* syn_text, const char* ref_text,
-                                   int* out_T);
+QWEN3_TTS_API float* qwen3_tts_build_icl_prefill(struct qwen3_tts_context* ctx, const char* syn_text,
+                                                 const char* ref_text, int* out_T);
 
 // Run the talker on `text`, AR-decode codebook-0 until <eos> or the
 // step limit, and return the resulting code stream. *out_n_codes is
@@ -265,7 +269,8 @@ QWEN3_TTS_API void qwen3_tts_codes_free(int32_t* codes);
 // 24 kHz mono float32 PCM. Requires `qwen3_tts_set_codec_path` to have
 // been called first. Caller frees with `qwen3_tts_pcm_free`.
 // *out_n_samples is set on success; returns nullptr on failure.
-QWEN3_TTS_API float* qwen3_tts_decode_codes(struct qwen3_tts_context* ctx, const int32_t* codes, int n_codes, int* out_n_samples);
+QWEN3_TTS_API float* qwen3_tts_decode_codes(struct qwen3_tts_context* ctx, const int32_t* codes, int n_codes,
+                                            int* out_n_samples);
 
 // Run the codec graph on `codes` and extract a named intermediate tensor
 // by `stage_name`. Useful for the diff harness — matches stage names that
@@ -275,7 +280,7 @@ QWEN3_TTS_API float* qwen3_tts_decode_codes(struct qwen3_tts_context* ctx, const
 //   "codec_blk0_out", "pcm"
 // Returns malloc'd float array of *out_n elements. Caller frees with free().
 QWEN3_TTS_API float* qwen3_tts_codec_extract_stage(struct qwen3_tts_context* ctx, const int32_t* codes, int n_codes,
-                                     const char* stage_name, int* out_n);
+                                                   const char* stage_name, int* out_n);
 
 // Synthesise text → 24 kHz mono float32 PCM. Caller frees with
 // `qwen3_tts_pcm_free`. *out_n_samples is set on success.
@@ -303,20 +308,21 @@ QWEN3_TTS_API void qwen3_tts_set_seed(struct qwen3_tts_context* ctx, uint64_t se
 // Compute the 128-mel log-mel spectrogram used by the speaker encoder
 // from 24 kHz mono audio. Returns malloc'd (T_mel × 128) row-major float32.
 // *out_T_mel is set to the number of mel frames. Caller frees with free().
-QWEN3_TTS_API float* qwen3_tts_compute_speaker_mel(struct qwen3_tts_context* ctx, const float* audio, int n_samples, int* out_T_mel,
-                                     int* out_n_mels);
+QWEN3_TTS_API float* qwen3_tts_compute_speaker_mel(struct qwen3_tts_context* ctx, const float* audio, int n_samples,
+                                                   int* out_T_mel, int* out_n_mels);
 
 // Run the ECAPA speaker encoder on a pre-computed mel spectrogram.
 // mel is (T_mel × n_mels=128) row-major float32. Returns malloc'd float[1024].
-QWEN3_TTS_API float* qwen3_tts_run_speaker_enc_on_mel(struct qwen3_tts_context* ctx, const float* mel, int T_mel, int* out_dim);
+QWEN3_TTS_API float* qwen3_tts_run_speaker_enc_on_mel(struct qwen3_tts_context* ctx, const float* mel, int T_mel,
+                                                      int* out_dim);
 
 // Compute a 1024-d speaker embedding from 24 kHz mono float32 audio
 // via the ECAPA-TDNN speaker encoder. Returns a malloc'd float[1024]
 // array that the caller frees with free(). Returns nullptr on failure.
 // Does NOT set the context's active voice — call qwen3_tts_set_voice_prompt
 // to both compute and activate the embedding for synthesis.
-QWEN3_TTS_API float* qwen3_tts_compute_speaker_embedding(struct qwen3_tts_context* ctx, const float* audio, int n_samples,
-                                           int* out_dim);
+QWEN3_TTS_API float* qwen3_tts_compute_speaker_embedding(struct qwen3_tts_context* ctx, const float* audio,
+                                                         int n_samples, int* out_dim);
 
 #ifdef __cplusplus
 }

--- a/src/qwen3_tts.h
+++ b/src/qwen3_tts.h
@@ -38,13 +38,11 @@ struct qwen3_tts_context_params {
 struct qwen3_tts_context_params qwen3_tts_context_default_params(void);
 
 // Initialise from the talker LM GGUF file.
-struct qwen3_tts_context* qwen3_tts_init_from_file(const char* path_model,
-                                                                 struct qwen3_tts_context_params params);
+struct qwen3_tts_context* qwen3_tts_init_from_file(const char* path_model, struct qwen3_tts_context_params params);
 
 // Initialise a codec-only context — no talker / code_predictor / speaker encoder.
 // Only loads the codec GGUF and sets up a backend.
-struct qwen3_tts_context* qwen3_tts_init_codec_only(const char* codec_path,
-                                                                  struct qwen3_tts_context_params params);
+struct qwen3_tts_context* qwen3_tts_init_codec_only(const char* codec_path, struct qwen3_tts_context_params params);
 
 // Point the runtime at the codec GGUF (cstr/qwen3-tts-tokenizer-12hz-GGUF).
 // Required before the first `qwen3_tts_synthesize` call. Returns 0 on success.
@@ -60,8 +58,7 @@ int qwen3_tts_set_voice_prompt(struct qwen3_tts_context* ctx, const char* wav_pa
 
 // Same as set_voice_prompt but also stores the reference transcription.
 // Required for synthesis when no voice pack is loaded.
-int qwen3_tts_set_voice_prompt_with_text(struct qwen3_tts_context* ctx, const char* wav_path,
-                                                       const char* ref_text);
+int qwen3_tts_set_voice_prompt_with_text(struct qwen3_tts_context* ctx, const char* wav_path, const char* ref_text);
 
 // ECAPA-only voice prompt: computes the speaker embedding but skips the
 // codec encode. Used for cross-lingual cloning (e.g. Japanese reference
@@ -88,7 +85,7 @@ const float* qwen3_tts_get_runtime_spk_emb(struct qwen3_tts_context* ctx, int* o
 //   "enc_emb"          — Final embeddings (channels-first) [512, T_frames]
 // Returns malloc'd float[*out_n] array. Caller frees with free().
 float* qwen3_tts_cenc_extract_stage(struct qwen3_tts_context* ctx, const float* audio, int n_samples,
-                                                  const char* stage_name, int* out_n);
+                                    const char* stage_name, int* out_n);
 
 // Load a voice pack GGUF (produced by `models/bake-qwen3-tts-voice-pack.py`)
 // containing one or more `(spk_embedding, ref_code)` pairs extracted via
@@ -196,8 +193,7 @@ int qwen3_tts_set_cv_style_instruct(struct qwen3_tts_context* ctx, const char* i
 // Pure-text path that doesn't depend on the speaker_embed / codec
 // splice, so a numerical mismatch here implicates only the
 // text_embedding lookup or the text_proj fc1/fc2.
-float* qwen3_tts_run_text_proj(struct qwen3_tts_context* ctx, const int32_t* ids, int n_tokens,
-                                             int* out_T, int* out_d);
+float* qwen3_tts_run_text_proj(struct qwen3_tts_context* ctx, const int32_t* ids, int n_tokens, int* out_T, int* out_d);
 
 // Run the talker prefill on a caller-supplied embedding tensor of shape
 // (n_tokens, hidden_size). Returns the codec_head logits at the LAST
@@ -208,7 +204,7 @@ float* qwen3_tts_run_text_proj(struct qwen3_tts_context* ctx, const int32_t* ids
 // prefill builder semantically correct" — feed in a PyTorch-prebuilt
 // embedding, expect bit-equivalent logits at the tail.
 float* qwen3_tts_run_talker_with_embeds(struct qwen3_tts_context* ctx, const float* embeds, int n_tokens,
-                                                      int* out_vocab);
+                                        int* out_vocab);
 
 // Run a single code-predictor AR step against caller-supplied embeds.
 // Mirrors the per-step calls inside `code_pred_generate_15`, but exposes
@@ -228,8 +224,8 @@ float* qwen3_tts_run_talker_with_embeds(struct qwen3_tts_context* ctx, const flo
 // 0..14 to drive a full AR frame. Returns malloc'd float[*out_vocab]
 // logits (last-position only). *out_vocab is set to cp_vocab_size on
 // success. Caller frees with free().
-float* qwen3_tts_run_code_pred_step(struct qwen3_tts_context* ctx, const float* embeds, int n_tokens,
-                                                  int n_past, int lm_head_idx, int* out_vocab);
+float* qwen3_tts_run_code_pred_step(struct qwen3_tts_context* ctx, const float* embeds, int n_tokens, int n_past,
+                                    int lm_head_idx, int* out_vocab);
 
 // Build the full ICL prefill embedding from a (syn_text, ref_text) pair
 // using the active voice pack's spk_embedding + ref_code. Returns a
@@ -238,8 +234,8 @@ float* qwen3_tts_run_code_pred_step(struct qwen3_tts_context* ctx, const float* 
 //
 // Mirrors `Qwen3TTSForConditionalGeneration.generate_icl_prompt` for
 // the non_streaming_mode=False voice-clone Base path.
-float* qwen3_tts_build_icl_prefill(struct qwen3_tts_context* ctx, const char* syn_text,
-                                                 const char* ref_text, int* out_T);
+float* qwen3_tts_build_icl_prefill(struct qwen3_tts_context* ctx, const char* syn_text, const char* ref_text,
+                                   int* out_T);
 
 // Run the talker on `text`, AR-decode codebook-0 until <eos> or the
 // step limit, and return the resulting code stream. *out_n_codes is
@@ -257,8 +253,7 @@ void qwen3_tts_codes_free(int32_t* codes);
 // 24 kHz mono float32 PCM. Requires `qwen3_tts_set_codec_path` to have
 // been called first. Caller frees with `qwen3_tts_pcm_free`.
 // *out_n_samples is set on success; returns nullptr on failure.
-float* qwen3_tts_decode_codes(struct qwen3_tts_context* ctx, const int32_t* codes, int n_codes,
-                                            int* out_n_samples);
+float* qwen3_tts_decode_codes(struct qwen3_tts_context* ctx, const int32_t* codes, int n_codes, int* out_n_samples);
 
 // Run the codec graph on `codes` and extract a named intermediate tensor
 // by `stage_name`. Useful for the diff harness — matches stage names that
@@ -268,7 +263,7 @@ float* qwen3_tts_decode_codes(struct qwen3_tts_context* ctx, const int32_t* code
 //   "codec_blk0_out", "pcm"
 // Returns malloc'd float array of *out_n elements. Caller frees with free().
 float* qwen3_tts_codec_extract_stage(struct qwen3_tts_context* ctx, const int32_t* codes, int n_codes,
-                                                   const char* stage_name, int* out_n);
+                                     const char* stage_name, int* out_n);
 
 // Synthesise text → 24 kHz mono float32 PCM. Caller frees with
 // `qwen3_tts_pcm_free`. *out_n_samples is set on success.
@@ -296,21 +291,20 @@ void qwen3_tts_set_seed(struct qwen3_tts_context* ctx, uint64_t seed);
 // Compute the 128-mel log-mel spectrogram used by the speaker encoder
 // from 24 kHz mono audio. Returns malloc'd (T_mel × 128) row-major float32.
 // *out_T_mel is set to the number of mel frames. Caller frees with free().
-float* qwen3_tts_compute_speaker_mel(struct qwen3_tts_context* ctx, const float* audio, int n_samples,
-                                                   int* out_T_mel, int* out_n_mels);
+float* qwen3_tts_compute_speaker_mel(struct qwen3_tts_context* ctx, const float* audio, int n_samples, int* out_T_mel,
+                                     int* out_n_mels);
 
 // Run the ECAPA speaker encoder on a pre-computed mel spectrogram.
 // mel is (T_mel × n_mels=128) row-major float32. Returns malloc'd float[1024].
-float* qwen3_tts_run_speaker_enc_on_mel(struct qwen3_tts_context* ctx, const float* mel, int T_mel,
-                                                      int* out_dim);
+float* qwen3_tts_run_speaker_enc_on_mel(struct qwen3_tts_context* ctx, const float* mel, int T_mel, int* out_dim);
 
 // Compute a 1024-d speaker embedding from 24 kHz mono float32 audio
 // via the ECAPA-TDNN speaker encoder. Returns a malloc'd float[1024]
 // array that the caller frees with free(). Returns nullptr on failure.
 // Does NOT set the context's active voice — call qwen3_tts_set_voice_prompt
 // to both compute and activate the embedding for synthesis.
-float* qwen3_tts_compute_speaker_embedding(struct qwen3_tts_context* ctx, const float* audio,
-                                                         int n_samples, int* out_dim);
+float* qwen3_tts_compute_speaker_embedding(struct qwen3_tts_context* ctx, const float* audio, int n_samples,
+                                           int* out_dim);
 
 #ifdef __cplusplus
 }

--- a/src/qwen3_tts.h
+++ b/src/qwen3_tts.h
@@ -19,6 +19,18 @@
 
 #include <stdint.h>
 
+// DLL export/import plumbing. Define QWEN3_TTS_SHARED when building the
+// shared library; consumers that dlopen / LoadLibrary the DLL can leave
+// everything undefed (the public functions use extern "C" linkage and
+// are trivially resolvable by name).
+#if defined(_WIN32) && defined(QWEN3_TTS_SHARED)
+#define QWEN3_TTS_API __declspec(dllexport)
+#elif defined(_WIN32) && defined(QWEN3_TTS_IMPORT)
+#define QWEN3_TTS_API __declspec(dllimport)
+#else
+#define QWEN3_TTS_API
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -35,14 +47,18 @@ struct qwen3_tts_context_params {
     bool flash_attn;     // PLAN #89 plumbing — Qwen3 talker SA blocks.
 };
 
-struct qwen3_tts_context_params qwen3_tts_context_default_params(void);
+QWEN3_TTS_API struct qwen3_tts_context_params qwen3_tts_context_default_params(void);
 
 // Initialise from the talker LM GGUF file.
-struct qwen3_tts_context* qwen3_tts_init_from_file(const char* path_model, struct qwen3_tts_context_params params);
+QWEN3_TTS_API struct qwen3_tts_context* qwen3_tts_init_from_file(const char* path_model, struct qwen3_tts_context_params params);
+
+// Initialise a codec-only context — no talker / code_predictor / speaker encoder.
+// Only loads the codec GGUF and sets up a backend.
+QWEN3_TTS_API struct qwen3_tts_context* qwen3_tts_init_codec_only(const char* codec_path, struct qwen3_tts_context_params params);
 
 // Point the runtime at the codec GGUF (cstr/qwen3-tts-tokenizer-12hz-GGUF).
 // Required before the first `qwen3_tts_synthesize` call. Returns 0 on success.
-int qwen3_tts_set_codec_path(struct qwen3_tts_context* ctx, const char* path);
+QWEN3_TTS_API int qwen3_tts_set_codec_path(struct qwen3_tts_context* ctx, const char* path);
 
 // Set a reference voice from a 24 kHz mono WAV plus its transcription.
 // Computes both the ECAPA speaker embedding AND the RVQ codec codes from
@@ -50,21 +66,27 @@ int qwen3_tts_set_codec_path(struct qwen3_tts_context* ctx, const char* path);
 // the transcription of wav_path — required for the ICL prefill to match
 // the reference audio with text. Pass nullptr / "" to clear the prompt.
 // Returns 0 on success.
-int qwen3_tts_set_voice_prompt(struct qwen3_tts_context* ctx, const char* wav_path);
+QWEN3_TTS_API int qwen3_tts_set_voice_prompt(struct qwen3_tts_context* ctx, const char* wav_path);
 
 // Same as set_voice_prompt but also stores the reference transcription.
 // Required for synthesis when no voice pack is loaded.
-int qwen3_tts_set_voice_prompt_with_text(struct qwen3_tts_context* ctx, const char* wav_path, const char* ref_text);
+QWEN3_TTS_API int qwen3_tts_set_voice_prompt_with_text(struct qwen3_tts_context* ctx, const char* wav_path, const char* ref_text);
+
+// ECAPA-only voice prompt: computes the speaker embedding but skips the
+// codec encode. Used for cross-lingual cloning (e.g. Japanese reference
+// → Chinese output) where the reference audio's speech codes would
+// interfere with the target language. Returns 0 on success.
+QWEN3_TTS_API int qwen3_tts_set_voice_prompt_xvec_only(struct qwen3_tts_context* ctx, const char* wav_path);
 
 // Debug: get the runtime ref codes after set_voice_prompt. Returns pointer
 // to internal int32 buffer of *out_n elements ([T_codec, 16] row-major).
 // Do NOT free — buffer is owned by ctx.
-const int32_t* qwen3_tts_get_runtime_ref_codes(struct qwen3_tts_context* ctx, int* out_n);
+QWEN3_TTS_API const int32_t* qwen3_tts_get_runtime_ref_codes(struct qwen3_tts_context* ctx, int* out_n);
 
 // Read-only pointer to the currently active runtime speaker embedding
 // (set by qwen3_tts_set_voice_prompt[_with_text]). Returns nullptr if no
 // runtime prompt is active. Buffer is owned by ctx; do not free.
-const float* qwen3_tts_get_runtime_spk_emb(struct qwen3_tts_context* ctx, int* out_n);
+QWEN3_TTS_API const float* qwen3_tts_get_runtime_spk_emb(struct qwen3_tts_context* ctx, int* out_n);
 
 // Run the codec encoder graph on `audio` (24 kHz mono float32) and extract
 // a named intermediate tensor by `stage_name`. Stage names match those set
@@ -74,7 +96,7 @@ const float* qwen3_tts_get_runtime_spk_emb(struct qwen3_tts_context* ctx, int* o
 //   "cenc_ds_out"      — After stride-2 downsample [T_frames, 512]
 //   "enc_emb"          — Final embeddings (channels-first) [512, T_frames]
 // Returns malloc'd float[*out_n] array. Caller frees with free().
-float* qwen3_tts_cenc_extract_stage(struct qwen3_tts_context* ctx, const float* audio, int n_samples,
+QWEN3_TTS_API float* qwen3_tts_cenc_extract_stage(struct qwen3_tts_context* ctx, const float* audio, int n_samples,
                                     const char* stage_name, int* out_n);
 
 // Load a voice pack GGUF (produced by `models/bake-qwen3-tts-voice-pack.py`)
@@ -82,18 +104,22 @@ float* qwen3_tts_cenc_extract_stage(struct qwen3_tts_context* ctx, const float* 
 // the official qwen-tts package. Required for voice-clone synthesis
 // until the runtime ECAPA speaker_encoder + codec encoder forwards
 // land.  Returns 0 on success.
-int qwen3_tts_load_voice_pack(struct qwen3_tts_context* ctx, const char* path);
+QWEN3_TTS_API int qwen3_tts_load_voice_pack(struct qwen3_tts_context* ctx, const char* path);
 
 // Select an active voice from the loaded voice pack by name.
 // Returns 0 on success, -1 if no voice pack is loaded, -2 if the
 // name is not in the pack.
-int qwen3_tts_select_voice(struct qwen3_tts_context* ctx, const char* name);
+QWEN3_TTS_API int qwen3_tts_select_voice(struct qwen3_tts_context* ctx, const char* name);
 
 // Set the synthesis language: 0=auto (no language hint, "nothink"
 // path), >0 = codec_language_id from the model config (e.g. English=2050,
 // Chinese=2055, Japanese=2058 — see the `codec_language_id` field in the
 // HF config.json's talker_config). Returns 0 on success.
-int qwen3_tts_set_language(struct qwen3_tts_context* ctx, int codec_language_id);
+QWEN3_TTS_API int qwen3_tts_set_language(struct qwen3_tts_context* ctx, int codec_language_id);
+
+// Set language by name (case-insensitive, e.g. "chinese", "japanese", "auto").
+// Looks up the name in the qwen3tts.codec_language_names table loaded from GGUF.
+QWEN3_TTS_API int qwen3_tts_set_language_by_name(struct qwen3_tts_context* ctx, const char* name);
 
 // ---------------------------------------------------------------------------
 // CustomVoice (fixed-speaker fine-tunes — Qwen3-TTS-CustomVoice variants)
@@ -110,11 +136,11 @@ int qwen3_tts_set_language(struct qwen3_tts_context* ctx, int codec_language_id)
 // Returns the number of fixed speakers in the loaded model (0 if the
 // model isn't CustomVoice). Pass into qwen3_tts_get_speaker_name to
 // enumerate them.
-int qwen3_tts_n_speakers(struct qwen3_tts_context* ctx);
+QWEN3_TTS_API int qwen3_tts_n_speakers(struct qwen3_tts_context* ctx);
 
 // Returns the i-th fixed speaker name. Buffer is owned by ctx; do not
 // free. Returns nullptr for out-of-range indices.
-const char* qwen3_tts_get_speaker_name(struct qwen3_tts_context* ctx, int i);
+QWEN3_TTS_API const char* qwen3_tts_get_speaker_name(struct qwen3_tts_context* ctx, int i);
 
 // Select a fixed CustomVoice speaker by name (case-insensitive). Sets
 // the runtime speaker_embed by lifting `talker.token_embd[spk_id]` (no
@@ -124,10 +150,10 @@ const char* qwen3_tts_get_speaker_name(struct qwen3_tts_context* ctx, int i);
 //
 // Returns 0 on success, -1 if the loaded model is not CustomVoice, -2
 // if the name is unknown.
-int qwen3_tts_set_speaker_by_name(struct qwen3_tts_context* ctx, const char* name);
+QWEN3_TTS_API int qwen3_tts_set_speaker_by_name(struct qwen3_tts_context* ctx, const char* name);
 
 // Returns true if the loaded model is a CustomVoice variant.
-int qwen3_tts_is_custom_voice(struct qwen3_tts_context* ctx);
+QWEN3_TTS_API int qwen3_tts_is_custom_voice(struct qwen3_tts_context* ctx);
 
 // ---------------------------------------------------------------------------
 // VoiceDesign (instruct-tuned variants — Qwen3-TTS-VoiceDesign)
@@ -142,13 +168,13 @@ int qwen3_tts_is_custom_voice(struct qwen3_tts_context* ctx);
 // The codec bridge omits the speaker frame entirely.
 
 // Returns true if the loaded model is a VoiceDesign variant.
-int qwen3_tts_is_voice_design(struct qwen3_tts_context* ctx);
+QWEN3_TTS_API int qwen3_tts_is_voice_design(struct qwen3_tts_context* ctx);
 
 // Set the natural-language voice description used as the instruct
 // prompt. Required before qwen3_tts_synthesize / synthesize_codes when
 // the loaded model is VoiceDesign. Re-callable; latest call wins.
 // Returns 0 on success, -1 if the loaded model is not VoiceDesign.
-int qwen3_tts_set_instruct(struct qwen3_tts_context* ctx, const char* instruct);
+QWEN3_TTS_API int qwen3_tts_set_instruct(struct qwen3_tts_context* ctx, const char* instruct);
 
 // Set a style-control instruction for CustomVoice synthesis (issue #91).
 // CustomVoice combines a fixed speaker (--voice <name>) with an optional
@@ -161,7 +187,7 @@ int qwen3_tts_set_instruct(struct qwen3_tts_context* ctx, const char* instruct);
 // Pass nullptr or "" to clear any previously set style.
 // Re-callable; latest call wins.
 // Returns 0 on success, -1 if the loaded model is not CustomVoice.
-int qwen3_tts_set_cv_style_instruct(struct qwen3_tts_context* ctx, const char* instruct);
+QWEN3_TTS_API int qwen3_tts_set_cv_style_instruct(struct qwen3_tts_context* ctx, const char* instruct);
 
 // ---------------------------------------------------------------------------
 // Diff-harness stage APIs (PLAN #52 step 4)
@@ -179,7 +205,7 @@ int qwen3_tts_set_cv_style_instruct(struct qwen3_tts_context* ctx, const char* i
 // Pure-text path that doesn't depend on the speaker_embed / codec
 // splice, so a numerical mismatch here implicates only the
 // text_embedding lookup or the text_proj fc1/fc2.
-float* qwen3_tts_run_text_proj(struct qwen3_tts_context* ctx, const int32_t* ids, int n_tokens, int* out_T, int* out_d);
+QWEN3_TTS_API float* qwen3_tts_run_text_proj(struct qwen3_tts_context* ctx, const int32_t* ids, int n_tokens, int* out_T, int* out_d);
 
 // Run the talker prefill on a caller-supplied embedding tensor of shape
 // (n_tokens, hidden_size). Returns the codec_head logits at the LAST
@@ -189,7 +215,7 @@ float* qwen3_tts_run_text_proj(struct qwen3_tts_context* ctx, const int32_t* ids
 // Decouples "is the talker graph numerically correct" from "is the
 // prefill builder semantically correct" — feed in a PyTorch-prebuilt
 // embedding, expect bit-equivalent logits at the tail.
-float* qwen3_tts_run_talker_with_embeds(struct qwen3_tts_context* ctx, const float* embeds, int n_tokens,
+QWEN3_TTS_API float* qwen3_tts_run_talker_with_embeds(struct qwen3_tts_context* ctx, const float* embeds, int n_tokens,
                                         int* out_vocab);
 
 // Run a single code-predictor AR step against caller-supplied embeds.
@@ -210,7 +236,7 @@ float* qwen3_tts_run_talker_with_embeds(struct qwen3_tts_context* ctx, const flo
 // 0..14 to drive a full AR frame. Returns malloc'd float[*out_vocab]
 // logits (last-position only). *out_vocab is set to cp_vocab_size on
 // success. Caller frees with free().
-float* qwen3_tts_run_code_pred_step(struct qwen3_tts_context* ctx, const float* embeds, int n_tokens, int n_past,
+QWEN3_TTS_API float* qwen3_tts_run_code_pred_step(struct qwen3_tts_context* ctx, const float* embeds, int n_tokens, int n_past,
                                     int lm_head_idx, int* out_vocab);
 
 // Build the full ICL prefill embedding from a (syn_text, ref_text) pair
@@ -220,7 +246,7 @@ float* qwen3_tts_run_code_pred_step(struct qwen3_tts_context* ctx, const float* 
 //
 // Mirrors `Qwen3TTSForConditionalGeneration.generate_icl_prompt` for
 // the non_streaming_mode=False voice-clone Base path.
-float* qwen3_tts_build_icl_prefill(struct qwen3_tts_context* ctx, const char* syn_text, const char* ref_text,
+QWEN3_TTS_API float* qwen3_tts_build_icl_prefill(struct qwen3_tts_context* ctx, const char* syn_text, const char* ref_text,
                                    int* out_T);
 
 // Run the talker on `text`, AR-decode codebook-0 until <eos> or the
@@ -231,15 +257,15 @@ float* qwen3_tts_build_icl_prefill(struct qwen3_tts_context* ctx, const char* sy
 // This is the path you can use today even without the codec — the
 // codes are valid Qwen3-TTS codec inputs; you can render them via the
 // HF python codec for audio.
-int32_t* qwen3_tts_synthesize_codes(struct qwen3_tts_context* ctx, const char* text, int* out_n_codes);
+QWEN3_TTS_API int32_t* qwen3_tts_synthesize_codes(struct qwen3_tts_context* ctx, const char* text, int* out_n_codes);
 
-void qwen3_tts_codes_free(int32_t* codes);
+QWEN3_TTS_API void qwen3_tts_codes_free(int32_t* codes);
 
 // Decode a flat code array (T_frames * 16 codes, row-major [T, 16]) to
 // 24 kHz mono float32 PCM. Requires `qwen3_tts_set_codec_path` to have
 // been called first. Caller frees with `qwen3_tts_pcm_free`.
 // *out_n_samples is set on success; returns nullptr on failure.
-float* qwen3_tts_decode_codes(struct qwen3_tts_context* ctx, const int32_t* codes, int n_codes, int* out_n_samples);
+QWEN3_TTS_API float* qwen3_tts_decode_codes(struct qwen3_tts_context* ctx, const int32_t* codes, int n_codes, int* out_n_samples);
 
 // Run the codec graph on `codes` and extract a named intermediate tensor
 // by `stage_name`. Useful for the diff harness — matches stage names that
@@ -248,43 +274,48 @@ float* qwen3_tts_decode_codes(struct qwen3_tts_context* ctx, const int32_t* code
 //   "codec_up0_out", "codec_up1_out", "codec_in_conv_out",
 //   "codec_blk0_out", "pcm"
 // Returns malloc'd float array of *out_n elements. Caller frees with free().
-float* qwen3_tts_codec_extract_stage(struct qwen3_tts_context* ctx, const int32_t* codes, int n_codes,
+QWEN3_TTS_API float* qwen3_tts_codec_extract_stage(struct qwen3_tts_context* ctx, const int32_t* codes, int n_codes,
                                      const char* stage_name, int* out_n);
 
 // Synthesise text → 24 kHz mono float32 PCM. Caller frees with
 // `qwen3_tts_pcm_free`. *out_n_samples is set on success.
 //
 // Returns nullptr until the codec decoder lands (PLAN #52 step 3).
-float* qwen3_tts_synthesize(struct qwen3_tts_context* ctx, const char* text, int* out_n_samples);
+QWEN3_TTS_API float* qwen3_tts_synthesize(struct qwen3_tts_context* ctx, const char* text, int* out_n_samples);
 
-void qwen3_tts_pcm_free(float* pcm);
+QWEN3_TTS_API void qwen3_tts_pcm_free(float* pcm);
 
-void qwen3_tts_free(struct qwen3_tts_context* ctx);
+QWEN3_TTS_API void qwen3_tts_free(struct qwen3_tts_context* ctx);
 
-void qwen3_tts_set_n_threads(struct qwen3_tts_context* ctx, int n_threads);
+// Drain the GPU command queue — blocks until all previously submitted
+// work completes. Call between repeated DLL invocations (e.g. per-sentence
+// in a Python read-aloud loop) to prevent HIP driver command-buffer pile-up.
+QWEN3_TTS_API void qwen3_tts_sync(struct qwen3_tts_context* ctx);
+
+QWEN3_TTS_API void qwen3_tts_set_n_threads(struct qwen3_tts_context* ctx, int n_threads);
 
 // Runtime sampling temperature for the code-predictor's top-k sampler
 // (default 0.9 — pass 0.0 to revert to that default; pass any other
 // non-zero value to override).
-void qwen3_tts_set_temperature(struct qwen3_tts_context* ctx, float temperature);
-void qwen3_tts_set_seed(struct qwen3_tts_context* ctx, uint64_t seed);
+QWEN3_TTS_API void qwen3_tts_set_temperature(struct qwen3_tts_context* ctx, float temperature);
+QWEN3_TTS_API void qwen3_tts_set_seed(struct qwen3_tts_context* ctx, uint64_t seed);
 
 // Compute the 128-mel log-mel spectrogram used by the speaker encoder
 // from 24 kHz mono audio. Returns malloc'd (T_mel × 128) row-major float32.
 // *out_T_mel is set to the number of mel frames. Caller frees with free().
-float* qwen3_tts_compute_speaker_mel(struct qwen3_tts_context* ctx, const float* audio, int n_samples, int* out_T_mel,
+QWEN3_TTS_API float* qwen3_tts_compute_speaker_mel(struct qwen3_tts_context* ctx, const float* audio, int n_samples, int* out_T_mel,
                                      int* out_n_mels);
 
 // Run the ECAPA speaker encoder on a pre-computed mel spectrogram.
 // mel is (T_mel × n_mels=128) row-major float32. Returns malloc'd float[1024].
-float* qwen3_tts_run_speaker_enc_on_mel(struct qwen3_tts_context* ctx, const float* mel, int T_mel, int* out_dim);
+QWEN3_TTS_API float* qwen3_tts_run_speaker_enc_on_mel(struct qwen3_tts_context* ctx, const float* mel, int T_mel, int* out_dim);
 
 // Compute a 1024-d speaker embedding from 24 kHz mono float32 audio
 // via the ECAPA-TDNN speaker encoder. Returns a malloc'd float[1024]
 // array that the caller frees with free(). Returns nullptr on failure.
 // Does NOT set the context's active voice — call qwen3_tts_set_voice_prompt
 // to both compute and activate the embedding for synthesis.
-float* qwen3_tts_compute_speaker_embedding(struct qwen3_tts_context* ctx, const float* audio, int n_samples,
+QWEN3_TTS_API float* qwen3_tts_compute_speaker_embedding(struct qwen3_tts_context* ctx, const float* audio, int n_samples,
                                            int* out_dim);
 
 #ifdef __cplusplus


### PR DESCRIPTION
# conv1d transpose: efficient decomposed mul_mat + col2im_1d (codec ~1200ms → ~130ms)

I've been trying to fix the conv1d transpose issue for the past few days(I'm not sure if you still remember the issue I posted about, but it's been bothering me a lot since then.), and then I came across a really elegant solution in [qwentts.cpp](https://github.com/ServeurpersoCom/qwentts.cpp/blob/master/src/causal-trans-conv.h) — it uses **w_perm → mul_mat → col2im_1d → GATHER** to perform a really efficient conv1d transpose. So I ported that approach here and applied it to the Qwen3-TTS codec decoder.

Test results on the same long sentence (10s), AMD 7900 XTX:

**Before — All on GPU (with conv1d transpose falls back on cpu):**
```
codes=2353 ms  codec=396 ms  total=2748 ms  audio=10.4 s  rtf=0.264
codes=2377 ms  codec=392 ms  total=2769 ms  audio=10.4 s  rtf=0.266
codes=2346 ms  codec=416 ms  total=2762 ms  audio=10.4 s  rtf=0.266
codes=2341 ms  codec=413 ms  total=2754 ms  audio=10.4 s  rtf=0.265
codes=2352 ms  codec=388 ms  total=2740 ms  audio=10.4 s  rtf=0.263
```

**Before — All on GPU (Yes, the GPU performs a really slow conv1d transpose — it's even slower than the CPU and takes a lot of time.):**
```
codes=2361 ms  codec=1198 ms  total=3558 ms  audio=10.4 s  rtf=0.342
codes=2333 ms  codec=1197 ms  total=3531 ms  audio=10.4 s  rtf=0.340
codes=2324 ms  codec=1198 ms  total=3522 ms  audio=10.4 s  rtf=0.339
codes=2361 ms  codec=1200 ms  total=3561 ms  audio=10.4 s  rtf=0.342
codes=2316 ms  codec=1198 ms  total=3514 ms  audio=10.4 s  rtf=0.338
```

**After — Decomposed mul_mat + col2im_1d, all weights and computation on GPU:**
```
codes=2380 ms  codec=131 ms  total=2511 ms  audio=10.4 s  rtf=0.241
codes=2357 ms  codec=129 ms  total=2486 ms  audio=10.4 s  rtf=0.239
codes=2442 ms  codec=131 ms  total=2573 ms  audio=10.4 s  rtf=0.247
codes=2393 ms  codec=128 ms  total=2521 ms  audio=10.4 s  rtf=0.242
codes=2343 ms  codec=126 ms  total=2470 ms  audio=10.4 s  rtf=0.237

```

The codec decoder drops from ~1200 ms down to ~130 ms. The talker forward is now the main bottleneck, which is exactly where we want it.

This decomposed approach should benefit any TTS model that relies heavily on ConvTranspose1d upsampling layers — I've only tested on Qwen3-TTS so far since its codec uses them most aggressively, but in general it doesn't hurt to have this path available.

### Metal

`ggml_col2im_1d` only has a CUDA kernel right now. On Metal the `w_perm`-based path will abort with "unsupported op". Someone with Apple hardware needs to port the kernel from `ggml-cuda/col2im-1d.cu` into `ggml-metal.metal` and wire up the dispatch. CPU is unaffected (it doesn't populate `w_perm` and keeps using the old `convt1d_crop` path).
