### PR TITLE
feat(server): honor --punc-model in server mode

### DIFF
--- a/examples/cli/crispasr_server.cpp
+++ b/examples/cli/crispasr_server.cpp
@@ -30,6 +30,8 @@
 #include "crispasr_vad_cli.h"
 #include "crispasr_aligner_cli.h"
 #include "whisper_params.h"
+#include "fireredpunc.h"   // server-mode punctuation restoration (--punc-model)
+#include "crispasr_cache.h" // ensure_cached_file() for resolving the punc model
 
 #include "common-crispasr.h" // read_audio_data
 #include "crispasr_chat.h"   // /v1/chat/completions
@@ -311,7 +313,8 @@ struct transcription_result {
 // Load audio from a multipart file upload, transcribe it, return result.
 // Acquires model_mutex internally.
 static transcription_result do_transcribe(const httplib::MultipartFormData& audio_file, CrispasrBackend* backend,
-                                          std::mutex& model_mutex, whisper_params rp, bool need_timestamps) {
+                                          std::mutex& model_mutex, whisper_params rp, bool need_timestamps,
+                                          fireredpunc_context* punc_ctx = nullptr) {
     transcription_result result;
     result.language = rp.language;
 
@@ -503,6 +506,22 @@ static transcription_result do_transcribe(const httplib::MultipartFormData& audi
         if (!rp.punctuation) {
             for (auto& seg : result.segs)
                 crispasr_strip_punctuation(seg);
+        }
+        // Otherwise, when a punctuation model is loaded (--punc-model), restore
+        // punctuation on each segment via FireRedPunc — the post-processor the CLI
+        // applies but the server path previously skipped, so non-PnC backends
+        // (e.g. parakeet RNNT/CTC) can return punctuated text. Serialized on its
+        // own mutex because the shared punc context is not re-entrant.
+        else if (punc_ctx) {
+            static std::mutex punc_mtx;
+            std::lock_guard<std::mutex> plk(punc_mtx);
+            for (auto& seg : result.segs) {
+                char* punctuated = fireredpunc_process(punc_ctx, seg.text.c_str());
+                if (punctuated) {
+                    seg.text = punctuated;
+                    free(punctuated);
+                }
+            }
         }
 
         auto t1 = std::chrono::steady_clock::now();
@@ -710,6 +729,41 @@ int crispasr_run_server(whisper_params& params, const std::string& host, int por
                 params.model.c_str());
     }
 
+    // Load the FireRedPunc post-processor once (resident) when the operator
+    // passes --punc-model. The server path previously ignored it (the punctuation
+    // step lived only in the CLI layer), so non-PnC backends such as parakeet
+    // RNNT came back unpunctuated. Resolves the same aliases the CLI does; the
+    // model auto-downloads on first use.
+    std::unique_ptr<fireredpunc_context, decltype(&fireredpunc_free)> punc_ctx(nullptr, fireredpunc_free);
+    {
+        std::string punc_path = params.punc_model;
+        if (punc_path == "none" || punc_path == "off")
+            punc_path.clear();
+        else if (punc_path == "auto" || punc_path == "firered")
+            punc_path = crispasr_cache::ensure_cached_file(
+                "fireredpunc-q4_k.gguf",
+                "https://huggingface.co/cstr/fireredpunc-GGUF/resolve/main/fireredpunc-q4_k.gguf",
+                params.no_prints, "crispasr[punc]", params.cache_dir);
+        else if (punc_path == "fullstop")
+            punc_path = crispasr_cache::ensure_cached_file(
+                "fullstop-punc-q4_k.gguf",
+                "https://huggingface.co/cstr/fullstop-punc-multilang-GGUF/resolve/main/fullstop-punc-q4_k.gguf",
+                params.no_prints, "crispasr[punc]", params.cache_dir);
+        else if (punc_path == "punctuate-all")
+            punc_path = crispasr_cache::ensure_cached_file(
+                "punctuate-all-q4_k.gguf",
+                "https://huggingface.co/cstr/punctuate-all-GGUF/resolve/main/punctuate-all-q4_k.gguf",
+                params.no_prints, "crispasr[punc]", params.cache_dir);
+        if (!punc_path.empty()) {
+            punc_ctx.reset(fireredpunc_init(punc_path.c_str()));
+            if (!punc_ctx)
+                fprintf(stderr, "crispasr-server: warning: failed to load punc model '%s' — continuing without\n",
+                        punc_path.c_str());
+            else
+                fprintf(stderr, "crispasr-server: loaded punctuation model '%s'\n", punc_path.c_str());
+        }
+    }
+
     Server svr;
 
     // CORS support — opt-in via --cors-origin. Browser clients calling our
@@ -801,7 +855,7 @@ int crispasr_run_server(whisper_params& params, const std::string& host, int por
         rp.split_on_word = form_bool(req, "split_on_word", rp.split_on_word);
         rp.max_len = form_int(req, "max_len", rp.max_len);
 
-        auto result = do_transcribe(audio_file, backend.get(), model_mutex, rp, /*need_timestamps=*/true);
+        auto result = do_transcribe(audio_file, backend.get(), model_mutex, rp, /*need_timestamps=*/true, punc_ctx.get());
         if (!result.ok) {
             json_error(res, 400, result.error);
             return;
@@ -937,7 +991,7 @@ int crispasr_run_server(whisper_params& params, const std::string& host, int por
 
         const bool need_timestamps =
             response_format == "verbose_json" || response_format == "srt" || response_format == "vtt";
-        auto result = do_transcribe(audio_file, backend.get(), model_mutex, rp, need_timestamps);
+        auto result = do_transcribe(audio_file, backend.get(), model_mutex, rp, need_timestamps, punc_ctx.get());
         if (!result.ok) {
             json_error(res, 400, result.error);
             return;


### PR DESCRIPTION
## Problem

`--punc-model` is applied in CLI one-shot mode but **silently ignored under `--server`**. A server started with e.g. `--punc-model fullstop -m parakeet-rnnt-1.1b-q4_k.gguf` still returns lowercase, unpunctuated text from `/v1/audio/transcriptions` and `/inference`, because the FireRedPunc/PCS post-processing step lives in the CLI layer (`crispasr_run.cpp`) and `crispasr_server.cpp` never loads or applies it.

This matters for non-PnC backends (Parakeet RNNT/CTC, etc.) that emit no punctuation natively — there's currently no server-side way to punctuate their output.

## Repro

```bash
crispasr --server --port 8109 -m parakeet-rnnt-1.1b-q4_k.gguf --punc-model fullstop
curl -s -F language=en -F beam_size=1 -F file=@clip.wav \
  http://127.0.0.1:8109/v1/audio/transcriptions
# before: "the patient presents with chest pain and shortness of breath
#          vitals are stable will you order a chest x ray and start oxygen"
# (the same model + --punc-model fullstop via CLI one-shot punctuates correctly)
```

## Fix

Load a resident `fireredpunc_context` once at server start when `--punc-model` is set (reusing the CLI's alias resolution: `auto`/`firered`/`fullstop`/`punctuate-all`, auto-downloaded via `crispasr_cache::ensure_cached_file`), thread it into `do_transcribe`, and apply `fireredpunc_process` per segment right after the existing punctuation-strip block.

- **Opt-in** — no behavior change unless `--punc-model` is passed.
- Gated on the per-request `punctuation` flag (so `punctuation=false` still strips).
- Serialized on a private mutex since the shared punc context isn't re-entrant.
- ~57 lines, one file.

## Verified

Parakeet RNNT 1.1b q4_k, CUDA, warm `/v1/audio/transcriptions`:

- **before:** `the patient presents with chest pain and shortness of breath vitals are stable will you order a chest x ray and start oxygen`
- **after (`--punc-model fullstop`):** `The patient presents with chest pain and shortness of breath. Vitals are stable. Will you order a chest x ray and start oxygen?`

The punctuation pass adds ~100 ms; greedy (`beam_size=1`) end-to-end ~1.1 s.

## Scope / notes

This wires only the **FireRedPunc** path (`auto`/`firered`/`fullstop`/`punctuate-all`). The separate `--punc-model pcs` (XLM-R PCS) path and the CLI's `crispasr_should_auto_enable_punctuation` parity could be added the same way if you'd like — happy to extend in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
