### PR TITLE
fix(wyoming): real HA data_length framing + language/shutdown/robustness (#172)

### DIFF
--- a/examples/cli/wyoming.cpp
+++ b/examples/cli/wyoming.cpp
@@ -30,9 +30,11 @@
 #include <algorithm>
 #include <atomic>
 #include <cerrno>
+#include <chrono>
 #include <cmath>
 #include <cstdio>
 #include <cstring>
+#include <mutex>
 #include <string>
 #include <thread>
 #include <vector>
@@ -45,15 +47,18 @@ typedef SOCKET socket_t;
 #define CLOSE_SOCKET closesocket
 #define INVALID_SOCKET_VAL INVALID_SOCKET
 #define SOCKET_ERRNO WSAGetLastError()
+#define SHUTDOWN_BOTH SD_BOTH
 #else
 #include <arpa/inet.h>
 #include <netinet/in.h>
+#include <sys/select.h>
 #include <sys/socket.h>
 #include <unistd.h>
 typedef int socket_t;
 #define INVALID_SOCKET_VAL (-1)
 #define CLOSE_SOCKET close
 #define SOCKET_ERRNO errno
+#define SHUTDOWN_BOTH SHUT_RDWR
 #endif
 
 using json = nlohmann::json;
@@ -105,13 +110,38 @@ static bool wyoming_read_header(socket_t fd, std::string& type, json& data, int&
     }
     if (line.empty())
         return false;
+    int data_length = 0;
     try {
         auto j = json::parse(line);
         type = j.value("type", "");
         data = j.value("data", json::object());
         payload_length = j.value("payload_length", 0);
+        data_length = j.value("data_length", 0);
     } catch (...) {
         return false;
+    }
+    // Wyoming clients (HA's `wyoming` lib) send a non-empty `data` object as a
+    // separate length-prefixed JSON blob AFTER the header line, advertised via
+    // `data_length` — not inline. Read and merge it before the binary payload,
+    // otherwise the payload read desyncs the stream. (issue #172)
+    if (data_length > 0) {
+        if (data_length > 16 * 1024 * 1024)
+            return false; // runaway data blob
+        std::string db;
+        db.resize((size_t)data_length);
+        if (!recv_exact(fd, &db[0], (size_t)data_length))
+            return false;
+        try {
+            auto dj = json::parse(db);
+            if (data.is_object() && dj.is_object()) {
+                for (auto it = dj.begin(); it != dj.end(); ++it)
+                    data[it.key()] = it.value();
+            } else {
+                data = dj;
+            }
+        } catch (...) {
+            return false;
+        }
     }
     return !type.empty();
 }
@@ -191,6 +221,12 @@ static CrispasrBackend* g_backend = nullptr;
 static std::mutex* g_mutex = nullptr;
 static whisper_params g_params;
 
+// Open connection tracking, so wyoming_stop() can wake blocked recv() calls and
+// wait for in-flight handlers to finish before the backend is torn down. (H3)
+static std::mutex g_clients_mtx;
+static std::vector<socket_t> g_clients;
+static std::atomic<int> g_active{0};
+
 // ---------------------------------------------------------------------------
 // Per-connection handler
 // ---------------------------------------------------------------------------
@@ -202,6 +238,12 @@ static void wyoming_handle_connection(socket_t fd) {
     int audio_width = 2; // bytes per sample (int16 = 2)
     int audio_ch = 1;
     std::vector<int16_t> audio_buf; // accumulated raw int16 samples
+
+    g_active.fetch_add(1);
+    {
+        std::lock_guard<std::mutex> lk(g_clients_mtx);
+        g_clients.push_back(fd);
+    }
 
     while (g_running.load()) {
         std::string type;
@@ -228,20 +270,24 @@ static void wyoming_handle_connection(socket_t fd) {
         // ----------------------------------------------------------------
         if (type == "describe") {
             const bool has_tts = (g_backend->capabilities() & CAP_TTS) != 0;
+            // Advertise the configured language instead of a hardcoded "en", so
+            // HA routes non-English audio to this service. (C4)
+            const std::string adv_lang = g_params.language.empty() ? std::string("en") : g_params.language;
+            const json langs = json::array({adv_lang});
 
             json asr_model;
             asr_model["name"] = g_backend->name();
             asr_model["description"] = std::string("CrispASR ") + g_backend->name() + " backend";
             asr_model["attribution"] = {{"name", "CrispASR"}, {"url", "https://github.com/CrispStrobe/CrispASR"}};
             asr_model["installed"] = true;
-            asr_model["languages"] = json::array({"en"});
+            asr_model["languages"] = langs;
 
             json asr_service;
             asr_service["name"] = "crispasr";
             asr_service["description"] = "CrispASR multi-backend speech recognition";
             asr_service["attribution"] = {{"name", "CrispASR"}, {"url", "https://github.com/CrispStrobe/CrispASR"}};
             asr_service["installed"] = true;
-            asr_service["languages"] = json::array({"en"});
+            asr_service["languages"] = langs;
             asr_service["models"] = json::array({asr_model});
 
             json info_data;
@@ -253,7 +299,7 @@ static void wyoming_handle_connection(socket_t fd) {
                 voice["description"] = "";
                 voice["attribution"] = {{"name", "CrispASR"}, {"url", "https://github.com/CrispStrobe/CrispASR"}};
                 voice["installed"] = true;
-                voice["languages"] = json::array({"en-us"});
+                voice["languages"] = langs;
 
                 json tts_service;
                 tts_service["name"] = "crispasr-tts";
@@ -299,6 +345,27 @@ static void wyoming_handle_connection(socket_t fd) {
                         audio_buf.push_back((int16_t)(((int)src[i * 2] + (int)src[i * 2 + 1]) / 2));
                 } else {
                     audio_buf.insert(audio_buf.end(), src, src + n_int16);
+                }
+            } else if (payload_length > 0 && audio_width == 4) {
+                // float32 LE PCM (some Wyoming clients) → mono int16 (H1)
+                int n_f32 = payload_length / 4;
+                const float* src = (const float*)payload.data();
+                int ch = std::max(audio_ch, 1);
+                int frames = n_f32 / ch;
+                for (int i = 0; i < frames; i++) {
+                    float acc = 0.0f;
+                    for (int c = 0; c < ch; c++)
+                        acc += src[i * ch + c];
+                    acc /= (float)ch;
+                    if (acc > 1.0f) acc = 1.0f;
+                    if (acc < -1.0f) acc = -1.0f;
+                    audio_buf.push_back((int16_t)(acc * 32767.0f));
+                }
+            } else if (payload_length > 0) {
+                static bool warned = false;
+                if (!warned) {
+                    fprintf(stderr, "wyoming: unsupported audio width=%d (expect 2 or 4) — dropping\n", audio_width);
+                    warned = true;
                 }
             }
 
@@ -402,7 +469,12 @@ static void wyoming_handle_connection(socket_t fd) {
         // Unknown message types are silently ignored (protocol allows this).
     }
 
+    {
+        std::lock_guard<std::mutex> lk(g_clients_mtx);
+        g_clients.erase(std::remove(g_clients.begin(), g_clients.end(), fd), g_clients.end());
+    }
     CLOSE_SOCKET(fd);
+    g_active.fetch_sub(1);
 }
 
 // ---------------------------------------------------------------------------
@@ -411,6 +483,18 @@ static void wyoming_handle_connection(socket_t fd) {
 
 static void wyoming_listener() {
     while (g_running.load()) {
+        // select() with a timeout so the loop re-checks g_running and exits
+        // promptly on shutdown — closesocket() alone does not reliably unblock
+        // a blocking accept() on Windows. (C2)
+        fd_set rfds;
+        FD_ZERO(&rfds);
+        FD_SET(g_listen_fd, &rfds);
+        struct timeval tv;
+        tv.tv_sec = 1;
+        tv.tv_usec = 0;
+        int sel = select((int)g_listen_fd + 1, &rfds, nullptr, nullptr, &tv);
+        if (sel <= 0)
+            continue; // timeout or interrupted → re-check g_running
         struct sockaddr_in addr;
         socklen_t addr_len = sizeof(addr);
         socket_t client = accept(g_listen_fd, (struct sockaddr*)&addr, &addr_len);
@@ -433,7 +517,10 @@ int wyoming_start(CrispasrBackend* backend, std::mutex& model_mutex, const whisp
 
 #ifdef _WIN32
     WSADATA wsa;
-    WSAStartup(MAKEWORD(2, 2), &wsa);
+    if (WSAStartup(MAKEWORD(2, 2), &wsa) != 0) {
+        fprintf(stderr, "wyoming: WSAStartup failed\n");
+        return -1;
+    }
 #endif
 
     g_backend = backend;
@@ -477,10 +564,28 @@ void wyoming_stop() {
     if (!g_running.load())
         return;
     g_running.store(false);
+
+    // Wake any connection threads blocked in recv() so they exit instead of
+    // touching the backend after teardown. (H3)
+    {
+        std::lock_guard<std::mutex> lk(g_clients_mtx);
+        for (socket_t cfd : g_clients)
+            shutdown(cfd, SHUTDOWN_BOTH);
+    }
+
+    if (g_listener_thread.joinable())
+        g_listener_thread.join(); // select() loop exits within ~1s (C2)
+
     if (g_listen_fd != INVALID_SOCKET_VAL) {
         CLOSE_SOCKET(g_listen_fd);
         g_listen_fd = INVALID_SOCKET_VAL;
     }
-    if (g_listener_thread.joinable())
-        g_listener_thread.join();
+
+    // Bounded wait for in-flight (detached) handlers to drain. (H3)
+    for (int i = 0; i < 100 && g_active.load() > 0; i++)
+        std::this_thread::sleep_for(std::chrono::milliseconds(20));
+
+#ifdef _WIN32
+    WSACleanup(); // (M1)
+#endif
 }

--- a/tests/test-server-wyoming.py
+++ b/tests/test-server-wyoming.py
@@ -31,7 +31,8 @@ ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 # ---------------------------------------------------------------------------
 
 def find_binary():
-    for rel in ["build/bin/crispasr", "build-ninja-compile/bin/crispasr", "bin/crispasr"]:
+    for rel in ["build/bin/crispasr", "build/bin/Release/crispasr.exe",
+                "build-ninja-compile/bin/crispasr", "bin/crispasr", "bin/crispasr.exe"]:
         p = os.path.join(ROOT, rel)
         if os.path.isfile(p) and os.access(p, os.X_OK):
             return p
@@ -60,12 +61,21 @@ def load_pcm_s16(path):
 
 
 def wyoming_send(sock, msg_type, data, payload=b""):
-    hdr = json.dumps({
-        "type": msg_type,
-        "data": data,
-        "payload_length": len(payload),
-    }) + "\n"
-    sock.sendall(hdr.encode())
+    # Frame exactly like Home Assistant's official `wyoming` library: non-empty
+    # `data` is sent as a SEPARATE length-prefixed JSON blob (data_length) after
+    # the header line — NOT inline. Sending it inline (as the old test did) hides
+    # the data_length parsing path and let issue #172's transcribe desync slip
+    # through. (regression guard)
+    hdr = {"type": msg_type}
+    data_bytes = b""
+    if data:
+        data_bytes = json.dumps(data, ensure_ascii=False).encode("utf-8")
+        hdr["data_length"] = len(data_bytes)
+    if payload:
+        hdr["payload_length"] = len(payload)
+    sock.sendall((json.dumps(hdr) + "\n").encode())
+    if data_bytes:
+        sock.sendall(data_bytes)
     if payload:
         sock.sendall(payload)
 


### PR DESCRIPTION
Fixes for the new Wyoming server (#172) and follow-ups, **tested end-to-end on Windows + RTX 3060 Ti (CUDA 13.2)** against Home Assistant's official `wyoming` 1.9.0 client. Happy to split this up if you prefer.

## The critical one (C1): transcribe path was dead

HA's official `wyoming` lib (`write_event`) sends a **non-empty `data` object as a separate length-prefixed JSON blob** after the header line (advertised via `data_length`), **not inline**:

```
{"type":"audio-chunk","data_length":M,"payload_length":N,"version":...}\n
<M bytes data JSON>
<N bytes PCM payload>
```

`wyoming_read_header` only read `payload_length` and ignored `data_length`, so for any event carrying `data` (transcribe / audio-start / audio-chunk / synthesize) the server read the data-JSON region as if it were the payload, desynced the stream, failed to parse the next header, and closed the connection. `describe` has empty `data`, so it worked — which is exactly why this slipped through.

**Why the existing test didn't catch it:** `tests/test-server-wyoming.py`'s `wyoming_send` sent `data` *inline* with `payload_length`, mirroring the server's (incorrect) expectation. I changed the test to frame `data` via `data_length` like the real lib — it now fails on the old code and passes on the fix.

## What's in here

| Fix | What |
|---|---|
| **C1** | `wyoming_read_header` reads `data_length`, reads + merges the separate data blob before the payload. Inline `data` still accepted. |
| **C4** | `describe->info` advertises the configured `--language` (asr service/model + voice) instead of hardcoded `"en"`. |
| **C2** | `select()` with a 1s timeout in the accept loop so the listener exits on shutdown (`closesocket()` doesn't unblock a blocking `accept()` on Windows -> `wyoming_stop()` could hang on `join()`). |
| **H3** | Track open client sockets; `wyoming_stop()` `shutdown()`s them to unblock `recv()` and bounded-waits for in-flight detached handlers — avoids backend use-after-free at teardown. |
| **H1** | Accept `width=4` (float32) `audio-chunk` payloads; warn-once + drop other widths instead of silently ignoring. |
| **M1** | Check `WSAStartup()` return; add `WSACleanup()`. |
| test | Faithful `data_length` framing + find Windows `build/bin/Release/crispasr.exe`. |

## Verification (Windows, CUDA, whisper ggml-tiny)

Against the official `wyoming` 1.9.0 client:
- `describe -> info` parsed; `transcribe + audio-start + 172 audio-chunk + audio-stop -> transcript` returns `"And so my fellow Americans ..."` — **no reset**.
- With `--language ru`, `info` advertises `languages: ["ru"]`.

Corrected `tests/test-server-wyoming.py` (now uses real framing): **5/5 pass** (describe/info, info structure, ASR round-trip, mid-stream-disconnect resilience, unknown-event resilience).

## Notes / not changed

- **H4** (model_mutex held for the whole `synthesize`): left as-is — it matches the HTTP server's serialization model; flagging rather than changing locking.
- **C3** (speaker `done_event` between plays): **verified NOT a bug** — miniaudio's `ma_event` is auto-reset on both win32 and posix, so repeated `play()`/`wait()` is correct.
- I left the outgoing server messages sending `data` inline (the official client reads inline `data` fine when `data_length` is absent); only the read path needed the `data_length` handling.
