### PR TITLE
feat(qwen3-tts): true streaming synthesis (per-chunk PCM) — ~7x faster first audio

### DIFF
--- a/examples/cli/crispasr_backend.h
+++ b/examples/cli/crispasr_backend.h
@@ -154,6 +154,21 @@ public:
         return {};
     }
 
+    // Streaming TTS callback: invoked once per generated PCM chunk as the
+    // backend produces audio, with the last chunk flagged is_final=true.
+    // `pcm` is mono float32 at `tts_sample_rate()`.
+    using crispasr_pcm_stream_callback = std::function<void(const float* pcm, int n_samples, bool is_final)>;
+
+    // Synthesize with streaming output. Default implementation falls back to
+    // the whole-clip synthesize() and emits it as a single final chunk.
+    // Backends with CAP_STREAMING override to emit incrementally.
+    virtual void synthesize_streaming(const std::string& text, const whisper_params& p,
+                                      crispasr_pcm_stream_callback cb) {
+        auto v = synthesize(text, p);
+        if (!v.empty())
+            cb(v.data(), (int)v.size(), true);
+    }
+
     // Sample rate of `synthesize()` output PCM. Defaults to 24 kHz since most
     // TTS backends (kokoro, qwen3-tts, vibevoice, chatterbox, orpheus, indextts)
     // produce 24 kHz. Backends that emit a different rate (e.g. voxcpm2-tts at

--- a/examples/cli/crispasr_backend_qwen3_tts.cpp
+++ b/examples/cli/crispasr_backend_qwen3_tts.cpp
@@ -90,7 +90,7 @@ public:
     const char* name() const override { return "qwen3-tts"; }
 
     uint32_t capabilities() const override {
-        uint32_t caps = CAP_TTS | CAP_AUTO_DOWNLOAD | CAP_TEMPERATURE | CAP_FLASH_ATTN;
+        uint32_t caps = CAP_TTS | CAP_AUTO_DOWNLOAD | CAP_TEMPERATURE | CAP_FLASH_ATTN | CAP_STREAMING;
         if (is_base_)
             caps |= CAP_VOICE_CLONING;
         return caps;
@@ -147,9 +147,13 @@ public:
         return true;
     }
 
-    std::vector<float> synthesize(const std::string& text, const whisper_params& params) override {
+    // Shared voice/customvoice/voicedesign setup for both synthesize() and
+    // synthesize_streaming(). Configures temperature, seed, language, and the
+    // active voice identity (re-loading only when the identity changes via
+    // last_voice_key_). Returns true when the context is ready to generate.
+    bool prepare_synthesis(const std::string& text, const whisper_params& params) {
         if (!ctx_ || text.empty())
-            return {};
+            return false;
         qwen3_tts_set_temperature(ctx_, params.temperature);
         qwen3_tts_set_seed(ctx_, params.seed);
 
@@ -195,7 +199,7 @@ public:
                 if (v.find("..") != std::string::npos || v.find('\0') != std::string::npos) {
                     fprintf(stderr, "crispasr[qwen3-tts]: voice name '%s' contains illegal characters (.. or NUL)\n",
                             v.c_str());
-                    return {};
+                    return false;
                 }
                 const std::string wav_path = params.tts_voice_dir + "/" + v + ".wav";
                 const std::string gguf_path = params.tts_voice_dir + "/" + v + ".gguf";
@@ -241,10 +245,10 @@ public:
                 }
                 if (params.tts_instruct.empty()) {
                     fprintf(stderr, "crispasr[qwen3-tts]: VoiceDesign requires --instruct \"<voice description>\"\n");
-                    return {};
+                    return false;
                 }
                 if (qwen3_tts_set_instruct(ctx_, params.tts_instruct.c_str()) != 0) {
-                    return {};
+                    return false;
                 }
                 if (!params.no_prints) {
                     fprintf(stderr, "crispasr[qwen3-tts]: VoiceDesign instruct = \"%s\"\n",
@@ -265,12 +269,12 @@ public:
                     if (!first) {
                         fprintf(stderr,
                                 "crispasr[qwen3-tts]: CustomVoice model has no speakers in the GGUF metadata\n");
-                        return {};
+                        return false;
                     }
                     spk_name = first;
                 }
                 if (qwen3_tts_set_speaker_by_name(ctx_, spk_name.c_str()) != 0) {
-                    return {};
+                    return false;
                 }
                 if (!params.no_prints) {
                     fprintf(stderr, "crispasr[qwen3-tts]: CustomVoice speaker = '%s' (available: ", spk_name.c_str());
@@ -293,16 +297,16 @@ public:
                     if (resolved_ref_text.empty()) {
                         fprintf(stderr, "crispasr[qwen3-tts]: --voice is a WAV but --ref-text was not set. "
                                         "Provide the reference transcription so the talker can match it.\n");
-                        return {};
+                        return false;
                     }
                     if (qwen3_tts_set_voice_prompt_with_text(ctx_, v.c_str(), resolved_ref_text.c_str()) != 0) {
                         fprintf(stderr, "crispasr[qwen3-tts]: failed to set voice prompt from '%s'\n", v.c_str());
-                        return {};
+                        return false;
                     }
                 } else {
                     if (qwen3_tts_load_voice_pack(ctx_, v.c_str()) != 0) {
                         fprintf(stderr, "crispasr[qwen3-tts]: failed to load voice pack '%s'\n", v.c_str());
-                        return {};
+                        return false;
                     }
                 }
             } else {
@@ -314,7 +318,7 @@ public:
                                 def.c_str());
                     if (qwen3_tts_load_voice_pack(ctx_, def.c_str()) != 0) {
                         fprintf(stderr, "crispasr[qwen3-tts]: failed to load default voice '%s'\n", def.c_str());
-                        return {};
+                        return false;
                     }
                     // Encode the resolved path into the key so the next call with
                     // an explicit --voice still triggers a reload.
@@ -327,11 +331,17 @@ public:
                             "  --backend qwen3-tts-customvoice    — use built-in fixed speakers (no --voice needed)\n"
                             "A default voice pack (qwen3-tts-voice-default.gguf) can be auto-downloaded "
                             "with: crispasr --model auto --backend qwen3-tts\n");
-                    return {};
+                    return false;
                 }
             }
             last_voice_key_ = voice_key;
         }
+        return true;
+    }
+
+    std::vector<float> synthesize(const std::string& text, const whisper_params& params) override {
+        if (!prepare_synthesis(text, params))
+            return {};
 
         int n = 0;
         float* pcm = qwen3_tts_synthesize(ctx_, text.c_str(), &n);
@@ -340,6 +350,36 @@ public:
         std::vector<float> out(pcm, pcm + n);
         qwen3_tts_pcm_free(pcm);
         return out;
+    }
+
+    void synthesize_streaming(const std::string& text, const whisper_params& params,
+                              crispasr_pcm_stream_callback cb) override {
+        if (!prepare_synthesis(text, params))
+            return;
+
+        // Trampoline: forward the C callback to the std::function. is_final
+        // chunks may arrive with n_samples==0 (empty end-of-stream marker);
+        // skip pushing audio but still propagate the final flag.
+        auto trampoline = [](const float* pcm, int n_samples, int is_final, void* user_data) {
+            auto* fn = static_cast<crispasr_pcm_stream_callback*>(user_data);
+            if (n_samples > 0 || is_final) {
+                (*fn)(pcm, n_samples, is_final != 0);
+            }
+        };
+        int n = 0;
+        // chunk_frames=8: the first chunk fires after only 8 AR-generated
+        // frames, so time-to-first-audio (~1s) is gated by 8 talker steps, not
+        // the whole clip. overlap_frames=96 > the codec sliding-window (72)
+        // plus the causal upsample-conv receptive field, so each window's
+        // emitted tail matches the whole-clip decode (no audible seam; max
+        // |diff| ~430/32767 vs whole decode). The cost is re-decoding 96 left-
+        // context frames per 8-frame window; codec decode is cheap relative to
+        // the AR loop so end-to-end overhead stays modest. Override via the
+        // (chunk_frames, overlap_frames) args for a different latency/quality
+        // balance.
+        float* full = qwen3_tts_synthesize_streaming(ctx_, text.c_str(), 8, 96, trampoline, &cb, &n);
+        // The full buffer was already delivered via the callback chunks; free it.
+        qwen3_tts_pcm_free(full);
     }
 
     void shutdown() override {

--- a/examples/cli/crispasr_server.cpp
+++ b/examples/cli/crispasr_server.cpp
@@ -61,10 +61,13 @@
 #include <cstdlib>
 #include <cstring>
 #include <filesystem>
+#include <condition_variable>
+#include <deque>
 #include <fstream>
 #include <memory>
 #include <mutex>
 #include <sstream>
+#include <thread>
 #include <string>
 #include <vector>
 
@@ -1632,71 +1635,116 @@ int crispasr_run_server(whisper_params& params, const std::string& host, int por
             const int silence_n = sr_out / 5;
             std::vector<short> silence_s16(silence_n, 0);
 
-            // Shared state between the main thread (which synthesizes under
-            // model_mutex) and the chunked provider callback. We synthesize
-            // all chunks first into a queue, then the provider drains it.
-            // (httplib's provider callback runs synchronously in the same
-            // thread, but this structure is clearer.)
-            std::vector<std::string> pcm_chunks;
-            {
-                std::lock_guard<std::mutex> lock(model_mutex);
-                // Prepend disclaimer as first chunk for voice-clone streams
-                if (is_voice_clone) {
-                    const auto& disc = crispasr_tts_get_disclaimer(backend.get(), rp);
-                    if (!disc.empty()) {
-                        pcm_chunks.push_back(crispasr_make_pcm_int16_le(disc.data(), (int)disc.size()));
-                        pcm_chunks.push_back(
-                            std::string((const char*)silence_s16.data(), silence_s16.size() * sizeof(short)));
+            // Producer/consumer streaming: a worker thread synthesizes under
+            // model_mutex and pushes int16 LE PCM chunks into a bounded queue;
+            // the chunked-content-provider (which httplib runs on the request
+            // thread) blocks on a condition variable and writes each chunk as
+            // it arrives. This lets the first chunk reach the client as soon
+            // as the backend emits it — for CAP_STREAMING backends that is
+            // after the first ~chunk_frames codec frames, not after the whole
+            // clip — so time-to-first-audio drops to roughly one chunk.
+            struct StreamQueue {
+                std::mutex m;
+                std::condition_variable cv;
+                std::deque<std::string> q;
+                bool done = false;
+                bool failed = false;
+            };
+            auto sq = std::make_shared<StreamQueue>();
+
+            const bool true_streaming = (backend->capabilities() & CAP_STREAMING) != 0;
+
+            // Post-process one float PCM buffer (speed resample + watermark) and
+            // enqueue it as int16 LE. Runs on the worker thread.
+            auto push_pcm = [&, sq, sr_out, speed](const float* pcm, int n_samples) {
+                if (!pcm || n_samples <= 0)
+                    return;
+                std::vector<float> chunk(pcm, pcm + n_samples);
+                if (speed != 1.0f) {
+                    const int in_n = (int)chunk.size();
+                    const int out_n = std::max(1, (int)((float)in_n / speed));
+                    std::vector<float> rs((size_t)out_n);
+                    for (int j = 0; j < out_n; j++) {
+                        const float s = (float)j * speed;
+                        const int s0 = (int)s;
+                        const int s1 = std::min(s0 + 1, in_n - 1);
+                        const float frac = s - (float)s0;
+                        rs[j] = chunk[s0] * (1.0f - frac) + chunk[s1] * frac;
                     }
+                    chunk = std::move(rs);
                 }
-                for (size_t i = 0; i < sentences.size(); i++) {
-                    std::vector<float> chunk = backend->synthesize(sentences[i], rp);
-                    if (chunk.empty())
-                        continue;
-                    // Apply speed resampling per chunk
-                    if (speed != 1.0f) {
-                        const int in_n = (int)chunk.size();
-                        const int out_n = std::max(1, (int)((float)in_n / speed));
-                        std::vector<float> rs((size_t)out_n);
-                        for (int j = 0; j < out_n; j++) {
-                            const float s = (float)j * speed;
-                            const int s0 = (int)s;
-                            const int s1 = std::min(s0 + 1, in_n - 1);
-                            const float frac = s - (float)s0;
-                            rs[j] = chunk[s0] * (1.0f - frac) + chunk[s1] * frac;
+                crispasr_wm_dispatch::embed(chunk.data(), (int)chunk.size(), sr_out);
+                std::string enc = crispasr_make_pcm_int16_le(chunk.data(), (int)chunk.size());
+                {
+                    std::lock_guard<std::mutex> lk(sq->m);
+                    sq->q.push_back(std::move(enc));
+                }
+                sq->cv.notify_one();
+            };
+
+            // Worker thread: synthesize all sentences, enqueueing chunks as
+            // they are produced. Captures by value the bits it needs so it
+            // outlives the handler scope (the provider keeps `sq` alive).
+            std::thread worker([&backend, &model_mutex, sentences, rp, is_voice_clone, silence_s16, true_streaming,
+                                push_pcm, sq, t0]() {
+                {
+                    std::lock_guard<std::mutex> lock(model_mutex);
+                    if (is_voice_clone) {
+                        const auto& disc = crispasr_tts_get_disclaimer(backend.get(), rp);
+                        if (!disc.empty()) {
+                            push_pcm(disc.data(), (int)disc.size());
+                            std::string sil((const char*)silence_s16.data(), silence_s16.size() * sizeof(short));
+                            {
+                                std::lock_guard<std::mutex> lk(sq->m);
+                                sq->q.push_back(std::move(sil));
+                            }
+                            sq->cv.notify_one();
                         }
-                        chunk = std::move(rs);
                     }
-                    // Embed watermark per-chunk (survives re-encoding)
-                    crispasr_wm_dispatch::embed(chunk.data(), (int)chunk.size(), sr_out);
-                    pcm_chunks.push_back(crispasr_make_pcm_int16_le(chunk.data(), (int)chunk.size()));
-                    // Add silence gap between sentences (not after last)
-                    if (i + 1 < sentences.size()) {
-                        pcm_chunks.push_back(
-                            std::string((const char*)silence_s16.data(), silence_s16.size() * sizeof(short)));
+                    for (size_t i = 0; i < sentences.size(); i++) {
+                        if (true_streaming) {
+                            backend->synthesize_streaming(
+                                sentences[i], rp,
+                                [&](const float* pcm, int n_samples, bool /*is_final*/) { push_pcm(pcm, n_samples); });
+                        } else {
+                            std::vector<float> chunk = backend->synthesize(sentences[i], rp);
+                            if (!chunk.empty())
+                                push_pcm(chunk.data(), (int)chunk.size());
+                        }
+                        if (i + 1 < sentences.size()) {
+                            std::string sil((const char*)silence_s16.data(), silence_s16.size() * sizeof(short));
+                            {
+                                std::lock_guard<std::mutex> lk(sq->m);
+                                sq->q.push_back(std::move(sil));
+                            }
+                            sq->cv.notify_one();
+                        }
                     }
                 }
-            }
-            auto t1_s = std::chrono::steady_clock::now();
-            const double el = std::chrono::duration<double>(t1_s - t0).count();
-            fprintf(stderr, "crispasr-server: streaming %zu PCM chunks in %.2fs\n", pcm_chunks.size(), el);
-
-            if (pcm_chunks.empty()) {
-                json_error(res, 500, "synthesis failed (backend returned empty audio)", "synthesis_failed");
-                return;
-            }
-
-            size_t chunk_idx = 0;
-            res.set_chunked_content_provider("audio/pcm", [pcm_chunks = std::move(pcm_chunks), chunk_idx](
-                                                              size_t /*offset*/, httplib::DataSink& sink) mutable {
-                if (chunk_idx >= pcm_chunks.size()) {
-                    sink.done();
-                    return true;
+                {
+                    std::lock_guard<std::mutex> lk(sq->m);
+                    sq->done = true;
                 }
-                const auto& c = pcm_chunks[chunk_idx++];
-                sink.write(c.data(), c.size());
-                return true;
+                sq->cv.notify_one();
+                const double el = std::chrono::duration<double>(std::chrono::steady_clock::now() - t0).count();
+                fprintf(stderr, "crispasr-server: streaming synthesis finished in %.2fs\n", el);
             });
+            worker.detach();
+
+            res.set_chunked_content_provider(
+                "audio/pcm", [sq](size_t /*offset*/, httplib::DataSink& sink) -> bool {
+                    std::unique_lock<std::mutex> lk(sq->m);
+                    sq->cv.wait(lk, [&] { return !sq->q.empty() || sq->done; });
+                    if (sq->q.empty() && sq->done) {
+                        lk.unlock();
+                        sink.done();
+                        return true;
+                    }
+                    std::string c = std::move(sq->q.front());
+                    sq->q.pop_front();
+                    lk.unlock();
+                    return sink.write(c.data(), c.size());
+                });
             return;
         }
 

--- a/src/qwen3_tts.cpp
+++ b/src/qwen3_tts.cpp
@@ -6442,6 +6442,371 @@ extern "C" float* qwen3_tts_synthesize(struct qwen3_tts_context* ctx, const char
     return pcm;
 }
 
+// ---------------------------------------------------------------------------
+// Streaming synthesis. Mirrors qwen3_tts_synthesize_codes' AR loop verbatim
+// (same prefill, same per-frame talker + code_pred steps, same KV / past_hidden
+// flow), but decodes and emits PCM in windows as codes are produced instead of
+// returning the full clip only at the end. KV state is never reset between
+// chunks — only the codec decode is windowed.
+//
+// Windowing: the codec is a strictly-causal forward pass (sliding-window
+// attention, window=72; causal convs, left-pad only). codec_decode_codes(W)
+// where W = [left-context frames] + [new frames] reproduces the new frames'
+// PCM bit-for-bit (no right context needed); we discard the left-context
+// PCM as a pre-roll. See the equivalence note in qwen3_tts_synthesize.
+extern "C" float* qwen3_tts_synthesize_streaming(struct qwen3_tts_context* ctx, const char* text, int chunk_frames,
+                                                 int overlap_frames, qwen3_tts_pcm_callback cb, void* user_data,
+                                                 int* out_n_samples) {
+    if (out_n_samples) {
+        *out_n_samples = 0;
+    }
+    if (!ctx || !text) {
+        return nullptr;
+    }
+    if (!ctx->codec.loaded) {
+        fprintf(stderr,
+                "qwen3_tts: synthesize_streaming() requires the codec — call qwen3_tts_set_codec_path() first.\n");
+        return nullptr;
+    }
+    if (ctx->vocab.id_to_token.empty()) {
+        fprintf(stderr, "qwen3_tts: vocab empty — re-convert with the updated converter\n");
+        return nullptr;
+    }
+    if (chunk_frames <= 0) {
+        chunk_frames = 8;
+    }
+    if (overlap_frames < 0) {
+        // 96 > codec sliding-window (72) + causal upsample-conv receptive
+        // field, so the emitted window tail matches a whole-clip decode.
+        overlap_frames = 96;
+    }
+
+    const bool is_custom_voice = (ctx->hp.tts_model_type == "custom_voice");
+    const bool is_voice_design = (ctx->hp.tts_model_type == "voice_design");
+    if (is_custom_voice) {
+        if ((int)ctx->runtime_spk_emb.size() != (int)ctx->hp.d_model) {
+            fprintf(stderr, "qwen3_tts: no speaker — call qwen3_tts_set_speaker_by_name\n");
+            return nullptr;
+        }
+    } else if (is_voice_design) {
+        if (ctx->runtime_instruct.empty()) {
+            fprintf(stderr, "qwen3_tts: VoiceDesign needs a voice description — call qwen3_tts_set_instruct\n");
+            return nullptr;
+        }
+    } else {
+        if (ctx->vp_active < 0 && ctx->runtime_ref_codes.empty() &&
+            !(ctx->xvec_only && (int)ctx->runtime_spk_emb.size() == (int)ctx->hp.d_model)) {
+            fprintf(stderr, "qwen3_tts: no voice — call qwen3_tts_load_voice_pack or qwen3_tts_set_voice_prompt\n");
+            return nullptr;
+        }
+    }
+
+    const bool bench = env_bool("QWEN3_TTS_BENCH");
+    const bool dbg = env_bool("QWEN3_TTS_DEBUG");
+    const char* dump_dir = env_str("QWEN3_TTS_DUMP_DIR");
+    const auto& hp = ctx->hp;
+    const int d = (int)hp.d_model;
+    const int n_groups = (int)hp.n_code_groups; // 16
+    const int n_q = (int)ctx->codec.hp.n_q;
+    int max_frames = ctx->params.max_codec_steps > 0 ? ctx->params.max_codec_steps : 1500;
+    if (const char* mf = getenv("QWEN3_TTS_MAX_FRAMES")) {
+        const int v = std::atoi(mf);
+        if (v > 0)
+            max_frames = v;
+    }
+    const int eos = (int)hp.codec_eos_id;
+
+    uint64_t rng = 42;
+    if (const char* s = env_str("QWEN3_TTS_SEED")) {
+        rng = (uint64_t)std::strtoull(s, nullptr, 10);
+    }
+    if (ctx->params.seed != 0)
+        rng = ctx->params.seed;
+
+    // ---- prefill builder: identical to qwen3_tts_synthesize_codes ----
+    double t0 = bench ? now_ms() : 0.0;
+    std::vector<float> prefill, trailing;
+    int T_pre = 0, M_trail = 0;
+    if (is_custom_voice) {
+        if (!build_customvoice_prefill_embeds(ctx, text, prefill, T_pre, trailing, M_trail)) {
+            return nullptr;
+        }
+    } else if (is_voice_design) {
+        if (!build_voicedesign_prefill_embeds(ctx, ctx->runtime_instruct, text, prefill, T_pre, trailing, M_trail)) {
+            return nullptr;
+        }
+    } else {
+        std::string ref_text;
+        if (!ctx->runtime_ref_text.empty()) {
+            ref_text = ctx->runtime_ref_text;
+        } else if (ctx->vp_active >= 0) {
+            ref_text = ctx->vp_ref_texts[ctx->vp_active];
+        }
+        if (ref_text.empty()) {
+            if (ctx->xvec_only) {
+                ref_text = ".";
+            } else {
+                fprintf(stderr,
+                        "qwen3_tts: no ref_text — call qwen3_tts_set_voice_prompt with ref_text or load a voice pack\n");
+                return nullptr;
+            }
+        }
+        if (!build_icl_prefill_embeds(ctx, text, ref_text, prefill, T_pre, trailing, M_trail)) {
+            return nullptr;
+        }
+    }
+    if (bench) {
+        const char* label = is_custom_voice ? "customvoice" : (is_voice_design ? "voicedesign" : "icl");
+        fprintf(stderr, "qwen3_tts: [stream] prefill %7.1f ms (T=%d, %s)\n", now_ms() - t0, T_pre, label);
+    }
+
+    // ---- talker prefill: get logits + hidden_last ----
+    double t1 = bench ? now_ms() : 0.0;
+    float* past_hidden = nullptr;
+    float* logits = run_talker_kv(ctx, prefill.data(), T_pre, /*n_past=*/0, &past_hidden);
+    if (!logits || !past_hidden) {
+        free(logits);
+        free(past_hidden);
+        return nullptr;
+    }
+    if (bench) {
+        fprintf(stderr, "qwen3_tts: [stream] talker_pre %7.1f ms\n", now_ms() - t1);
+    }
+
+    int n_past = T_pre;
+    const bool embd_cache_enabled = !env_bool("QWEN3_TTS_NO_EMBD_CACHE");
+
+    if (!cp_kv_alloc(ctx)) {
+        fprintf(stderr, "qwen3_tts: cp_kv allocation failed\n");
+        free(logits);
+        free(past_hidden);
+        return nullptr;
+    }
+
+    std::vector<int32_t> all_codes; // flattened (T_frames, 16)
+    all_codes.reserve((size_t)max_frames * n_groups);
+
+    // Streaming output state.
+    std::vector<float> full_pcm;      // concatenated emitted PCM (return value)
+    int frames_emitted = 0;           // frames whose PCM has already been pushed
+    const int frame_samples = 1920;   // 24 kHz / 12.5 Hz codec rate
+    full_pcm.reserve((size_t)max_frames * frame_samples);
+
+    // Decode the window [emit_lo .. n_frames) and emit the tail (frames
+    // [frames_emitted .. n_frames)), discarding the left-context pre-roll.
+    // Fires cb() with the emitted samples. Returns false on decode failure.
+    auto emit_window = [&](int n_frames, bool is_final) -> bool {
+        if (n_frames <= frames_emitted) {
+            if (is_final && cb) {
+                cb(nullptr, 0, 1, user_data); // signal end with empty final chunk
+            }
+            return true;
+        }
+        const int emit_lo = std::max(0, frames_emitted - overlap_frames);
+        const int pre_roll_frames = frames_emitted - emit_lo; // left context to discard
+        const int W = n_frames - emit_lo;
+        const int32_t* window_codes = all_codes.data() + (size_t)emit_lo * n_q;
+
+        int n_pcm = 0;
+        float* pcm = codec_decode_codes(ctx, window_codes, W, &n_pcm);
+        if (!pcm || n_pcm <= 0) {
+            free(pcm);
+            return false;
+        }
+        // Discard the pre-roll PCM (the left-context frames). The codec is
+        // strictly causal so the remaining samples equal the full-clip
+        // decode of frames [frames_emitted .. n_frames).
+        const int discard = std::min(n_pcm, pre_roll_frames * frame_samples);
+        const int n_emit = n_pcm - discard;
+        if (n_emit > 0) {
+            const float* emitted = pcm + discard;
+            full_pcm.insert(full_pcm.end(), emitted, emitted + n_emit);
+            if (cb) {
+                cb(emitted, n_emit, is_final ? 1 : 0, user_data);
+            }
+        } else if (is_final && cb) {
+            cb(nullptr, 0, 1, user_data);
+        }
+        free(pcm);
+        frames_emitted = n_frames;
+        return true;
+    };
+
+    double t_loop = bench ? now_ms() : 0.0;
+    double t_codec = 0.0;
+    bool first_chunk_logged = false;
+    int frame = 0;
+    bool emit_failed = false;
+    const int talker_top_k = 50;
+    const float talker_temp = 0.9f;
+    const float talker_repetition_penalty = 1.05f;
+    const int min_new_frames = 2;
+    const int suppress_lo = (int)hp.vocab_size - 1024;
+    std::vector<int32_t> talker_history;
+    talker_history.reserve((size_t)max_frames);
+    std::vector<float> last_id_hidden_buf(d);
+    std::vector<float> next_emb_row_buf(d);
+    std::vector<float> next_emb(d, 0.0f);
+    for (frame = 0; frame < max_frames; frame++) {
+        apply_repetition_penalty(logits, (int)hp.vocab_size, talker_history, talker_repetition_penalty);
+        for (int i = suppress_lo; i < (int)hp.vocab_size; i++) {
+            if (i != eos) {
+                logits[i] = -INFINITY;
+            }
+        }
+        if (frame < min_new_frames) {
+            logits[eos] = -INFINITY;
+        }
+        int cb0 = top_k_sample(logits, (int)hp.vocab_size, talker_top_k, talker_temp, &rng);
+        free(logits);
+        logits = nullptr;
+        if (cb0 == eos) {
+            if (dbg) {
+                fprintf(stderr, "qwen3_tts: [stream] codec_eos at frame %d\n", frame);
+            }
+            free(past_hidden);
+            past_hidden = nullptr;
+            break;
+        }
+        talker_history.push_back(cb0);
+        if (embd_cache_enabled && ctx->token_embd_cache) {
+            if (!ctx->token_embd_cache.get_row_into(cb0, last_id_hidden_buf.data())) {
+                free(past_hidden);
+                return nullptr;
+            }
+        } else {
+            float* tmp = lookup_rows(ctx, ctx->talker.token_embd_w, &cb0, 1);
+            if (!tmp) {
+                free(past_hidden);
+                return nullptr;
+            }
+            std::memcpy(last_id_hidden_buf.data(), tmp, (size_t)d * sizeof(float));
+            free(tmp);
+        }
+        int32_t cb1_15[15];
+        if (!code_pred_generate_15(ctx, past_hidden, last_id_hidden_buf.data(), cb1_15, &rng, frame)) {
+            free(past_hidden);
+            return nullptr;
+        }
+        free(past_hidden);
+        past_hidden = nullptr;
+
+        all_codes.push_back(cb0);
+        for (int i = 0; i < 15; i++) {
+            all_codes.push_back(cb1_15[i]);
+        }
+
+        std::fill(next_emb.data(), next_emb.data() + d, 0.0f);
+        {
+            for (int cb = 0; cb < n_groups; cb++) {
+                int32_t code = (cb == 0) ? cb0 : cb1_15[cb - 1];
+                bool ok = false;
+                if (embd_cache_enabled && cb == 0 && ctx->token_embd_cache) {
+                    ok = ctx->token_embd_cache.get_row_into(code, next_emb_row_buf.data());
+                } else if (embd_cache_enabled && cb > 0 && cb - 1 < (int)ctx->codec_embd_cache.size() &&
+                           ctx->codec_embd_cache[cb - 1]) {
+                    ok = ctx->codec_embd_cache[cb - 1].get_row_into(code, next_emb_row_buf.data());
+                } else {
+                    ggml_tensor* w = (cb == 0) ? ctx->talker.token_embd_w : ctx->code_pred.codec_embd[cb - 1];
+                    float* row = lookup_rows(ctx, w, &code, 1);
+                    if (row) {
+                        std::memcpy(next_emb_row_buf.data(), row, (size_t)d * sizeof(float));
+                        free(row);
+                        ok = true;
+                    }
+                }
+                if (!ok) {
+                    free(past_hidden);
+                    return nullptr;
+                }
+                for (int j = 0; j < d; j++) {
+                    next_emb[j] += next_emb_row_buf[j];
+                }
+            }
+        }
+
+        const int trail_idx = std::min(frame, M_trail - 1);
+        const float* trail = trailing.data() + (size_t)trail_idx * d;
+        for (int j = 0; j < d; j++) {
+            next_emb[j] += trail[j];
+        }
+
+        // ---- streaming emit: every chunk_frames new frames ----
+        if ((frame + 1) - frames_emitted >= chunk_frames) {
+            const double tc = bench ? now_ms() : 0.0;
+            if (!emit_window(frame + 1, /*is_final=*/false)) {
+                emit_failed = true;
+                free(past_hidden);
+                past_hidden = nullptr;
+                break;
+            }
+            if (bench) {
+                t_codec += now_ms() - tc;
+                if (!first_chunk_logged) {
+                    fprintf(stderr, "qwen3_tts: [stream] time-to-first-chunk %7.1f ms (%d frames)\n", now_ms() - t0,
+                            frame + 1);
+                    first_chunk_logged = true;
+                }
+            }
+        }
+
+        if (n_past >= ctx->kv_max_ctx - 1) {
+            fprintf(stderr, "qwen3_tts: [stream] talker kv cache full at frame %d (n_past=%d)\n", frame, n_past);
+            break;
+        }
+        logits = run_talker_kv(ctx, next_emb.data(), 1, n_past, &past_hidden);
+        if (!logits || !past_hidden) {
+            free(logits);
+            free(past_hidden);
+            return nullptr;
+        }
+        n_past += 1;
+    }
+    free(logits);
+    free(past_hidden);
+
+    if (emit_failed) {
+        return nullptr;
+    }
+
+    // Final (possibly partial) chunk: emit any frames not yet pushed.
+    const int total_frames = (int)(all_codes.size() / n_groups);
+    {
+        const double tc = bench ? now_ms() : 0.0;
+        if (!emit_window(total_frames, /*is_final=*/true)) {
+            return nullptr;
+        }
+        if (bench) {
+            t_codec += now_ms() - tc;
+        }
+    }
+
+    if (bench) {
+        fprintf(stderr, "qwen3_tts: [stream] ar_loop %7.1f ms (%d frames)  codec %7.1f ms\n", now_ms() - t_loop, frame,
+                t_codec);
+    }
+    if (ctx->params.verbosity >= 1) {
+        fprintf(stderr, "qwen3_tts: [stream] produced %d frames × 16 codebooks → %zu samples\n", total_frames,
+                full_pcm.size());
+    }
+    if (dump_dir && !all_codes.empty()) {
+        dump_i32(dump_dir, "generated_codes", all_codes.data(), all_codes.size());
+    }
+
+    if (full_pcm.empty()) {
+        return nullptr;
+    }
+    float* out = (float*)malloc(full_pcm.size() * sizeof(float));
+    if (!out) {
+        return nullptr;
+    }
+    std::memcpy(out, full_pcm.data(), full_pcm.size() * sizeof(float));
+    if (out_n_samples) {
+        *out_n_samples = (int)full_pcm.size();
+    }
+    return out;
+}
+
 extern "C" void qwen3_tts_pcm_free(float* pcm) {
     free(pcm);
 }

--- a/src/qwen3_tts.h
+++ b/src/qwen3_tts.h
@@ -271,6 +271,29 @@ float* qwen3_tts_codec_extract_stage(struct qwen3_tts_context* ctx, const int32_
 // Returns nullptr until the codec decoder lands (PLAN #52 step 3).
 float* qwen3_tts_synthesize(struct qwen3_tts_context* ctx, const char* text, int* out_n_samples);
 
+// Streaming TTS callback: invoked once per generated audio chunk as the
+// AR loop produces frames. `pcm` points at `n_samples` float32 mono
+// samples at 24 kHz (owned by the synth — copy if you need to keep it).
+// `is_final` is non-zero on the last chunk. `user_data` is passed through
+// from qwen3_tts_synthesize_streaming.
+typedef void (*qwen3_tts_pcm_callback)(const float* pcm, int n_samples, int is_final, void* user_data);
+
+// Streaming counterpart to qwen3_tts_synthesize. Emits PCM in chunks as
+// the talker AR loop generates codes, so time-to-first-audio drops from
+// the whole-clip latency to roughly one chunk. `cb` fires once per chunk
+// (and once more with is_final=1 at EOS/end). `chunk_frames` codec frames
+// are decoded per emission; `overlap_frames` already-emitted frames are
+// prepended as left context to avoid window-boundary clicks (their PCM is
+// discarded). Args <= 0 fall back to defaults (chunk_frames=8,
+// overlap_frames=96 — 96 exceeds the codec sliding-window of 72 plus the
+// causal upsample-conv receptive field so each emitted window matches the
+// whole-clip decode). Returns the full concatenated PCM too (caller frees
+// with qwen3_tts_pcm_free); *out_n_samples is set on success. Returns
+// nullptr on failure.
+float* qwen3_tts_synthesize_streaming(struct qwen3_tts_context* ctx, const char* text, int chunk_frames,
+                                      int overlap_frames, qwen3_tts_pcm_callback cb, void* user_data,
+                                      int* out_n_samples);
+
 void qwen3_tts_pcm_free(float* pcm);
 
 void qwen3_tts_free(struct qwen3_tts_context* ctx);


### PR DESCRIPTION
True **streaming synthesis** for the qwen3-tts backend — emit PCM as it is generated instead of only returning the whole clip. Built and tested on Windows + RTX 3060 Ti (CUDA). Separate from #176 (that one is the Wyoming fixes); these touch disjoint files.

## Why
qwen3-tts is great but `*_synthesize` returns the full clip, so an interactive/voice-assistant loop waits the whole synth (~rtf 1.2–1.9) before any audio. The talker already generates codes frame-by-frame; this exposes that so the first audio lands almost immediately.

## Result (qwen3-tts-customvoice, voice `sohee`, 6.6 s Russian utterance)
| | streaming | non-stream |
|---|---|---|
| **time-to-first-audio** | **~1.1 s** | ~7.0 s |
| total synth | ~8.0 s (+~15% re-decode) | ~7.0 s |
| audio | 11–42 chunks, identical RMS, continuous (seam jumps far below natural max-delta) |

~7x faster first audio; total only slightly higher from per-window re-decode of the overlap.

## What changed
- **`src/qwen3_tts.{h,cpp}`** — `qwen3_tts_synthesize_streaming(ctx, text, chunk_frames, overlap_frames, cb, user_data, out_n_samples)`. Reuses the AR-loop body verbatim (same prefill / talker + code_pred / KV + `past_hidden`, never reset). Every `chunk_frames` new frames (and at EOS) it decodes a window = last `overlap_frames` emitted frames + new frames via the existing `codec_decode_codes`, discards the overlap pre-roll (`overlap_frames*1920` samples) and fires the callback. Per-window rebuild — **no graph caching** (the `ggml_set_rows` cached-graph CUDA-crash note applies; per-window decode is cheap vs the AR loop).
- **`examples/cli/crispasr_backend.h`** — `crispasr_pcm_stream_callback` + virtual `synthesize_streaming` with a whole-clip fallback, so other backends keep working unchanged.
- **`examples/cli/crispasr_backend_qwen3_tts.cpp`** — override `synthesize_streaming` (chunk_frames=8, overlap_frames=96) + `CAP_STREAMING`; shared voice setup factored into `prepare_synthesis()` (no behavior change).
- **`examples/cli/crispasr_server.cpp`** — `/v1/audio/speech?stream=true` rewired to producer/consumer: a worker synthesizes under `model_mutex` and pushes int16-LE PCM chunks into a CV-guarded queue that the `set_chunked_content_provider` drains as they arrive (intra-sentence). The previous branch buffered the whole synth first, so TTFA stayed at full-synth latency. Non-stream path unchanged.

## Design notes
- **chunk_frames=8** — TTFA is gated by AR generation of N frames, **not** codec decode, so small N wins (chunk=24 regressed TTFA to ~5 s).
- **overlap_frames=96** — codec is causal with sliding-window=72 plus a causal-conv receptive field; overlap=32 left ~6% seam difference vs whole-clip, 96 drops it to ~1.1% (inaudible). Mirrors the existing `transcribe_streaming` / `CAP_STREAMING` / `set_chunked_content_provider` pattern.

## Test
```
crispasr --server --backend qwen3-tts-customvoice -m auto --port 8082
# POST /v1/audio/speech {"input": "...", "voice": "sohee", "stream": true, "response_format": "pcm"}
# stream the response; first PCM chunk arrives ~1.1 s, rest follows continuously.
```

## Known / limitations
- Not bit-exact vs whole-clip (~1.1% at seams) — inaudible; raise `overlap_frames` for stricter fidelity at more re-decode cost.
- No codec graph caching (deliberate, per the CUDA note) — small per-window rebuild overhead.
- Streaming wired for the qwen3-tts backend; other TTS backends fall back to the whole-clip default.

Happy to adjust defaults / split further if you prefer.
