### PR TITLE
fix(qwen3-tts): make O15 code-pred graph reuse safe on CUDA and 1.7B (#56)

### DIFF
--- a/src/qwen3_tts.cpp
+++ b/src/qwen3_tts.cpp
@@ -724,6 +724,13 @@ struct qwen3_tts_context {
     ggml_cgraph* cp_t1_gf = nullptr;
     ggml_backend_sched_t cp_t1_sched = nullptr; // dedicated sched for O15 T=1 reuse
     bool cp_t1_allocated = false;               // true once cp_t1_sched has allocated cp_t1_gf
+    // Dedicated persistent arena for cp_t1_gf's tensor metadata. Without this
+    // the graph is built into the shared `compute_meta`, which intervening
+    // builds (notably the 1.7B small_to_mtp projection, run between code steps)
+    // overwrite — leaving cp_t1_gf's tensors dangling so a later reuse hits
+    // GGML_ASSERT in ggml_backend_tensor_set (#56; 1.7B-specific, not CUDA).
+    ggml_context* cp_t1_ctx = nullptr;
+    std::vector<uint8_t> cp_t1_compute_meta;
 
     // Step-0 graph cache (PLAN #52 step 4 follow-on). The first cp_pred call
     // per frame is T=2 with lm_head[0]; the existing cp_t1_gf cache only
@@ -1896,13 +1903,35 @@ float* run_code_pred_kv(qwen3_tts_context* c, const float* embeds, int n_tokens,
     ggml_cgraph* gf;
     if (can_skip) {
         gf = c->cp_t1_gf;
+    } else if (use_slot) {
+        if (!c->cp_t1_gf) {
+            // First T=1 build: into a dedicated persistent arena (cp_t1_ctx) so
+            // intervening compute_meta builds (notably the 1.7B small_to_mtp
+            // projection, run between code steps) can't clobber this cached
+            // graph's tensor metadata. The graph is n_past-invariant under O15
+            // (positions carries n_past; lm_head via cp_lm_head_slot), so it is
+            // built once and reused for all T=1 steps and frames.
+            c->cp_t1_compute_meta.assign(c->compute_meta.size(), 0);
+            ggml_init_params ip = {c->cp_t1_compute_meta.size(), c->cp_t1_compute_meta.data(), true};
+            c->cp_t1_ctx = ggml_init(ip);
+            if (!c->cp_t1_ctx) {
+                return nullptr;
+            }
+            gf = build_graph_code_pred_kv(c, n_past, n_tokens, lm_head, c->cp_t1_ctx);
+            if (!gf) {
+                ggml_free(c->cp_t1_ctx);
+                c->cp_t1_ctx = nullptr;
+                c->cp_t1_compute_meta.clear();
+                return nullptr;
+            }
+            c->cp_t1_gf = gf; // cache for all future T=1 steps and frames
+        } else {
+            gf = c->cp_t1_gf;
+        }
     } else {
         gf = build_graph_code_pred_kv(c, n_past, n_tokens, lm_head);
         if (!gf) {
             return nullptr;
-        }
-        if (use_slot) {
-            c->cp_t1_gf = gf; // cache for future skip_plan calls within this frame
         }
     }
 
@@ -1925,12 +1954,20 @@ float* run_code_pred_kv(qwen3_tts_context* c, const float* embeds, int n_tokens,
     if (!use_slot && !code_pred_reserve_sched(c, sched)) {
         return nullptr;
     }
+    // The "skip reset+alloc on cache hit" optimisation is only safe on backends
+    // whose scheduler keeps a previous allocation valid across computes
+    // (Metal/CPU). On CUDA, computing a reused graph without re-allocating the
+    // scheduler triggers an illegal memory access (#56). So by default we
+    // re-alloc each step — we still keep the larger O15 win (the graph itself is
+    // built exactly once, no per-step rebuild). Metal/CPU users can opt back
+    // into the skip with QWEN3_TTS_O15_SKIP_REALLOC=1.
+    const bool skip_realloc = can_skip && c->cp_t1_allocated && env_bool("QWEN3_TTS_O15_SKIP_REALLOC");
     const double t_reset0 = bench ? now_ms() : 0.0;
-    if (!can_skip || !c->cp_t1_allocated) {
+    if (!skip_realloc) {
         ggml_backend_sched_reset(sched);
     }
     const double t_reset1 = bench ? now_ms() : 0.0;
-    if (!can_skip || !c->cp_t1_allocated) {
+    if (!skip_realloc) {
         if (!ggml_backend_sched_alloc_graph(sched, gf)) {
             return nullptr;
         }
@@ -6491,6 +6528,9 @@ extern "C" void qwen3_tts_free(struct qwen3_tts_context* ctx) {
     }
     if (ctx->cp_step0_sched) {
         ggml_backend_sched_free(ctx->cp_step0_sched);
+    }
+    if (ctx->cp_t1_ctx) {
+        ggml_free(ctx->cp_t1_ctx);
     }
     if (ctx->cp_step0_ctx) {
         ggml_free(ctx->cp_step0_ctx);


### PR DESCRIPTION
## Summary

`QWEN3_TTS_O15` (code-predictor cached-graph reuse) crashes with `GGML_ASSERT(tensor) failed` in `ggml_backend_tensor_set` (`ggml-backend.cpp:325`) on the first reused code step. This is the crash tracked in #56. Investigating on CUDA hardware turned up **two independent root causes** — one of which is not CUDA-specific at all.

O15 stays **default-off**; this PR only makes it crash-free (and actually usable on 1.7B) when enabled.

## Root causes

**1. 1.7B arena clobber — not CUDA-specific.**
The cached `cp_t1_gf` graph was built into the shared `c->compute_meta` arena. On 1.7B models, `apply_small_to_mtp` runs its own graph in that *same* arena between code steps, overwriting `cp_t1_gf`'s tensor metadata. The next reuse then resolves **every** named input (`inputs_embeds` / `positions` / `causal_mask`) to `NULL` → assert. 0.6B has no `small_to_mtp` projection (it takes the `memcpy` path), so the existing Metal/CPU validation on 0.6B never exercised this — it would assert on 1.7B Metal/CPU too.

**2. CUDA cached-graph reuse — CUDA-specific.**
Computing a reused graph *without* re-allocating the scheduler triggers an illegal memory access on the CUDA backend (Metal/CPU tolerate it).

## Fix

1. Build `cp_t1_gf` into a **dedicated persistent arena** (`cp_t1_ctx`), mirroring the existing step-0 cache. The T=1 graph is `n_past`-invariant under O15 (`positions` carries `n_past`, `lm_head` via `cp_lm_head_slot`), so it is built **once** and reused across all steps and frames.
2. **Re-alloc the scheduler each step by default.** The larger win is preserved (the graph is built only once — no per-step rebuild). The full reset+alloc skip is now opt-in via `QWEN3_TTS_O15_SKIP_REALLOC=1` for Metal/CPU.

## Validation

RTX 3060 Ti, CUDA 13.2, `qwen3-tts-12hz-1.7b-customvoice-q8_0`:

| config | result |
|---|---|
| `QWEN3_TTS_O15=0` (baseline) | OK ×4, rtf 1.05 |
| `QWEN3_TTS_O15=1` (this PR, default) | **OK ×4, no crash**, rtf 1.05 |
| `QWEN3_TTS_O15=1 QWEN3_TTS_O15_SKIP_REALLOC=1` | illegal-access (expected — skip is Metal/CPU-only) |

Before this PR, `QWEN3_TTS_O15=1` aborted with `GGML_ASSERT(tensor) failed` at `ggml-backend.cpp:325` on the first reused step.

### Performance note (honest)

On this GPU the code-pred path is **compute-bound** — bench shows ~55 ms compute vs ~4 ms (build+reset+alloc) per frame — so graph reuse is **perf-neutral on CUDA** (rtf 1.05 either way). The documented ~14–19 ms/frame win (per the existing code comment) applies on M1 Metal, where graph-construction overhead is relatively larger; on 1.7B that win was previously unreachable because of bug #1.

Closes #56.