### PR TITLE
fix(build): fully fix building with libopusfile

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -251,6 +251,9 @@ if (CRISPASR_OPUS)
                 # references from libopus.
                 # With this you e.g. get `-lopusfile -logg -lopus` instead of just
                 # `/usr/lib/libopusfile.so` passed to the linker.
+                # Using `PkgConfig::OPUSFILE` was also populating compiler flags. So we append
+                # those separately now.
+                target_compile_options(crispasr-lib PRIVATE ${OPUSFILE_CFLAGS})
                 target_link_libraries(crispasr-lib PRIVATE ${OPUSFILE_STATIC_LIBRARIES})
                 set(_crispasr_opus_ok ON)
                 message(STATUS "CrispASR: .opus via system opusfile ${OPUSFILE_VERSION} (pkg-config)")


### PR DESCRIPTION
 1646a89ddf244dc1e24f564e4c0080f47c707397 fixed the linking stage, but  broke the compiling stage, since using `PkgConfig::OPUSFILE` was also  appending compile flags.

 Complete the build fix by appending compile flags separately.

 Compilation was failing due to `opusfile.h` being not found.

 `pkg-cofig  --cflags` adds `-I/usr/include/opus` which is the include
 path containing the header file.

----------

Apologies for the earlier incomplete fix. I didn't catch this because I made the mistake of not testing with a clean build, and the compiled object files were already there.