### PR TITLE
fix(registry): remove dead lid-silero entry with non-existent HF repo

### DIFF
--- a/flutter/crispasr/lib/src/crispasr.dart
+++ b/flutter/crispasr/lib/src/crispasr.dart
@@ -611,7 +611,7 @@ enum LidMethod {
   whisper,
   /// GGUF-packed Silero 95-language classifier (~16 MB). Fast, no GPU
   /// required. Recommended default when the user has the
-  /// `silero-lid-95-f16.gguf` (or legacy `silero-lang95-v1-f16.gguf`)
+  /// `silero-lid-lang95-f32.gguf` (or legacy `silero-lang95-v1-f16.gguf`)
   /// on disk.
   silero,
   /// FireRed-LID 120-language Transformer (~300 MB). Higher coverage

--- a/src/crispasr_model_registry.cpp
+++ b/src/crispasr_model_registry.cpp
@@ -962,11 +962,6 @@ constexpr Entry k_registry[] = {
     // Audio-LID family — speech-signal language identification.
     // Silero + Ecapa run through the module-level `detect_language_pcm`;
     // FireRed requires the session-level `Session::detect_language` (Phase 6).
-    // `lid-silero` is the recommended default: 95 languages, ~16 MB, Apache-2.0.
-    // Converted from deepghs/silero-lang95-onnx via models/convert-silero-lid-to-gguf.py.
-    {"lid-silero", "silero-lid-95-f16.gguf",
-     "https://huggingface.co/cstr/silero-lid-95-GGUF/resolve/main/silero-lid-95-f16.gguf",
-     "~16 MB", nullptr, nullptr},
     // ECAPA-TDNN LID: speechbrain/lang-id-voxlingua107-ecapa (Apache-2.0),
     // 107 languages, attentive statistical pooling. ~42 MB F16.
     // Converted via models/convert-ecapa-tdnn-lid-to-gguf.py.


### PR DESCRIPTION
## Summary

The `lid-silero` row in `k_registry[]` (`src/crispasr_model_registry.cpp`) pointed at `https://huggingface.co/cstr/silero-lid-95-GGUF/resolve/main/silero-lid-95-f16.gguf` — a repo that was never published. The actually-shipped silero LID model lives at `cstr/silero-lid-lang95-GGUF` as `silero-lid-lang95-f32.gguf` (f32 only — quants break accuracy on the small conv tensors), and the audio-LID CLI already hardcodes that correct URL (`kSileroLidDefault*` in `examples/cli/crispasr_lid_cli.cpp:55-57`), bypassing the registry entirely.

This PR deletes the dead entry. No internal code path queries the registry for `lid-silero`:

- **audio-LID CLI** (`crispasr_lid_cli.cpp:79-84`) resolves via its own hardcoded constants + `ensure_cached_file`, never the registry.
- **text-LID dispatch** (`src/text_lid_dispatch.cpp`, `crisp_lid/src/text_lid_dispatch.cpp`) only resolves `lid-cld3` / `lid-glotlid` / `lid-fasttext176` — text family, not audio.
- **`tests/test-registry.cpp`** has no `lid-silero` assertion and no count assertion.

The dead URL only surfaced via (a) the model-manager CLI's catalog listing and (b) the Go/Dart/JS `crispasr_registry_lookup_abi` bindings if an external caller explicitly asked for `lid-silero`. Removing it makes those paths return "not found" instead of handing out a URL that 404s — strictly an improvement.

Also fixes a stale filename in the Dart `LidMethod.silero` doc comment (`silero-lid-95-f16.gguf` → `silero-lid-lang95-f32.gguf`).

## Verification

- `clang++ -fsyntax-only -std=c++17 -Isrc -Iinclude src/crispasr_model_registry.cpp` → exit 0 (array still well-formed after deletion).
- `git diff`: 5 lines removed from `k_registry[]`, 1 filename swapped in the Dart doc comment. The Audio-LID family header comment is preserved.
- `tools/format.sh --fix` could not be run locally (no clang-format v18 on this machine) — but the diff only deletes already-formatted lines, so no format drift is possible. CI lint will confirm.
- `ctest -L unit` could not be run locally (no build dir on this machine) — but `test-registry.cpp` doesn't reference `lid-silero` and doesn't assert count, so no test regression is possible.

## Test plan

- [ ] CI lint (clang-format v18) passes
- [ ] CI unit tests pass (`ctest -L unit`)
- [ ] `crispasr_model_mgr_cli` catalog still lists `lid-ecapa` and `lid-firered` (Audio-LID family header preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)