### PR TITLE
fix: model-scoped dequant caches (a second model loaded in the same process read the first's weights)

### DIFF
--- a/src/pocket_tts.cpp
+++ b/src/pocket_tts.cpp
@@ -3072,6 +3072,12 @@ struct pocket_tts_context* pocket_tts_init_from_file(const char* path_model, str
 void pocket_tts_free(struct pocket_tts_context* ctx) {
     if (!ctx)
         return;
+    // Drop this model's dequantized weights from the file-scope cache. It is
+    // keyed by tensor data pointer, which the allocator may hand back to a
+    // subsequently loaded model; without this, that model would read stale
+    // entries — i.e. this model's weights. (A per-model cache would be the
+    // fuller fix; see tensor_f32_data.)
+    g_f16_cache.clear();
     if (ctx->buf_perm)
         ggml_backend_buffer_free(ctx->buf_perm);
     if (ctx->ctx_perm)

--- a/src/wav2vec2-ggml.cpp
+++ b/src/wav2vec2-ggml.cpp
@@ -1672,14 +1672,14 @@ static std::vector<float> wav2vec2_compute_logits_graph(const wav2vec2_model& m,
     t0 = ggml_time_us();
     {
         // hidden_ht is [T, H] layout (same as ggml [H, T] data layout)
-        layer_norm(hidden_ht.data(), hidden_ht.data(), tensor_data_f32(m, m.enc_ln_w), tensor_data_f32(m, m.enc_ln_b), T, H,
-                   ln_eps);
+        layer_norm(hidden_ht.data(), hidden_ht.data(), tensor_data_f32(m, m.enc_ln_w), tensor_data_f32(m, m.enc_ln_b),
+                   T, H, ln_eps);
 
         int V_size = (int)hp.vocab_size;
         std::vector<float> logits(T * V_size);
         std::vector<uint8_t> scratch;
-        ggml_linear_f32(scratch, m.lm_w, m.lm_b ? tensor_data_f32(m, m.lm_b) : nullptr, hidden_ht.data(), logits.data(), H,
-                        V_size, T, n_threads, m.backend);
+        ggml_linear_f32(scratch, m.lm_w, m.lm_b ? tensor_data_f32(m, m.lm_b) : nullptr, hidden_ht.data(), logits.data(),
+                        H, V_size, T, n_threads, m.backend);
         t_lm = ggml_time_us() - t0;
 
         if (bench) {
@@ -1892,11 +1892,13 @@ std::vector<float> wav2vec2_compute_logits(const wav2vec2_model& m, const float*
         layer_norm(hidden.data(), normed.data(), tensor_data_f32(m, e.ln2_w), tensor_data_f32(m, e.ln2_b), T, H,
                    hp.layer_norm_eps);
 
-        ggml_linear_f32(scratch, e.fc1_w, tensor_data_f32(m, e.fc1_b), normed.data(), ffn_mid.data(), H, I, T, n_threads);
+        ggml_linear_f32(scratch, e.fc1_w, tensor_data_f32(m, e.fc1_b), normed.data(), ffn_mid.data(), H, I, T,
+                        n_threads);
         for (int i = 0; i < T * I; i++)
             ffn_mid[i] = gelu(ffn_mid[i]);
 
-        ggml_linear_f32(scratch, e.fc2_w, tensor_data_f32(m, e.fc2_b), ffn_mid.data(), ffn_out.data(), I, H, T, n_threads);
+        ggml_linear_f32(scratch, e.fc2_w, tensor_data_f32(m, e.fc2_b), ffn_mid.data(), ffn_out.data(), I, H, T,
+                        n_threads);
         for (int i = 0; i < T * H; i++)
             hidden[i] += ffn_out[i];
     }

--- a/src/wav2vec2-ggml.cpp
+++ b/src/wav2vec2-ggml.cpp
@@ -265,28 +265,27 @@ bool wav2vec2_load(const char* fname, wav2vec2_model& model) {
 
 // Read tensor data to a CPU float vector. Works whether the tensor lives
 // on CPU, CUDA, Metal, etc. — ggml_backend_tensor_get handles the D2H copy.
-// The returned vector is cached per tensor pointer to avoid repeated copies.
-static std::unordered_map<const ggml_tensor*, std::vector<float>> g_tensor_cache;
-
-static const float* tensor_data_f32(const ggml_tensor* t) {
+// The dequantized copy is cached in the owning model (m.tensor_cache), keyed
+// by tensor pointer, to avoid repeated D2H copies. Scoping the cache to the
+// model — rather than a file-scope global — ties its lifetime to the model's:
+// once a model is freed its cache goes with it, so a subsequently loaded model
+// (which may reuse the freed tensor addresses) can never read a prior model's
+// weights, and two live models never share cache state.
+static const float* tensor_data_f32(const wav2vec2_model& m, const ggml_tensor* t) {
     if (!t)
         return nullptr;
     // CPU tensor: direct pointer is fine
     if (ggml_backend_buffer_is_host(t->buffer))
         return (const float*)t->data;
     // GPU tensor: copy to CPU cache
-    auto it = g_tensor_cache.find(t);
-    if (it != g_tensor_cache.end())
+    auto it = m.tensor_cache.find(t);
+    if (it != m.tensor_cache.end())
         return it->second.data();
     size_t n = ggml_nelements(t);
-    auto& buf = g_tensor_cache[t];
+    auto& buf = m.tensor_cache[t];
     buf.resize(n);
     ggml_backend_tensor_get(t, buf.data(), 0, n * sizeof(float));
     return buf.data();
-}
-
-static void tensor_cache_clear() {
-    g_tensor_cache.clear();
 }
 
 // ===========================================================================
@@ -903,12 +902,12 @@ static void wav2vec2_debug_attention(const wav2vec2_model& m, const float* hidde
 
     // ---- Manual path (matching wav2vec2_compute_logits exactly) ----
     std::vector<float> normed(T * H), Q_m(T * H), K_m(T * H), V_m(T * H);
-    layer_norm(hidden_th, normed.data(), tensor_data_f32(e.ln1_w), tensor_data_f32(e.ln1_b), T, H, ln_eps);
+    layer_norm(hidden_th, normed.data(), tensor_data_f32(m, e.ln1_w), tensor_data_f32(m, e.ln1_b), T, H, ln_eps);
 
     std::vector<uint8_t> scratch;
-    ggml_linear_f32(scratch, e.q_w, tensor_data_f32(e.q_b), normed.data(), Q_m.data(), H, H, T, 1, m.backend);
-    ggml_linear_f32(scratch, e.k_w, tensor_data_f32(e.k_b), normed.data(), K_m.data(), H, H, T, 1, m.backend);
-    ggml_linear_f32(scratch, e.v_w, tensor_data_f32(e.v_b), normed.data(), V_m.data(), H, H, T, 1, m.backend);
+    ggml_linear_f32(scratch, e.q_w, tensor_data_f32(m, e.q_b), normed.data(), Q_m.data(), H, H, T, 1, m.backend);
+    ggml_linear_f32(scratch, e.k_w, tensor_data_f32(m, e.k_b), normed.data(), K_m.data(), H, H, T, 1, m.backend);
+    ggml_linear_f32(scratch, e.v_w, tensor_data_f32(m, e.v_b), normed.data(), V_m.data(), H, H, T, 1, m.backend);
 
     // Manual attention
     std::vector<float> attn_m(T * H, 0.f);
@@ -938,7 +937,7 @@ static void wav2vec2_debug_attention(const wav2vec2_model& m, const float* hidde
         }
     }
     std::vector<float> oproj_m(T * H);
-    ggml_linear_f32(scratch, e.o_w, tensor_data_f32(e.o_b), attn_m.data(), oproj_m.data(), H, H, T, 1, m.backend);
+    ggml_linear_f32(scratch, e.o_w, tensor_data_f32(m, e.o_b), attn_m.data(), oproj_m.data(), H, H, T, 1, m.backend);
     std::vector<float> res_m(T * H);
     for (int i = 0; i < T * H; i++)
         res_m[i] = hidden_th[i] + oproj_m[i];
@@ -1012,7 +1011,7 @@ static void wav2vec2_debug_single_op(const wav2vec2_model & m,
     // Test JUST mul_mat — no LN, just raw matmul with the hidden state
     std::vector<float> fc1_manual(T * I);
     std::vector<uint8_t> scratch;
-    ggml_linear_f32(scratch, e.fc1_w, tensor_data_f32(e.fc1_b),
+    ggml_linear_f32(scratch, e.fc1_w, tensor_data_f32(m, e.fc1_b),
                     hidden_th, fc1_manual.data(), H, I, T, 1, m.backend);
 
     fprintf(stderr, "[dbg] manual fc1(raw)[t=0, 0:8]:");
@@ -1262,13 +1261,13 @@ static std::vector<float> wav2vec2_compute_logits_graph(const wav2vec2_model& m,
                     w_buf[i] = ggml_fp16_to_fp32(w16[i]);
                 wdata = w_buf.data();
             } else {
-                wdata = tensor_data_f32(m.cnn[li].conv_w);
+                wdata = tensor_data_f32(m, m.cnn[li].conv_w);
             }
-            conv1d(cf.data(), wdata, m.cnn[li].conv_b ? tensor_data_f32(m.cnn[li].conv_b) : nullptr, co.data(),
+            conv1d(cf.data(), wdata, m.cnn[li].conv_b ? tensor_data_f32(m, m.cnn[li].conv_b) : nullptr, co.data(),
                    (int)C_cur, (int)C_out, (int)K, (int)S, (int)L_cur, 0);
             if (m.cnn[li].has_norm) {
-                const float* nw = tensor_data_f32(m.cnn[li].norm_w);
-                const float* nb = tensor_data_f32(m.cnn[li].norm_b);
+                const float* nw = tensor_data_f32(m, m.cnn[li].norm_w);
+                const float* nb = tensor_data_f32(m, m.cnn[li].norm_b);
                 if (hp.feat_extract_norm_type == 1)
                     layer_norm_cf(co.data(), co.data(), nw, nb, (int)C_out, (int)L_out, hp.layer_norm_eps);
                 else
@@ -1325,12 +1324,12 @@ static std::vector<float> wav2vec2_compute_logits_graph(const wav2vec2_model& m,
         fprintf(stderr, "wav2vec2: CNN done: T=%d C=%d (%.1fms)\n", T, C_cnn, t_cnn / 1e3);
     // ---- 2. Feature projection: LN + Linear ----
     t0 = ggml_time_us();
-    layer_norm(feat.data(), feat.data(), tensor_data_f32(m.fp_ln_w), tensor_data_f32(m.fp_ln_b), T, C_cnn,
+    layer_norm(feat.data(), feat.data(), tensor_data_f32(m, m.fp_ln_w), tensor_data_f32(m, m.fp_ln_b), T, C_cnn,
                hp.layer_norm_eps);
 
     std::vector<float> hidden(T * H);
     std::vector<uint8_t> scratch;
-    ggml_linear_f32(scratch, m.fp_w, tensor_data_f32(m.fp_b), feat.data(), hidden.data(), C_cnn, H, T, n_threads,
+    ggml_linear_f32(scratch, m.fp_w, tensor_data_f32(m, m.fp_b), feat.data(), hidden.data(), C_cnn, H, T, n_threads,
                     m.backend);
 
     // Dump feature projection output
@@ -1378,8 +1377,8 @@ static std::vector<float> wav2vec2_compute_logits_graph(const wav2vec2_model& m,
             int K_this = (int)w_tensor->ne[0];
 
             // Grouped positional conv: try ggml (SIMD), fallback to manual CPU
-            const float* pw = tensor_data_f32(w_tensor);
-            const float* pb = b_tensor ? tensor_data_f32(b_tensor) : nullptr;
+            const float* pw = tensor_data_f32(m, w_tensor);
+            const float* pb = b_tensor ? tensor_data_f32(m, b_tensor) : nullptr;
             std::vector<float> pos_out(H * T, 0.0f);
             if (!ggml_grouped_conv1d_same(pos_cf.data(), pos_out.data(), H, K_this, G_pos, T, pw, pb, m.backend))
                 grouped_conv1d_same(pos_cf.data(), pw, pb, pos_out.data(), H, H, K_this, G_pos, T);
@@ -1502,8 +1501,8 @@ static std::vector<float> wav2vec2_compute_logits_graph(const wav2vec2_model& m,
                     ggml_backend_tensor_set(inp, hidden_ht.data(), 0, H * T * sizeof(float));
                     // Set per-group pos_conv weight/bias inputs (F32 dequantized)
                     {
-                        const float* pw = tensor_data_f32(m.pos_conv_w);
-                        const float* pb = m.pos_conv_b ? tensor_data_f32(m.pos_conv_b) : nullptr;
+                        const float* pw = tensor_data_f32(m, m.pos_conv_w);
+                        const float* pb = m.pos_conv_b ? tensor_data_f32(m, m.pos_conv_b) : nullptr;
                         int K_pos = (int)hp.num_conv_pos_embeddings;
                         int G_pos = (int)hp.num_conv_pos_embedding_groups;
                         int cpg = H / G_pos;
@@ -1673,13 +1672,13 @@ static std::vector<float> wav2vec2_compute_logits_graph(const wav2vec2_model& m,
     t0 = ggml_time_us();
     {
         // hidden_ht is [T, H] layout (same as ggml [H, T] data layout)
-        layer_norm(hidden_ht.data(), hidden_ht.data(), tensor_data_f32(m.enc_ln_w), tensor_data_f32(m.enc_ln_b), T, H,
+        layer_norm(hidden_ht.data(), hidden_ht.data(), tensor_data_f32(m, m.enc_ln_w), tensor_data_f32(m, m.enc_ln_b), T, H,
                    ln_eps);
 
         int V_size = (int)hp.vocab_size;
         std::vector<float> logits(T * V_size);
         std::vector<uint8_t> scratch;
-        ggml_linear_f32(scratch, m.lm_w, m.lm_b ? tensor_data_f32(m.lm_b) : nullptr, hidden_ht.data(), logits.data(), H,
+        ggml_linear_f32(scratch, m.lm_w, m.lm_b ? tensor_data_f32(m, m.lm_b) : nullptr, hidden_ht.data(), logits.data(), H,
                         V_size, T, n_threads, m.backend);
         t_lm = ggml_time_us() - t0;
 
@@ -1768,11 +1767,11 @@ std::vector<float> wav2vec2_compute_logits(const wav2vec2_model& m, const float*
                 w_buf[i] = ggml_fp16_to_fp32(w16[i]);
             wdata = w_buf.data();
         } else {
-            wdata = tensor_data_f32(m.cnn[li].conv_w);
+            wdata = tensor_data_f32(m, m.cnn[li].conv_w);
         }
-        const float* bdata = m.cnn[li].conv_b ? tensor_data_f32(m.cnn[li].conv_b) : nullptr;
-        const float* nw = m.cnn[li].has_norm ? tensor_data_f32(m.cnn[li].norm_w) : nullptr;
-        const float* nb = m.cnn[li].has_norm ? tensor_data_f32(m.cnn[li].norm_b) : nullptr;
+        const float* bdata = m.cnn[li].conv_b ? tensor_data_f32(m, m.cnn[li].conv_b) : nullptr;
+        const float* nw = m.cnn[li].has_norm ? tensor_data_f32(m, m.cnn[li].norm_w) : nullptr;
+        const float* nb = m.cnn[li].has_norm ? tensor_data_f32(m, m.cnn[li].norm_b) : nullptr;
 
         conv1d(cnn_in.data(), wdata, bdata, cnn_out.data(), (int)C_cur, (int)C_out, (int)K, (int)stride, (int)L_cur,
                /*left_pad=*/0);
@@ -1806,13 +1805,13 @@ std::vector<float> wav2vec2_compute_logits(const wav2vec2_model& m, const float*
     // ------------------------------------------------------------------
     int H = (int)hp.hidden_size;
 
-    layer_norm(feat.data(), feat.data(), tensor_data_f32(m.fp_ln_w), tensor_data_f32(m.fp_ln_b), T, C_cnn,
+    layer_norm(feat.data(), feat.data(), tensor_data_f32(m, m.fp_ln_w), tensor_data_f32(m, m.fp_ln_b), T, C_cnn,
                hp.layer_norm_eps);
 
     std::vector<float> hidden(T * H);
     std::vector<uint8_t> scratch;
 
-    ggml_linear_f32(scratch, m.fp_w, tensor_data_f32(m.fp_b), feat.data(), hidden.data(), C_cnn, H, T, n_threads,
+    ggml_linear_f32(scratch, m.fp_w, tensor_data_f32(m, m.fp_b), feat.data(), hidden.data(), C_cnn, H, T, n_threads,
                     m.backend);
 
     // ------------------------------------------------------------------
@@ -1829,8 +1828,8 @@ std::vector<float> wav2vec2_compute_logits(const wav2vec2_model& m, const float*
         int G_pos = (int)hp.num_conv_pos_embedding_groups;
 
         // Grouped positional conv: try ggml (SIMD), fallback to manual CPU
-        const float* pw = tensor_data_f32(m.pos_conv_w);
-        const float* pb = tensor_data_f32(m.pos_conv_b);
+        const float* pw = tensor_data_f32(m, m.pos_conv_w);
+        const float* pb = tensor_data_f32(m, m.pos_conv_b);
         if (!ggml_grouped_conv1d_same(hcf.data(), pos_out.data(), H, K_pos, G_pos, T, pw, pb, m.backend))
             grouped_conv1d_same(hcf.data(), pw, pb, pos_out.data(), H, H, K_pos, G_pos, T);
 
@@ -1857,14 +1856,14 @@ std::vector<float> wav2vec2_compute_logits(const wav2vec2_model& m, const float*
     for (uint32_t li = 0; li < hp.num_hidden_layers; li++) {
         const auto& e = m.enc[li];
 
-        layer_norm(hidden.data(), normed.data(), tensor_data_f32(e.ln1_w), tensor_data_f32(e.ln1_b), T, H,
+        layer_norm(hidden.data(), normed.data(), tensor_data_f32(m, e.ln1_w), tensor_data_f32(m, e.ln1_b), T, H,
                    hp.layer_norm_eps);
 
-        ggml_linear_f32(scratch, e.q_w, tensor_data_f32(e.q_b), normed.data(), Q_buf.data(), H, H, T, n_threads,
+        ggml_linear_f32(scratch, e.q_w, tensor_data_f32(m, e.q_b), normed.data(), Q_buf.data(), H, H, T, n_threads,
                         m.backend);
-        ggml_linear_f32(scratch, e.k_w, tensor_data_f32(e.k_b), normed.data(), K_buf.data(), H, H, T, n_threads,
+        ggml_linear_f32(scratch, e.k_w, tensor_data_f32(m, e.k_b), normed.data(), K_buf.data(), H, H, T, n_threads,
                         m.backend);
-        ggml_linear_f32(scratch, e.v_w, tensor_data_f32(e.v_b), normed.data(), V_buf.data(), H, H, T, n_threads,
+        ggml_linear_f32(scratch, e.v_w, tensor_data_f32(m, e.v_b), normed.data(), V_buf.data(), H, H, T, n_threads,
                         m.backend);
 
         // Encoder self-attention, hand-rolled CPU path (O(T²) — the alignment
@@ -1885,19 +1884,19 @@ std::vector<float> wav2vec2_compute_logits(const wav2vec2_model& m, const float*
             }
         }
 
-        ggml_linear_f32(scratch, e.o_w, tensor_data_f32(e.o_b), attn_out.data(), normed.data(), H, H, T, n_threads,
+        ggml_linear_f32(scratch, e.o_w, tensor_data_f32(m, e.o_b), attn_out.data(), normed.data(), H, H, T, n_threads,
                         m.backend);
         for (int i = 0; i < T * H; i++)
             hidden[i] += normed[i];
 
-        layer_norm(hidden.data(), normed.data(), tensor_data_f32(e.ln2_w), tensor_data_f32(e.ln2_b), T, H,
+        layer_norm(hidden.data(), normed.data(), tensor_data_f32(m, e.ln2_w), tensor_data_f32(m, e.ln2_b), T, H,
                    hp.layer_norm_eps);
 
-        ggml_linear_f32(scratch, e.fc1_w, tensor_data_f32(e.fc1_b), normed.data(), ffn_mid.data(), H, I, T, n_threads);
+        ggml_linear_f32(scratch, e.fc1_w, tensor_data_f32(m, e.fc1_b), normed.data(), ffn_mid.data(), H, I, T, n_threads);
         for (int i = 0; i < T * I; i++)
             ffn_mid[i] = gelu(ffn_mid[i]);
 
-        ggml_linear_f32(scratch, e.fc2_w, tensor_data_f32(e.fc2_b), ffn_mid.data(), ffn_out.data(), I, H, T, n_threads);
+        ggml_linear_f32(scratch, e.fc2_w, tensor_data_f32(m, e.fc2_b), ffn_mid.data(), ffn_out.data(), I, H, T, n_threads);
         for (int i = 0; i < T * H; i++)
             hidden[i] += ffn_out[i];
     }
@@ -1905,7 +1904,7 @@ std::vector<float> wav2vec2_compute_logits(const wav2vec2_model& m, const float*
     // ------------------------------------------------------------------
     // 5. Encoder global LayerNorm
     // ------------------------------------------------------------------
-    layer_norm(hidden.data(), hidden.data(), tensor_data_f32(m.enc_ln_w), tensor_data_f32(m.enc_ln_b), T, H,
+    layer_norm(hidden.data(), hidden.data(), tensor_data_f32(m, m.enc_ln_w), tensor_data_f32(m, m.enc_ln_b), T, H,
                hp.layer_norm_eps);
 
     // ------------------------------------------------------------------
@@ -1913,7 +1912,7 @@ std::vector<float> wav2vec2_compute_logits(const wav2vec2_model& m, const float*
     // ------------------------------------------------------------------
     int V = (int)hp.vocab_size;
     std::vector<float> logits(T * V);
-    ggml_linear_f32(scratch, m.lm_w, tensor_data_f32(m.lm_b), hidden.data(), logits.data(), H, V, T, n_threads,
+    ggml_linear_f32(scratch, m.lm_w, tensor_data_f32(m, m.lm_b), hidden.data(), logits.data(), H, V, T, n_threads,
                     m.backend);
 
     return logits;

--- a/src/wav2vec2-ggml.h
+++ b/src/wav2vec2-ggml.h
@@ -22,6 +22,7 @@
 #include <cstdint>
 #include <map>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 // ---------------------------------------------------------------------------
@@ -101,6 +102,13 @@ struct wav2vec2_model {
     ggml_backend_buffer_t buf = nullptr; // backend buffer (core_gguf)
     ggml_backend_t backend = nullptr;    // backend that owns buf
     std::map<std::string, ggml_tensor*> tensors;
+
+    // CPU dequantization cache for GPU-resident weights, keyed by tensor
+    // pointer (see tensor_data_f32). Scoped to the model so its lifetime
+    // matches the weights it caches — a reloaded/second model cannot alias a
+    // freed tensor pointer, and two live models never share cache state.
+    // mutable: the compute path takes `const wav2vec2_model&` and populates it.
+    mutable std::unordered_map<const ggml_tensor*, std::vector<float>> tensor_cache;
 
     wav2vec2_model() = default;
     wav2vec2_model(const wav2vec2_model&) = delete;


### PR DESCRIPTION
## Summary

Two backends cached dequantized weights in a **file-scope, never-cleared** map
keyed by a raw pointer. Because the process-global cache outlives the model it
describes, loading a second model in the same process — after the first is freed
— returns the **first model's weights** for the second, since the allocator
commonly hands the freed tensor addresses back to the new model. The second
model then computes against the wrong weights and produces empty or degenerate
output.

Affected:
- `wav2vec2-ggml.cpp` — `g_tensor_cache`, keyed by `ggml_tensor*`. GPU-only: the
  cache is on the manual CPU compute path that reads GPU-resident weights via
  `ggml_backend_tensor_get`; on a CPU backend the direct-pointer path is taken
  and the cache is bypassed.
- `pocket_tts.cpp` — `g_f16_cache`, keyed by `tensor->data`. Not GPU-only —
  triggers for any F16 weight.

## Reproduction (wav2vec2)

On a Metal/CUDA build:

1. Open a session on wav2vec2 model **A**, transcribe → correct.
2. Close it; open a session on a *different* wav2vec2 model **B**, transcribe →
   **empty / degenerate** output.

It's order-independent (A→B corrupts B; B→A corrupts A). Model A alone, model B
alone, or the *same* model opened twice all decode correctly — which is what
makes single-model usage and same-model reloads look fine.

## Fix

- **`fix(wav2vec2)`** — move the cache into `wav2vec2_model` (`mutable`, so the
  `const wav2vec2_model&` compute path can populate it). Its lifetime now matches
  the model: a reloaded/second model can't alias a freed pointer, and two live
  models never share cache state. Removes the now-unused `tensor_cache_clear`.
- **`fix(pocket_tts)`** — minimal: clear `g_f16_cache` in `pocket_tts_free`, so a
  freed model leaves no stale entries for the next load to collide with.

No behavior change for single-model use; the cache still avoids repeated D2H
copies within a model's lifetime.

## Notes / follow-ups

**(a) pocket_tts got the minimal fix, not the per-model treatment.** Scoping its
cache to the model the way `wav2vec2` now does would require threading the model
through several context-less eager helpers (`linear_f32` + its ~24 callers, the
eager `conv1d`/`conv_transpose1d` helpers, and the scalar Mimi transformer),
which is a larger, harder-to-review change. The clear-on-free here fully fixes
the reload corruption; per-model scoping would additionally isolate two live
models.

**(b) A related but distinct single-model assumption exists elsewhere** (not
touched here, flagging for triage):
- `kugelaudio.cpp` and `vibevoice.cpp` — `tokenize_text_greedy` builds a
  `static std::map<std::string,int> vocab_map` once (guarded by `static bool
  built`) from the first model's vocab and reuses it for every subsequent model,
  so a second model with a different vocab is tokenized with the first's.
- `voxcpm2_tts.cpp` — `vae_encode_cached` memoizes by `{ctx, pcm, n_samples}`
  pointers; a theoretical stale-`ctx`-pointer hit after free.

These are a different mechanism/fix and TTS-only, so I left them out of this PR.

Authored by Claude Opus.