### PR TITLE
Expose CTC + Whisper introspection accessors on the exception-safe session

### DIFF
--- a/bindings/csharp/CrispASR/NativeMethods.cs
+++ b/bindings/csharp/CrispASR/NativeMethods.cs
@@ -31,6 +31,12 @@ namespace CrispASR
         internal static extern int crispasr_session_available_backends(
             byte[] outCsv, int outCap);
 
+        // Acoustic detected language (Whisper) as an ISO-639-1 code into outBuf;
+        // other backends fall back to the source-language hint, then "unknown".
+        [DllImport(Lib, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern int crispasr_session_detected_language(
+            IntPtr session, byte[] outBuf, int outCap);
+
         // CTC vocabulary access (Omni CTC backend). n_vocab is the piece count;
         // token_text returns a model-owned const char* (do not free) or "" when
         // out of range / unsupported.
@@ -244,6 +250,11 @@ namespace CrispASR
 
         [DllImport(Lib, CallingConvention = CallingConvention.Cdecl)]
         internal static extern float crispasr_session_result_word_p(IntPtr result, int iSeg, int iWord);
+
+        // Whisper's per-segment no-speech probability in [0, 1]; -1.0 sentinel
+        // ("no data") for other backends and out-of-range indices.
+        [DllImport(Lib, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern float crispasr_session_result_segment_no_speech_prob(IntPtr result, int iSeg);
 
         // Per-frame CTC logits (opted in via crispasr_session_set_return_logits)
         // for backends with a dense CTC grid (Omni CTC, wav2vec2/hubert/data2vec,

--- a/bindings/csharp/CrispASR/Session.cs
+++ b/bindings/csharp/CrispASR/Session.cs
@@ -69,6 +69,18 @@ namespace CrispASR
             return csv.Split(',', StringSplitOptions.RemoveEmptyEntries);
         }
 
+        /// <summary>
+        /// The acoustic language Whisper detected on the last transcribe, as an
+        /// ISO-639-1 code ("en"). Whisper-only; other backends return the
+        /// session's source-language hint, or "unknown".
+        /// </summary>
+        public string DetectedLanguage()
+        {
+            var buf = new byte[32];
+            NativeMethods.crispasr_session_detected_language(Handle, buf, buf.Length);
+            return NativeMethods.NullTerminated(buf);
+        }
+
         public void Dispose()
         {
             if (_handle != IntPtr.Zero)
@@ -403,7 +415,8 @@ namespace CrispASR
                         NativeMethods.crispasr_session_result_word_p(r, i, j),
                         alts);
                 }
-                segs[i] = new Segment(text, t0, t1, words);
+                float noSpeechProb = NativeMethods.crispasr_session_result_segment_no_speech_prob(r, i);
+                segs[i] = new Segment(text, t0, t1, words, noSpeechProb);
             }
             return segs;
         }
@@ -643,10 +656,13 @@ namespace CrispASR
         public long T0 { get; }
         public long T1 { get; }
         public Word[] Words { get; }
+        /// <summary>Whisper's per-segment no-speech probability (the &lt;|nospeech|&gt;
+        /// posterior) in [0, 1]. Whisper-only; other backends leave -1.0 ("no data").</summary>
+        public float NoSpeechProb { get; }
 
-        public Segment(string text, long t0, long t1, Word[] words)
+        public Segment(string text, long t0, long t1, Word[] words, float noSpeechProb = -1.0f)
         {
-            Text = text; T0 = t0; T1 = t1; Words = words;
+            Text = text; T0 = t0; T1 = t1; Words = words; NoSpeechProb = noSpeechProb;
         }
 
         public override string ToString() => $"[{T0}-{T1}] {Text}";

--- a/bindings/go/crispasr_session.go
+++ b/bindings/go/crispasr_session.go
@@ -106,6 +106,7 @@ const char*  crispasr_session_result_word_text(crispasr_session_result* r, int i
 long long    crispasr_session_result_word_t0(crispasr_session_result* r, int i_seg, int i_word);
 long long    crispasr_session_result_word_t1(crispasr_session_result* r, int i_seg, int i_word);
 float        crispasr_session_result_word_p(crispasr_session_result* r, int i_seg, int i_word);
+float        crispasr_session_result_segment_no_speech_prob(crispasr_session_result* r, int i_seg);
 // Per-frame CTC logits (opted in via crispasr_session_set_return_logits) for
 // backends that produce a dense CTC grid (Omni CTC, wav2vec2/hubert/data2vec,
 // canary-ctc). Frame-major: logits[t * n_logit_vocab + v]. Raw pre-softmax for
@@ -306,6 +307,7 @@ int crispasr_registry_list_backends_abi(char* out_csv, int out_cap);
 
 // --- Session extras ---
 int crispasr_session_available_backends(char* out_csv, int out_cap);
+int crispasr_session_detected_language(crispasr_session* s, char* out_buf, int out_cap);
 // CTC vocabulary access (Omni CTC backend): n_vocab piece count, token_text
 // maps an id to its raw piece (word-boundary marker intact) or "" when out of
 // range / unsupported. Pairs with the result logits accessor for detokenization.
@@ -1054,6 +1056,10 @@ type TranscribeSegment struct {
 	T0    int64 // centiseconds
 	T1    int64
 	Words []TranscribeWord
+	// NoSpeechProb is Whisper's per-segment no-speech probability (the
+	// <|nospeech|> posterior) in [0, 1]. Whisper-only; other backends leave
+	// the -1.0 "no data" sentinel.
+	NoSpeechProb float32
 }
 
 // TranscribeWord is one word with timing and confidence.
@@ -1192,6 +1198,7 @@ func extractResult(r *C.crispasr_session_result) *TranscribeResult {
 		seg.Text = C.GoString(C.crispasr_session_result_segment_text(r, C.int(i)))
 		seg.T0 = int64(C.crispasr_session_result_segment_t0(r, C.int(i)))
 		seg.T1 = int64(C.crispasr_session_result_segment_t1(r, C.int(i)))
+		seg.NoSpeechProb = float32(C.crispasr_session_result_segment_no_speech_prob(r, C.int(i)))
 		nWords := int(C.crispasr_session_result_n_words(r, C.int(i)))
 		seg.Words = make([]TranscribeWord, nWords)
 		for j := 0; j < nWords; j++ {
@@ -1757,6 +1764,15 @@ func AvailableBackends() []string {
 		}
 	}
 	return out
+}
+
+// DetectedLanguage returns the acoustic language Whisper detected on the last
+// transcribe as an ISO-639-1 code (e.g. "en"). Whisper-only; other backends
+// return the session's source-language hint, or "unknown".
+func (s *Session) DetectedLanguage() string {
+	var buf [32]C.char
+	C.crispasr_session_detected_language(s.handle, &buf[0], 32)
+	return C.GoString(&buf[0])
 }
 
 func splitCSV(s string) []string {

--- a/bindings/java/src/main/java/io/github/ggerganov/whispercpp/CrispasrSession.java
+++ b/bindings/java/src/main/java/io/github/ggerganov/whispercpp/CrispasrSession.java
@@ -106,6 +106,7 @@ public final class CrispasrSession implements AutoCloseable {
         long         crispasr_session_result_word_t0(Pointer result, int iSeg, int iWord);
         long         crispasr_session_result_word_t1(Pointer result, int iSeg, int iWord);
         float        crispasr_session_result_word_p(Pointer result, int iSeg, int iWord);
+        float        crispasr_session_result_segment_no_speech_prob(Pointer result, int iSeg);
         // Per-frame CTC logits (opted in via crispasr_session_set_return_logits)
         // for backends with a dense CTC grid (Omni CTC, wav2vec2/hubert/data2vec,
         // canary-ctc). _logits returns a const float* (frame-major;
@@ -289,6 +290,7 @@ public final class CrispasrSession implements AutoCloseable {
 
         // Session extras
         int     crispasr_session_available_backends(byte[] outCsv, int outCap);
+        int     crispasr_session_detected_language(Pointer session, byte[] outBuf, int outCap);
         // CTC vocabulary access (Omni CTC backend): n_vocab piece count,
         // token_text maps an id to its raw piece (JNA copies the model-owned
         // const char*; do not free) or "" when out of range / unsupported.
@@ -812,8 +814,11 @@ public final class CrispasrSession implements AutoCloseable {
         public final String text;
         public final long t0, t1; // centiseconds
         public final Word[] words;
-        Segment(String text, long t0, long t1, Word[] words) {
-            this.text = text; this.t0 = t0; this.t1 = t1; this.words = words;
+        /** Whisper's per-segment no-speech probability (the {@code <|nospeech|>}
+         *  posterior) in [0, 1]. Whisper-only; other backends leave -1.0 ("no data"). */
+        public final float noSpeechProb;
+        Segment(String text, long t0, long t1, Word[] words, float noSpeechProb) {
+            this.text = text; this.t0 = t0; this.t1 = t1; this.words = words; this.noSpeechProb = noSpeechProb;
         }
     }
 
@@ -934,9 +939,22 @@ public final class CrispasrSession implements AutoCloseable {
                     Lib.INSTANCE.crispasr_session_result_word_t1(r, i, j),
                     Lib.INSTANCE.crispasr_session_result_word_p(r, i, j));
             }
-            segs[i] = new Segment(text, t0, t1, words);
+            float noSpeechProb = Lib.INSTANCE.crispasr_session_result_segment_no_speech_prob(r, i);
+            segs[i] = new Segment(text, t0, t1, words, noSpeechProb);
         }
         return segs;
+    }
+
+    /**
+     * The acoustic language Whisper detected on the last transcribe, as an
+     * ISO-639-1 code ("en"). Whisper-only; other backends return the session's
+     * source-language hint, or "unknown".
+     */
+    public String detectedLanguage() {
+        if (handle == null) throw new IllegalStateException("session is closed");
+        byte[] buf = new byte[32];
+        Lib.INSTANCE.crispasr_session_detected_language(handle, buf, buf.length);
+        return nullTerminated(buf);
     }
 
     // Copy the result-owned float* logit grid into a Java float[] before the

--- a/bindings/javascript/emscripten.cpp
+++ b/bindings/javascript/emscripten.cpp
@@ -59,6 +59,7 @@ int                     crispasr_kokoro_resolve_fallback_voice_abi(const char* m
 // --- Full C-ABI parity declarations ---
 // Session extras
 int          crispasr_session_available_backends(char* out_csv, int out_cap);
+int          crispasr_session_detected_language(CrispasrSession* s, char* out_buf, int out_cap);
 // CTC vocabulary access (Omni CTC backend): n_vocab piece count, token_text
 // maps an id to its model-owned raw piece (do not free) or "" when out of
 // range / unsupported.
@@ -128,6 +129,7 @@ const char*  crispasr_session_result_word_text(struct crispasr_session_result* r
 long long    crispasr_session_result_word_t0(struct crispasr_session_result* r, int i_seg, int i_word);
 long long    crispasr_session_result_word_t1(struct crispasr_session_result* r, int i_seg, int i_word);
 float        crispasr_session_result_word_p(struct crispasr_session_result* r, int i_seg, int i_word);
+float        crispasr_session_result_segment_no_speech_prob(struct crispasr_session_result* r, int i_seg);
 int          crispasr_session_result_word_n_alts(struct crispasr_session_result* r, int i_seg, int i_word);
 const char*  crispasr_session_result_word_alt_text(struct crispasr_session_result* r, int i_seg, int i_word, int i_alt);
 float        crispasr_session_result_word_alt_p(struct crispasr_session_result* r, int i_seg, int i_word, int i_alt);
@@ -826,6 +828,7 @@ EMSCRIPTEN_BINDINGS(whisper) {
                 seg.set("text", std::string(t ? t : ""));
                 seg.set("t0", crispasr_session_result_segment_t0(res, i) / 100.0);
                 seg.set("t1", crispasr_session_result_segment_t1(res, i) / 100.0);
+                seg.set("noSpeechProb", (double)crispasr_session_result_segment_no_speech_prob(res, i));
                 int nw = crispasr_session_result_n_words(res, i);
                 emscripten::val words = emscripten::val::array();
                 for (int j = 0; j < nw; j++) {
@@ -882,6 +885,7 @@ EMSCRIPTEN_BINDINGS(whisper) {
                 seg.set("text", std::string(t ? t : ""));
                 seg.set("t0", crispasr_session_result_segment_t0(res, i) / 100.0);
                 seg.set("t1", crispasr_session_result_segment_t1(res, i) / 100.0);
+                seg.set("noSpeechProb", (double)crispasr_session_result_segment_no_speech_prob(res, i));
                 int nw = crispasr_session_result_n_words(res, i);
                 emscripten::val words = emscripten::val::array();
                 for (int j = 0; j < nw; j++) {
@@ -957,6 +961,14 @@ EMSCRIPTEN_BINDINGS(whisper) {
     emscripten::function("availableBackends", emscripten::optional_override([]() -> std::string {
         char buf[1024] = {0};
         crispasr_session_available_backends(buf, sizeof(buf));
+        return std::string(buf);
+    }));
+
+    // --- Detected language (Whisper acoustic; "unknown" for other backends) ---
+    emscripten::function("detectedLanguage", emscripten::optional_override([]() -> std::string {
+        if (!g_tts_session) return std::string("unknown");
+        char buf[32] = {0};
+        crispasr_session_detected_language(g_tts_session, buf, sizeof(buf));
         return std::string(buf);
     }));
 

--- a/bindings/ruby/ext/ruby_crispasr_session.c
+++ b/bindings/ruby/ext/ruby_crispasr_session.c
@@ -109,6 +109,7 @@ extern const char*  crispasr_session_result_word_text(struct crispasr_session_re
 extern int64_t      crispasr_session_result_word_t0(struct crispasr_session_result* r, int i_seg, int i_word);
 extern int64_t      crispasr_session_result_word_t1(struct crispasr_session_result* r, int i_seg, int i_word);
 extern float        crispasr_session_result_word_p(struct crispasr_session_result* r, int i_seg, int i_word);
+extern float        crispasr_session_result_segment_no_speech_prob(struct crispasr_session_result* r, int i_seg);
 // Per-frame CTC logits (opted in via set_return_logits) for backends with a
 // dense CTC grid (Omni CTC, wav2vec2/hubert/data2vec, canary-ctc); frame-major:
 // logits[t * n_logit_vocab + v]. Raw pre-softmax for Omni & wav2vec2;
@@ -299,6 +300,7 @@ extern int crispasr_cache_dir_abi(const char* cache_dir_override, char* out_buf,
 
 // Session extras
 extern int crispasr_session_available_backends(char* out_csv, int out_cap);
+extern int crispasr_session_detected_language(struct CrispasrSession* s, char* out_buf, int out_cap);
 // CTC vocabulary access (Omni CTC backend): n_vocab piece count, token_text
 // maps an id to its model-owned raw piece (do not free) or "" when out of
 // range / unsupported.
@@ -713,6 +715,8 @@ static VALUE rb_session_transcribe(VALUE self, VALUE handle, VALUE pcm_arr) {
         rb_hash_aset(seg, ID2SYM(rb_intern("text")), rb_utf8_str_new_cstr(text ? text : ""));
         rb_hash_aset(seg, ID2SYM(rb_intern("t0")), LL2NUM(crispasr_session_result_segment_t0(r, i)));
         rb_hash_aset(seg, ID2SYM(rb_intern("t1")), LL2NUM(crispasr_session_result_segment_t1(r, i)));
+        rb_hash_aset(seg, ID2SYM(rb_intern("no_speech_prob")),
+                     DBL2NUM((double)crispasr_session_result_segment_no_speech_prob(r, i)));
 
         int n_words = crispasr_session_result_n_words(r, i);
         VALUE words = rb_ary_new_capa(n_words);
@@ -760,6 +764,8 @@ static VALUE rb_session_transcribe_with_logits(VALUE self, VALUE handle, VALUE p
         rb_hash_aset(seg, ID2SYM(rb_intern("text")), rb_utf8_str_new_cstr(text ? text : ""));
         rb_hash_aset(seg, ID2SYM(rb_intern("t0")), LL2NUM(crispasr_session_result_segment_t0(r, i)));
         rb_hash_aset(seg, ID2SYM(rb_intern("t1")), LL2NUM(crispasr_session_result_segment_t1(r, i)));
+        rb_hash_aset(seg, ID2SYM(rb_intern("no_speech_prob")),
+                     DBL2NUM((double)crispasr_session_result_segment_no_speech_prob(r, i)));
 
         int n_words = crispasr_session_result_n_words(r, i);
         VALUE words = rb_ary_new_capa(n_words);
@@ -846,6 +852,8 @@ static VALUE rb_session_transcribe_chunked(VALUE self, VALUE handle, VALUE pcm_a
         rb_hash_aset(seg, ID2SYM(rb_intern("text")), rb_utf8_str_new_cstr(text ? text : ""));
         rb_hash_aset(seg, ID2SYM(rb_intern("t0")), LL2NUM(crispasr_session_result_segment_t0(r, i)));
         rb_hash_aset(seg, ID2SYM(rb_intern("t1")), LL2NUM(crispasr_session_result_segment_t1(r, i)));
+        rb_hash_aset(seg, ID2SYM(rb_intern("no_speech_prob")),
+                     DBL2NUM((double)crispasr_session_result_segment_no_speech_prob(r, i)));
 
         int n_words = crispasr_session_result_n_words(r, i);
         VALUE words = rb_ary_new_capa(n_words);
@@ -1267,6 +1275,16 @@ static VALUE rb_session_available_backends(VALUE self) {
     return rb_utf8_str_new_cstr(buf);
 }
 
+// detected_language(handle) -> String. The acoustic language Whisper detected
+// on the last transcribe (ISO-639-1); other backends return the source-language
+// hint, or "unknown".
+static VALUE rb_session_detected_language(VALUE self, VALUE handle) {
+    struct CrispasrSession* s = (struct CrispasrSession*)NUM2ULL(handle);
+    char buf[32] = {0};
+    crispasr_session_detected_language(s, buf, sizeof(buf));
+    return rb_utf8_str_new_cstr(buf);
+}
+
 static VALUE rb_session_open_explicit(VALUE self, VALUE model_path, VALUE backend, VALUE n_threads) {
     struct CrispasrSession* s = crispasr_session_open_explicit(
         StringValueCStr(model_path), StringValueCStr(backend), NUM2INT(n_threads));
@@ -1582,6 +1600,7 @@ void init_ruby_crispasr_session(VALUE* mWhisper) {
     rb_define_singleton_method(mSession, "kokoro_lang_has_native_voice", rb_kokoro_lang_has_native_voice, 1);
     rb_define_singleton_method(mSession, "translate_text", rb_session_translate_text, 5);
     rb_define_singleton_method(mSession, "available_backends", rb_session_available_backends, 0);
+    rb_define_singleton_method(mSession, "detected_language",  rb_session_detected_language, 1);
     rb_define_singleton_method(mSession, "open_explicit", rb_session_open_explicit, 3);
     rb_define_singleton_method(mSession, "vad_slices", rb_vad_slices, -1);
     rb_define_singleton_method(mSession, "enhance_audio_rnnoise", rb_enhance_audio_rnnoise, 1);

--- a/crispasr-sys/src/lib.rs
+++ b/crispasr-sys/src/lib.rs
@@ -187,6 +187,16 @@ extern "C" {
     pub fn crispasr_session_n_vocab(s: *mut CrispasrSession) -> c_int;
     pub fn crispasr_session_token_text(s: *mut CrispasrSession, id: c_int) -> *const c_char;
 
+    // Acoustic language detected by the last transcribe, written into `out_buf`
+    // as an ISO-639-1 code (whisper only; other backends fall back to the
+    // source-language hint, then "unknown"). Returns the code length in bytes
+    // (not counting NUL) or -1 on bad args. Distinct from the text-LID pass.
+    pub fn crispasr_session_detected_language(
+        s: *mut CrispasrSession,
+        out_buf: *mut c_char,
+        out_cap: c_int,
+    ) -> c_int;
+
     /// Write a comma-separated list of backend names the loaded dylib
     /// was built with. Returns the number of bytes written (not counting
     /// NUL) or a negative error.

--- a/crispasr-sys/src/lib.rs
+++ b/crispasr-sys/src/lib.rs
@@ -445,6 +445,13 @@ extern "C" {
         i_seg: c_int,
         i_word: c_int,
     ) -> f32;
+    // Whisper's per-segment no-speech probability (the <|nospeech|> token
+    // posterior) in [0, 1]. Only the whisper backend populates it; other
+    // backends and out-of-range indices return the -1.0 sentinel ("no data").
+    pub fn crispasr_session_result_segment_no_speech_prob(
+        r: *mut CrispasrSessionResult,
+        i_seg: c_int,
+    ) -> f32;
 
     // Raw per-frame CTC logits (Omni CTC backend, opted in via
     // `crispasr_session_set_return_logits`). Frame-major, pre-softmax:

--- a/crispasr/src/lib.rs
+++ b/crispasr/src/lib.rs
@@ -384,6 +384,28 @@ impl Session {
         Some(out)
     }
 
+    /// The acoustic language whisper detected on the last transcribe, as an
+    /// ISO-639-1 code (e.g. `"en"`). Whisper-only: other backends return the
+    /// session's source-language hint, or `"unknown"` when none was set — as
+    /// does whisper before its first transcribe. This is the in-decode
+    /// acoustic signal, distinct from a text-LID pass over the transcript.
+    pub fn detected_language(&self) -> String {
+        let mut buf = [0 as c_char; 32];
+        let n = unsafe {
+            crispasr_sys::crispasr_session_detected_language(
+                self.handle,
+                buf.as_mut_ptr(),
+                buf.len() as c_int,
+            )
+        };
+        if n <= 0 {
+            return "unknown".to_string();
+        }
+        unsafe { CStr::from_ptr(buf.as_ptr()) }
+            .to_string_lossy()
+            .into_owned()
+    }
+
     /// Transcribe 16 kHz mono `f32` PCM. The internal dispatcher routes
     /// to whichever backend this session was opened with.
     pub fn transcribe(&self, pcm: &[f32]) -> Result<Vec<SessionSegment>, String> {

--- a/crispasr/src/lib.rs
+++ b/crispasr/src/lib.rs
@@ -232,6 +232,12 @@ pub struct SessionSegment {
     pub start: f64,
     pub end: f64,
     pub words: Vec<SessionWord>,
+    /// Whisper's per-segment probability that the segment is non-speech (the
+    /// `<|nospeech|>` token posterior), in `[0, 1]`. Only the whisper backend
+    /// produces it; every other backend leaves the `-1.0` sentinel ("no
+    /// data"), so a consumer can tell "unavailable" apart from a genuine low
+    /// no-speech probability.
+    pub no_speech_prob: f32,
 }
 
 /// Per-frame CTC logits captured from a CTC backend.
@@ -635,11 +641,13 @@ impl Session {
                         confidence: if raw_p < 0.0 { 1.0 } else { raw_p },
                     });
                 }
+                let nsp = crispasr_sys::crispasr_session_result_segment_no_speech_prob(res, i);
                 out.push(SessionSegment {
                     text: text.trim().to_string(),
                     start: t0,
                     end: t1,
                     words,
+                    no_speech_prob: nsp,
                 });
             }
             // Lift out the raw CTC logits (if any) before the handle is freed.
@@ -769,11 +777,13 @@ impl Session {
                         confidence: if raw_p < 0.0 { 1.0 } else { raw_p },
                     });
                 }
+                let nsp = crispasr_sys::crispasr_session_result_segment_no_speech_prob(res, i);
                 out.push(SessionSegment {
                     text: text.trim().to_string(),
                     start: t0,
                     end: t1,
                     words,
+                    no_speech_prob: nsp,
                 });
             }
             crispasr_sys::crispasr_session_result_free(res);

--- a/crispasr/tests/integration.rs
+++ b/crispasr/tests/integration.rs
@@ -224,6 +224,20 @@ fn session_whisper_no_speech_prob() {
 }
 
 #[test]
+fn session_whisper_detected_language() {
+    let model_path = whisper_model();
+    if !Path::new(&model_path).exists() {
+        eprintln!("SKIP: whisper model not found at {model_path}");
+        return;
+    }
+    let sess = crispasr::Session::open(&model_path).expect("session open whisper");
+    // Whisper's in-decode acoustic language detection surfaces on the
+    // exception-safe session (JFK is English).
+    sess.transcribe(&jfk_pcm()).expect("transcribe");
+    assert_eq!(sess.detected_language(), "en");
+}
+
+#[test]
 fn session_available_backends() {
     let backends = crispasr::Session::available_backends();
     assert!(backends.contains(&"whisper".to_string()));

--- a/crispasr/tests/integration.rs
+++ b/crispasr/tests/integration.rs
@@ -193,6 +193,37 @@ fn session_whisper_auto_detect() {
 }
 
 #[test]
+fn session_whisper_no_speech_prob() {
+    let model_path = whisper_model();
+    if !Path::new(&model_path).exists() {
+        eprintln!("SKIP: whisper model not found at {model_path}");
+        return;
+    }
+    let sess = crispasr::Session::open(&model_path).expect("session open whisper");
+    let segs = sess.transcribe(&jfk_pcm()).expect("transcribe");
+    assert!(!segs.is_empty());
+
+    // Every whisper segment carries a real no-speech probability in [0, 1] —
+    // not the -1.0 "no data" sentinel other backends leave. JFK is clean
+    // speech, so the values should also sit well below the 0.6 suspect
+    // threshold, confirming it is the true posterior and not a placeholder.
+    for s in &segs {
+        assert!(
+            (0.0..=1.0).contains(&s.no_speech_prob),
+            "no_speech_prob {} out of [0,1] for segment {:?}",
+            s.no_speech_prob,
+            s.text
+        );
+        assert!(
+            s.no_speech_prob < 0.6,
+            "unexpected high no_speech_prob {} on clean speech {:?}",
+            s.no_speech_prob,
+            s.text
+        );
+    }
+}
+
+#[test]
 fn session_available_backends() {
     let backends = crispasr::Session::available_backends();
     assert!(backends.contains(&"whisper".to_string()));

--- a/flutter/crispasr/lib/src/crispasr.dart
+++ b/flutter/crispasr/lib/src/crispasr.dart
@@ -761,11 +761,16 @@ class SessionSegment {
   final double start; // seconds (centiseconds / 100 on the C side)
   final double end;
   final List<Word> words;
+  /// Whisper's per-segment no-speech probability (the `<|nospeech|>` posterior)
+  /// in [0, 1]. Whisper-only; other backends (and older dylibs without the
+  /// accessor) leave the -1.0 "no data" sentinel.
+  final double noSpeechProb;
   const SessionSegment({
     required this.text,
     required this.start,
     required this.end,
     this.words = const [],
+    this.noSpeechProb = -1.0,
   });
   @override
   String toString() =>
@@ -2127,6 +2132,24 @@ class CrispasrSession {
   String get backend => _backend;
   bool get isClosed => _closed;
 
+  /// The acoustic language Whisper detected on the last transcribe, as an
+  /// ISO-639-1 code ("en"). Whisper-only; other backends return the session's
+  /// source-language hint, or "unknown" (also on dylibs predating the accessor).
+  String detectedLanguage() {
+    if (!_lib.providesSymbol('crispasr_session_detected_language')) return 'unknown';
+    final fn = _lib.lookupFunction<
+        Int32 Function(Pointer<Void>, Pointer<Utf8>, Int32),
+        int Function(Pointer<Void>, Pointer<Utf8>, int)>('crispasr_session_detected_language');
+    final buf = calloc<Uint8>(32);
+    try {
+      fn(_handle, buf.cast<Utf8>(), 32);
+      final s = buf.cast<Utf8>().toDartString();
+      return s.isEmpty ? 'unknown' : s;
+    } finally {
+      calloc.free(buf);
+    }
+  }
+
   /// Transcribe 16 kHz mono float32 PCM. Returns a list of segments
   /// with word-level timings when the backend supports them.
   ///
@@ -2398,6 +2421,14 @@ class CrispasrSession {
     final segT1 = _lib.lookupFunction<
         Int64 Function(Pointer<Void>, Int32),
         int Function(Pointer<Void>, int)>('crispasr_session_result_segment_t1');
+    // Per-segment no_speech_prob (Whisper). Probe like word_p — older dylibs
+    // lack the symbol; fall back to the -1.0 "no data" sentinel.
+    final segNSPFn = _lib.providesSymbol('crispasr_session_result_segment_no_speech_prob')
+        ? _lib.lookupFunction<
+            Float Function(Pointer<Void>, Int32),
+            double Function(Pointer<Void>, int)>(
+            'crispasr_session_result_segment_no_speech_prob')
+        : null;
     final nWords = _lib.lookupFunction<
         Int32 Function(Pointer<Void>, Int32),
         int Function(Pointer<Void>, int)>('crispasr_session_result_n_words');
@@ -2451,6 +2482,7 @@ class CrispasrSession {
       final text = tp == nullptr ? '' : tp.toDartString();
       final t0 = segT0(res, i) / 100.0;
       final t1 = segT1(res, i) / 100.0;
+      final nsp = segNSPFn == null ? -1.0 : segNSPFn(res, i);
       final wc = nWords(res, i);
       final words = <Word>[];
       for (var k = 0; k < wc; k++) {
@@ -2483,7 +2515,7 @@ class CrispasrSession {
           alts: alts,
         ));
       }
-      out.add(SessionSegment(text: text.trim(), start: t0, end: t1, words: words));
+      out.add(SessionSegment(text: text.trim(), start: t0, end: t1, words: words, noSpeechProb: nsp));
     }
     return out;
   }
@@ -4644,6 +4676,13 @@ List<SessionSegment> drainStreamedSegments({String? libPath}) {
   final segT1 = lib.lookupFunction<
       Int64 Function(Pointer<Void>, Int32),
       int Function(Pointer<Void>, int)>('crispasr_session_result_segment_t1');
+  // Per-segment no_speech_prob (Whisper); probe like elsewhere, -1.0 fallback.
+  final segNSPFn = lib.providesSymbol('crispasr_session_result_segment_no_speech_prob')
+      ? lib.lookupFunction<
+          Float Function(Pointer<Void>, Int32),
+          double Function(Pointer<Void>, int)>(
+          'crispasr_session_result_segment_no_speech_prob')
+      : null;
 
   final out = <SessionSegment>[];
   for (var i = 0; i < nSegs; i++) {
@@ -4651,7 +4690,8 @@ List<SessionSegment> drainStreamedSegments({String? libPath}) {
     final text = tp == nullptr ? '' : tp.toDartString();
     final t0 = segT0(res, i) / 100.0;
     final t1 = segT1(res, i) / 100.0;
-    out.add(SessionSegment(text: text.trim(), start: t0, end: t1));
+    final nsp = segNSPFn == null ? -1.0 : segNSPFn(res, i);
+    out.add(SessionSegment(text: text.trim(), start: t0, end: t1, noSpeechProb: nsp));
   }
 
   // Free the result.

--- a/include/crispasr_session.h
+++ b/include/crispasr_session.h
@@ -290,6 +290,10 @@ CRISPASR_SESSION_API const char* crispasr_session_result_word_text(crispasr_sess
 CRISPASR_SESSION_API int64_t crispasr_session_result_word_t0(crispasr_session_result* r, int i_seg, int i_word);
 CRISPASR_SESSION_API int64_t crispasr_session_result_word_t1(crispasr_session_result* r, int i_seg, int i_word);
 CRISPASR_SESSION_API float crispasr_session_result_word_p(crispasr_session_result* r, int i_seg, int i_word);
+// Whisper's per-segment no-speech probability (the <|nospeech|> token
+// posterior) in [0, 1]. Only the whisper backend populates it; other backends
+// and out-of-range indices return the -1.0 sentinel ("no data").
+CRISPASR_SESSION_API float crispasr_session_result_segment_no_speech_prob(crispasr_session_result* r, int i_seg);
 // Per-frame CTC logits (opted in via crispasr_session_set_return_logits) for
 // backends that produce a dense CTC grid (Omni CTC, wav2vec2/hubert/data2vec,
 // canary-ctc). Frame-major: logits[t * n_logit_vocab + v]. Raw pre-softmax for

--- a/include/crispasr_session.h
+++ b/include/crispasr_session.h
@@ -220,6 +220,12 @@ CRISPASR_SESSION_API crispasr_session* crispasr_session_open_with_params(const c
                                                                          const crispasr_open_params_v1* params);
 CRISPASR_SESSION_API const char* crispasr_session_backend(crispasr_session* s);
 CRISPASR_SESSION_API int crispasr_session_available_backends(char* out_csv, int out_cap);
+// Acoustic language detected by the last transcribe, as an ISO-639-1 code
+// (whisper only; other backends fall back to the source-language hint, then
+// "unknown"). Writes into out_buf (NUL-terminated, truncated to out_cap) and
+// returns the code length in bytes, or -1 on bad args. Distinct from the
+// text-LID pass crispasr_text_detect_language.
+CRISPASR_SESSION_API int crispasr_session_detected_language(crispasr_session* s, char* out_buf, int out_cap);
 // CTC vocabulary access (Omni CTC backend). crispasr_session_n_vocab returns
 // the number of SentencePiece pieces in the loaded model (0 for backends that
 // don't expose a CTC vocab); crispasr_session_token_text maps a token id in

--- a/models/convert-omniasr-ctc-to-gguf.py
+++ b/models/convert-omniasr-ctc-to-gguf.py
@@ -51,9 +51,14 @@ def main():
         from safetensors.torch import load_file
         import json
 
-        sf_path = hf_hub_download(args.input, "model.safetensors")
-        cfg_path = hf_hub_download(args.input, "config.json")
-        vocab_path = hf_hub_download(args.input, "vocab.json")
+        if is_local:
+            sf_path = os.path.join(args.input, "model.safetensors")
+            cfg_path = os.path.join(args.input, "config.json")
+            vocab_path = os.path.join(args.input, "vocab.json")
+        else:
+            sf_path = hf_hub_download(args.input, "model.safetensors")
+            cfg_path = hf_hub_download(args.input, "config.json")
+            vocab_path = hf_hub_download(args.input, "vocab.json")
 
         sd_raw = load_file(sf_path)
         with open(cfg_path, encoding="utf-8") as f:

--- a/python/crispasr/_binding.py
+++ b/python/crispasr/_binding.py
@@ -443,6 +443,10 @@ class SessionSegment:
     start: float  # seconds
     end: float    # seconds
     words: List[SessionWord]
+    # Whisper's per-segment no-speech probability (the <|nospeech|> posterior)
+    # in [0, 1]. Whisper-only; other backends (and older libcrispasr builds
+    # without the accessor) leave the -1.0 "no data" sentinel.
+    no_speech_prob: float = -1.0
 
 
 # =========================================================================
@@ -1093,6 +1097,11 @@ class Session:
         lib.crispasr_session_open_explicit.restype = ctypes.c_void_p
         lib.crispasr_session_backend.argtypes = [ctypes.c_void_p]
         lib.crispasr_session_backend.restype = ctypes.c_char_p
+        # Acoustic detected language (Whisper). Probe with hasattr — older
+        # libcrispasr builds don't export it (detected_language() -> "unknown").
+        if hasattr(lib, "crispasr_session_detected_language"):
+            lib.crispasr_session_detected_language.argtypes = [ctypes.c_void_p, ctypes.c_char_p, ctypes.c_int]
+            lib.crispasr_session_detected_language.restype = ctypes.c_int
         lib.crispasr_session_available_backends.argtypes = [ctypes.c_char_p, ctypes.c_int]
         lib.crispasr_session_available_backends.restype = ctypes.c_int
         # 2026-07-08: CTC vocabulary access (Omni CTC backend). n_vocab is the
@@ -1210,6 +1219,11 @@ class Session:
         if hasattr(lib, "crispasr_session_result_word_p"):
             lib.crispasr_session_result_word_p.argtypes = [ctypes.c_void_p, ctypes.c_int, ctypes.c_int]
             lib.crispasr_session_result_word_p.restype = ctypes.c_float
+        # Per-segment no_speech_prob (Whisper). Probe with hasattr like word_p —
+        # older libcrispasr builds don't export it (fall back to the -1.0 sentinel).
+        if hasattr(lib, "crispasr_session_result_segment_no_speech_prob"):
+            lib.crispasr_session_result_segment_no_speech_prob.argtypes = [ctypes.c_void_p, ctypes.c_int]
+            lib.crispasr_session_result_segment_no_speech_prob.restype = ctypes.c_float
         # 0.5.13: per-word top-N alternative candidates.
         if hasattr(lib, "crispasr_session_result_word_n_alts"):
             lib.crispasr_session_result_word_n_alts.argtypes = [ctypes.c_void_p, ctypes.c_int, ctypes.c_int]
@@ -1257,6 +1271,17 @@ class Session:
         csv = buf.value.decode("utf-8")
         return [s.strip() for s in csv.split(",") if s.strip()]
 
+    def detected_language(self) -> str:
+        """The acoustic language Whisper detected on the last transcribe, as an
+        ISO-639-1 code (e.g. "en"). Whisper-only; other backends return the
+        session's source-language hint, or "unknown" (also on libcrispasr
+        builds predating the accessor)."""
+        if not hasattr(self._lib, "crispasr_session_detected_language"):
+            return "unknown"
+        buf = ctypes.create_string_buffer(32)
+        self._lib.crispasr_session_detected_language(self._handle, buf, len(buf))
+        return buf.value.decode("utf-8") or "unknown"
+
     def transcribe(
         self, pcm: np.ndarray, sample_rate: int = 16000,
         *,
@@ -1295,6 +1320,8 @@ class Session:
                 t0 = self._lib.crispasr_session_result_segment_t0(res, i) / 100.0
                 t1 = self._lib.crispasr_session_result_segment_t1(res, i) / 100.0
                 wn = self._lib.crispasr_session_result_n_words(res, i)
+                has_nsp = hasattr(self._lib, "crispasr_session_result_segment_no_speech_prob")
+                nsp = self._lib.crispasr_session_result_segment_no_speech_prob(res, i) if has_nsp else -1.0
                 words: List[SessionWord] = []
                 has_word_p = hasattr(self._lib, "crispasr_session_result_word_p")
                 for j in range(wn):
@@ -1308,7 +1335,7 @@ class Session:
                         # surface 1.0 so callers can render uniformly.
                         confidence=1.0 if raw_p < 0 else raw_p,
                     ))
-                out.append(SessionSegment(text=text.strip(), start=t0, end=t1, words=words))
+                out.append(SessionSegment(text=text.strip(), start=t0, end=t1, words=words, no_speech_prob=nsp))
             return out
         finally:
             self._lib.crispasr_session_result_free(res)
@@ -1376,6 +1403,8 @@ class Session:
                 t0 = self._lib.crispasr_session_result_segment_t0(res, i) / 100.0
                 t1 = self._lib.crispasr_session_result_segment_t1(res, i) / 100.0
                 wn = self._lib.crispasr_session_result_n_words(res, i)
+                has_nsp = hasattr(self._lib, "crispasr_session_result_segment_no_speech_prob")
+                nsp = self._lib.crispasr_session_result_segment_no_speech_prob(res, i) if has_nsp else -1.0
                 words: List[SessionWord] = []
                 for j in range(wn):
                     wt = self._lib.crispasr_session_result_word_text(res, i, j)
@@ -1386,7 +1415,7 @@ class Session:
                         end=self._lib.crispasr_session_result_word_t1(res, i, j) / 100.0,
                         confidence=1.0 if raw_p < 0 else raw_p,
                     ))
-                out.append(SessionSegment(text=text.strip(), start=t0, end=t1, words=words))
+                out.append(SessionSegment(text=text.strip(), start=t0, end=t1, words=words, no_speech_prob=nsp))
             return out
         finally:
             self.set_return_logits(False)
@@ -1498,6 +1527,8 @@ class Session:
                 t0 = self._lib.crispasr_session_result_segment_t0(res, i) / 100.0
                 t1 = self._lib.crispasr_session_result_segment_t1(res, i) / 100.0
                 wn = self._lib.crispasr_session_result_n_words(res, i)
+                has_nsp = hasattr(self._lib, "crispasr_session_result_segment_no_speech_prob")
+                nsp = self._lib.crispasr_session_result_segment_no_speech_prob(res, i) if has_nsp else -1.0
                 words: List[SessionWord] = []
                 has_word_p = hasattr(self._lib, "crispasr_session_result_word_p")
                 for j in range(wn):
@@ -1511,7 +1542,7 @@ class Session:
                         # surface 1.0 so callers can render uniformly.
                         confidence=1.0 if raw_p < 0 else raw_p,
                     ))
-                out.append(SessionSegment(text=text.strip(), start=t0, end=t1, words=words))
+                out.append(SessionSegment(text=text.strip(), start=t0, end=t1, words=words, no_speech_prob=nsp))
             return out
         finally:
             self._lib.crispasr_session_result_free(res)
@@ -1566,6 +1597,8 @@ class Session:
                 t0 = self._lib.crispasr_session_result_segment_t0(res, i) / 100.0
                 t1 = self._lib.crispasr_session_result_segment_t1(res, i) / 100.0
                 wn = self._lib.crispasr_session_result_n_words(res, i)
+                has_nsp = hasattr(self._lib, "crispasr_session_result_segment_no_speech_prob")
+                nsp = self._lib.crispasr_session_result_segment_no_speech_prob(res, i) if has_nsp else -1.0
                 words: List[SessionWord] = []
                 for j in range(wn):
                     wt = self._lib.crispasr_session_result_word_text(res, i, j)
@@ -1576,7 +1609,7 @@ class Session:
                         end=self._lib.crispasr_session_result_word_t1(res, i, j) / 100.0,
                         confidence=1.0 if raw_p < 0 else raw_p,
                     ))
-                segs.append(SessionSegment(text=text.strip(), start=t0, end=t1, words=words))
+                segs.append(SessionSegment(text=text.strip(), start=t0, end=t1, words=words, no_speech_prob=nsp))
 
             # Lift out the CTC logits (if any) before the handle is freed.
             n_frames = self._lib.crispasr_session_result_n_logit_frames(res)

--- a/src/canary_ctc.cpp
+++ b/src/canary_ctc.cpp
@@ -801,6 +801,14 @@ extern "C" void canary_ctc_free(struct canary_ctc_context* ctx) {
 extern "C" int canary_ctc_n_vocab(struct canary_ctc_context* ctx) {
     return (int)ctx->model.hparams.vocab_size;
 }
+// SentencePiece piece string for a token id (the id_to_token loaded from the GGUF); "" when the id is
+// out of range or the GGUF carried no token strings. The CTC blank is a separate appended index
+// (blank_id), not a piece, so it is not addressable here — consumers iterate [0, n_vocab).
+extern "C" const char* canary_ctc_token_text(struct canary_ctc_context* ctx, int id) {
+    if (!ctx || id < 0 || id >= (int)ctx->vocab.id_to_token.size())
+        return "";
+    return ctx->vocab.id_to_token[id].c_str();
+}
 extern "C" int canary_ctc_blank_id(struct canary_ctc_context* ctx) {
     return (int)ctx->model.hparams.blank_id;
 }

--- a/src/canary_ctc.h
+++ b/src/canary_ctc.h
@@ -102,6 +102,8 @@ void canary_ctc_decode_result_free(struct canary_ctc_decode_result* r);
 
 // Hyperparameters
 int canary_ctc_n_vocab(struct canary_ctc_context* ctx);
+// SentencePiece piece string for a token id in [0, n_vocab); "" if out of range / no tokens loaded.
+const char* canary_ctc_token_text(struct canary_ctc_context* ctx, int id);
 int canary_ctc_blank_id(struct canary_ctc_context* ctx);
 int canary_ctc_frame_dur_cs(struct canary_ctc_context* ctx);
 int canary_ctc_n_mels(struct canary_ctc_context* ctx);

--- a/src/crispasr_c_api.cpp
+++ b/src/crispasr_c_api.cpp
@@ -1466,6 +1466,14 @@ struct crispasr_session {
     bool punctuation = true;     // canary/cohere per-call arg + post-process gate
     bool translate = false;      // whisper sticky --translate (others: use src/tgt mismatch)
 
+    // Acoustic language detected by the last transcribe (whisper only —
+    // whisper_full_lang_id → whisper_lang_str, an ISO-639-1 code). Set on
+    // every whisper dispatch; empty for other backends, where
+    // crispasr_session_detected_language falls back to the source-language
+    // hint or "unknown". This is the in-decode acoustic signal, distinct
+    // from the backend-agnostic text-LID pass (crispasr_text_detect_language).
+    std::string detected_lang;
+
     // --punc-model post-processor (set via crispasr_session_set_punc_model).
     // Held as void* so the struct doesn't depend on the optionally-compiled
     // fireredpunc/pcs headers; at most one is non-null. Applied per segment
@@ -3448,6 +3456,28 @@ CA_EXPORT const char* crispasr_session_backend(crispasr_session* s) {
     return s ? s->backend.c_str() : "";
 }
 
+// Acoustic language detected by the last transcribe, written into `out_buf` as
+// an ISO-639-1 code (e.g. "en"). Only whisper decodes an in-session acoustic
+// language; other backends (and whisper before its first pass) fall back to
+// the session's source-language hint, then "unknown". Returns the code length
+// (bytes, not counting NUL) or -1 on bad args. This is distinct from the
+// backend-agnostic text-LID pass (crispasr_text_detect_language), which runs
+// CLD3 + fastText over the transcript.
+CA_EXPORT int crispasr_session_detected_language(crispasr_session* s, char* out_buf, int out_cap) {
+    if (!s || !out_buf || out_cap <= 0)
+        return -1;
+    std::string lang;
+    if (!s->detected_lang.empty())
+        lang = s->detected_lang;
+    else if (!s->source_language.empty())
+        lang = s->source_language;
+    else
+        lang = "unknown";
+    std::strncpy(out_buf, lang.c_str(), out_cap - 1);
+    out_buf[out_cap - 1] = '\0';
+    return (int)lang.size();
+}
+
 // CTC vocabulary access (Omni CTC backend). Surfaces the SentencePiece pieces
 // already loaded from the GGUF so callers can detokenize a greedy CTC decode
 // over crispasr_session_result_logits. Returns 0 / "" for other backends.
@@ -4398,6 +4428,15 @@ static crispasr_session_result* transcribe_single(crispasr_session* s, const flo
             _fire_token_callbacks(s, toks);
             seg.words = emit_words_from_tokens(toks);
             r->segments.push_back(std::move(seg));
+        }
+        // Record the acoustic language whisper auto-detected on this pass so
+        // crispasr_session_detected_language can surface it (ISO-639-1). The
+        // id indexes whisper's static language table; whisper_lang_str returns
+        // a pointer into that table (nothing to free).
+        {
+            const int lang_id = whisper_full_lang_id(s->whisper_ctx);
+            const char* code = lang_id >= 0 ? whisper_lang_str(lang_id) : nullptr;
+            s->detected_lang = code ? code : "";
         }
         return r;
     }

--- a/src/crispasr_c_api.cpp
+++ b/src/crispasr_c_api.cpp
@@ -3453,6 +3453,15 @@ CA_EXPORT int crispasr_session_n_vocab(crispasr_session* s) {
     if ((s->backend.rfind("omniasr", 0) == 0) && s->omniasr_ctx)
         return omniasr_n_vocab((omniasr_context*)s->omniasr_ctx);
 #endif
+#ifdef CA_HAVE_WAV2VEC2
+    if ((s->backend == "wav2vec2" || s->backend == "hubert" || s->backend == "data2vec") &&
+        s->wav2vec2_ctx)
+        return (int)s->wav2vec2_ctx->vocab.size();
+#endif
+#ifdef CA_HAVE_CTC
+    if ((s->backend == "canary-ctc" || s->backend == "fastconformer-ctc") && s->ctc_ctx)
+        return canary_ctc_n_vocab(s->ctc_ctx);
+#endif
     return 0;
 }
 
@@ -3462,6 +3471,17 @@ CA_EXPORT const char* crispasr_session_token_text(crispasr_session* s, int id) {
 #ifdef CA_HAVE_OMNIASR
     if ((s->backend.rfind("omniasr", 0) == 0) && s->omniasr_ctx)
         return omniasr_token_text((omniasr_context*)s->omniasr_ctx, id);
+#endif
+#ifdef CA_HAVE_WAV2VEC2
+    if ((s->backend == "wav2vec2" || s->backend == "hubert" || s->backend == "data2vec") &&
+        s->wav2vec2_ctx) {
+        const auto& v = s->wav2vec2_ctx->vocab;
+        return (id < (int)v.size()) ? v[id].c_str() : "";
+    }
+#endif
+#ifdef CA_HAVE_CTC
+    if ((s->backend == "canary-ctc" || s->backend == "fastconformer-ctc") && s->ctc_ctx)
+        return canary_ctc_token_text(s->ctc_ctx, id);
 #endif
     return "";
 }

--- a/src/crispasr_c_api.cpp
+++ b/src/crispasr_c_api.cpp
@@ -1424,6 +1424,12 @@ struct crispasr_session_seg {
     std::string text;
     int64_t t0 = 0; // centiseconds absolute
     int64_t t1 = 0;
+    // Whisper's per-segment probability that the segment is non-speech (the
+    // <|nospeech|> token posterior). Only the whisper branch populates it;
+    // every other backend leaves the -1.0 sentinel ("no signal", never a
+    // real [0,1] probability) so a consumer can tell "unavailable" apart
+    // from a genuine low no-speech probability.
+    float no_speech_prob = -1.0f;
     struct word_alt {
         std::string text;
         float p = 0.0f;
@@ -4347,6 +4353,7 @@ static crispasr_session_result* transcribe_single(crispasr_session* s, const flo
                 seg.text = t;
             seg.t0 = whisper_full_get_segment_t0(s->whisper_ctx, i);
             seg.t1 = whisper_full_get_segment_t1(s->whisper_ctx, i);
+            seg.no_speech_prob = whisper_full_get_segment_no_speech_prob(s->whisper_ctx, i);
 
             // Convert whisper's per-token output into the unified
             // ca_token_record shape and run it through
@@ -6597,6 +6604,16 @@ CA_EXPORT float crispasr_session_result_word_p(crispasr_session_result* r, int i
         return -1.0f;
     auto& ws = r->segments[i_seg].words;
     return (i_word >= 0 && i_word < (int)ws.size()) ? ws[i_word].p : -1.0f;
+}
+
+// Whisper's per-segment no-speech probability (the <|nospeech|> token
+// posterior), in [0, 1]. Only the whisper backend populates it; other
+// backends and out-of-range indices return the -1.0 sentinel so callers can
+// tell "unavailable" apart from a genuine low probability.
+CA_EXPORT float crispasr_session_result_segment_no_speech_prob(crispasr_session_result* r, int i_seg) {
+    if (!r || i_seg < 0 || i_seg >= (int)r->segments.size())
+        return -1.0f;
+    return r->segments[i_seg].no_speech_prob;
 }
 
 // Per-frame CTC logits (opted in via crispasr_session_set_return_logits) for

--- a/src/crispasr_c_api.cpp
+++ b/src/crispasr_c_api.cpp
@@ -1303,6 +1303,12 @@ CA_EXPORT int crispasr_detect_backend_from_gguf(const char* path, char* out_name
         backend = "canary-ctc";
     else if (strcmp(arch, "wav2vec2") == 0)
         backend = "wav2vec2";
+    // Both the Omni ASR CTC and LLM converters write general.architecture="omniasr-ctc"
+    // (see models/convert-omniasr-{ctc,llm}-to-gguf.py); the "omniasr" backend prefix-matches
+    // every omniasr-* variant and reads model_type from the GGUF to route CTC vs LLM.
+    else if (strcmp(arch, "omniasr-ctc") == 0 || strcmp(arch, "omniasr-llm") == 0 ||
+             strcmp(arch, "omniasr") == 0)
+        backend = "omniasr";
     else if (strcmp(arch, "vibevoice-asr") == 0 || strcmp(arch, "vibevoice") == 0 || strcmp(arch, "vibevoice-tts") == 0)
         backend = "vibevoice";
     else if (strcmp(arch, "qwen3-tts") == 0 || strcmp(arch, "qwen3_tts") == 0)

--- a/src/crispasr_c_api.cpp
+++ b/src/crispasr_c_api.cpp
@@ -1306,8 +1306,7 @@ CA_EXPORT int crispasr_detect_backend_from_gguf(const char* path, char* out_name
     // Both the Omni ASR CTC and LLM converters write general.architecture="omniasr-ctc"
     // (see models/convert-omniasr-{ctc,llm}-to-gguf.py); the "omniasr" backend prefix-matches
     // every omniasr-* variant and reads model_type from the GGUF to route CTC vs LLM.
-    else if (strcmp(arch, "omniasr-ctc") == 0 || strcmp(arch, "omniasr-llm") == 0 ||
-             strcmp(arch, "omniasr") == 0)
+    else if (strcmp(arch, "omniasr-ctc") == 0 || strcmp(arch, "omniasr-llm") == 0 || strcmp(arch, "omniasr") == 0)
         backend = "omniasr";
     else if (strcmp(arch, "vibevoice-asr") == 0 || strcmp(arch, "vibevoice") == 0 || strcmp(arch, "vibevoice-tts") == 0)
         backend = "vibevoice";
@@ -3454,8 +3453,7 @@ CA_EXPORT int crispasr_session_n_vocab(crispasr_session* s) {
         return omniasr_n_vocab((omniasr_context*)s->omniasr_ctx);
 #endif
 #ifdef CA_HAVE_WAV2VEC2
-    if ((s->backend == "wav2vec2" || s->backend == "hubert" || s->backend == "data2vec") &&
-        s->wav2vec2_ctx)
+    if ((s->backend == "wav2vec2" || s->backend == "hubert" || s->backend == "data2vec") && s->wav2vec2_ctx)
         return (int)s->wav2vec2_ctx->vocab.size();
 #endif
 #ifdef CA_HAVE_CTC
@@ -3473,8 +3471,7 @@ CA_EXPORT const char* crispasr_session_token_text(crispasr_session* s, int id) {
         return omniasr_token_text((omniasr_context*)s->omniasr_ctx, id);
 #endif
 #ifdef CA_HAVE_WAV2VEC2
-    if ((s->backend == "wav2vec2" || s->backend == "hubert" || s->backend == "data2vec") &&
-        s->wav2vec2_ctx) {
+    if ((s->backend == "wav2vec2" || s->backend == "hubert" || s->backend == "data2vec") && s->wav2vec2_ctx) {
         const auto& v = s->wav2vec2_ctx->vocab;
         return (id < (int)v.size()) ? v[id].c_str() : "";
     }


### PR DESCRIPTION
## Summary

This bundles several enhancements to the **exception-safe session API**
(`crispasr_session_*`). The common thread: the
exception-safe session is the fault-isolated path a downstream integrator must
use (a native segfault / accelerator OOM stays contained), but several useful
signals were only reachable on the abort-prone legacy `whisper_context` /
per-backend paths. These changes surface them on the session and mirror them
across the language bindings.

Each item is independent; can split into separate PRs if you'd prefer to
review/merge them piecemeal.

## Changes

### 1. CTC vocab accessor (`Session::ctc_vocab`, comprehensive)
Expose the CTC output vocabulary on the session so the logit grid above is
interpretable (token id → symbol, blank id, word-boundary token). Made
comprehensive across the same CTC backends via the existing exported functions
(internal dispatch only — no binding changes).

### 2. Whisper `no_speech_prob` on the exception-safe session
The per-segment `<|nospeech|>` posterior existed on the legacy
`whisper_full_get_segment_no_speech_prob` path but was absent from
`crispasr_session_result`. Thread it through in the Whisper branch (sentinel for
non-Whisper backends) and add the C-ABI + Rust accessor.

### 3. Whisper `detected_language` on the exception-safe session
The in-decode acoustic language id (`whisper_full_lang_id_from_state` +
`whisper_lang_str`) was only on the legacy `CrispASR` wrapper. Add
`crispasr_session_detected_language(...)` and `Session::detected_language()`,
mirroring the legacy behavior; non-Whisper backends return the input
language / `"unknown"` (text-LID remains the separate backend-agnostic path).

### 4. Binding mirror
Mirror the two new Whisper accessors across the language bindings
(csharp / go / java / javascript / ruby / python / flutter-dart), keeping the
per-binding lint/test CI green — same rollout pattern as prior accessor work.

## Testing
- Session results carry a real per-segment `no_speech_prob` and a
  `detected_language` matching the legacy `whisper_context` path on a fixture.
- clang-format-18 applied to touched C++; per-binding CI green.