### PR TITLE
fix(session): plumb use_gpu into firered-asr open; map firered-asr in GGUF autodetect

### DIFF
--- a/src/crispasr_c_api.cpp
+++ b/src/crispasr_c_api.cpp
@@ -1371,6 +1371,8 @@ CA_EXPORT int crispasr_detect_backend_from_gguf(const char* path, char* out_name
         backend = "canary-ctc";
     else if (strcmp(arch, "wav2vec2") == 0)
         backend = "wav2vec2";
+    else if (strcmp(arch, "firered-asr") == 0 || strcmp(arch, "firered") == 0)
+        backend = "firered-asr";
     // Both the Omni ASR CTC and LLM converters write general.architecture="omniasr-ctc"
     // (see models/convert-omniasr-{ctc,llm}-to-gguf.py); the "omniasr" backend prefix-matches
     // every omniasr-* variant and reads model_type from the GGUF to route CTC vs LLM.
@@ -2670,6 +2672,7 @@ CA_EXPORT crispasr_session* crispasr_session_open_explicit(const char* model_pat
     if (s->backend == "firered-asr" || s->backend == "firered") {
         firered_asr_context_params p = firered_asr_context_default_params();
         p.n_threads = s->n_threads;
+        p.use_gpu = g_open_use_gpu_tls;
         s->firered_ctx = firered_asr_init_from_file(model_path, p);
         if (!s->firered_ctx) {
             delete s;


### PR DESCRIPTION
Two small firered-asr fixes, found while embedding crispasr-sys in a downstream app that gates FireRed between CPU and Metal:

- `crispasr_session_open_explicit` now sets `p.use_gpu = g_open_use_gpu_tls` for the firered-asr backend, the same way every other backend branch already does. Without it the caller's CPU/GPU choice is silently ignored for firered sessions (the context always opens with the default).
- `crispasr_detect_backend_from_gguf` now maps `general.architecture` `firered-asr`/`firered` to the `firered-asr` backend, so FireRed GGUFs autodetect like the other architectures instead of falling through unrecognized.