### PR TITLE
build(sys): disable ggml ccache auto-detection

### DIFF
--- a/crispasr-sys/build.rs
+++ b/crispasr-sys/build.rs
@@ -198,6 +198,13 @@ fn configure_and_build(src_root: &Path) -> PathBuf {
             .arg("-DCMAKE_CXX_COMPILER_LAUNCHER=ccache");
     }
 
+    // ggml's own cmake auto-detects ccache/sccache as a compiler launcher.
+    // Under the Ninja generator, sccache fails on the GGML_METAL_EMBED_LIBRARY
+    // assembly object (ninja emits depfile rules for the .s compile; sccache
+    // cannot produce the .d and aborts the build). The explicit ccache
+    // launcher above is unaffected, so just disable ggml's auto-detection.
+    configure.arg("-DGGML_CCACHE=OFF");
+
     if cfg!(feature = "cuda") {
         configure.arg("-DGGML_CUDA=ON");
     }


### PR DESCRIPTION
ggml's own cmake auto-detects ccache/sccache as a compiler launcher. Under the Ninja generator, sccache breaks the build on the `GGML_METAL_EMBED_LIBRARY` assembly object: ninja emits depfile rules for the `.s` compile, sccache cannot produce the `.d`, and the build aborts.

build.rs already wires plain ccache explicitly as the launcher when present (with the `CRISPASR_NO_CCACHE` opt-out), and that path is unaffected — so passing `-DGGML_CCACHE=OFF` loses no caching, it just stops ggml from silently picking up sccache and failing on machines that have it on PATH (e.g. Rust CI boxes using `RUSTC_WRAPPER=sccache`).