### PR TITLE
build(sys): disable opus/amr file-decode extras

### DIFF
--- a/crispasr-sys/build.rs
+++ b/crispasr-sys/build.rs
@@ -198,6 +198,14 @@ fn configure_and_build(src_root: &Path) -> PathBuf {
             .arg("-DCMAKE_CXX_COMPILER_LAUNCHER=ccache");
     }
 
+    // The session/back-end library is consumed with raw PCM input; the
+    // optional .opus/.amr file-decode extras would link Homebrew/system
+    // dylibs by absolute path (libopusfile, libopencore-amr, ...) and break
+    // the library on machines without them. Keep the build self-contained.
+    configure
+        .arg("-DCRISPASR_OPUS=OFF")
+        .arg("-DCRISPASR_AMR=OFF");
+
     if cfg!(feature = "cuda") {
         configure.arg("-DGGML_CUDA=ON");
     }


### PR DESCRIPTION
When crispasr-sys drives the cmake build itself (the OUT_DIR fallback path), the optional `.opus`/`.amr` file-decode extras link Homebrew/system dylibs by absolute path (`libopusfile`, `libopencore-amr`, ...). The produced `libcrispasr` then fails to load on any machine that doesn't have those packages installed — a real problem when the crate is embedded in a redistributable app.

Sys-crate consumers feed raw PCM through the C API, so the file-decode extras are unused on this path anyway. This only changes the build.rs-driven configure; the CMake project defaults are untouched for people running cmake directly.