### PR TITLE
build: make the shipped library file name configurable

### DIFF
--- a/crispasr-sys/build.rs
+++ b/crispasr-sys/build.rs
@@ -198,6 +198,10 @@ fn configure_and_build(src_root: &Path) -> PathBuf {
             .arg("-DCMAKE_CXX_COMPILER_LAUNCHER=ccache");
     }
 
+    // Rebrandable library file name (CRISPASR_LIB_NAME env, also used for the
+    // link-lib directive) — keeps downstream bundles free of the project name.
+    configure.arg(format!("-DCRISPASR_LIB_OUTPUT_NAME={}", link_lib_name()));
+
     if cfg!(feature = "cuda") {
         configure.arg("-DGGML_CUDA=ON");
     }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -218,10 +218,13 @@ if(APPLE)
         PROPERTIES LANGUAGE OBJCXX)
 endif()
 
+# Downstream bundlers can rebrand the shipped library file name (the C API
+# symbols are unchanged). Defaults to the historical "crispasr".
+set(CRISPASR_LIB_OUTPUT_NAME "crispasr" CACHE STRING "Base file name for the built library")
 set_target_properties(crispasr-lib PROPERTIES
     VERSION ${PROJECT_VERSION}
     SOVERSION ${SOVERSION}
-    OUTPUT_NAME crispasr
+    OUTPUT_NAME ${CRISPASR_LIB_OUTPUT_NAME}
 )
 
 target_include_directories(crispasr-lib PUBLIC . ../include)


### PR DESCRIPTION
Adds a `CRISPASR_LIB_OUTPUT_NAME` cache variable for the library file name (default stays `crispasr`, so existing builds are unchanged) and has build.rs pass `link_lib_name()` through, so the existing `CRISPASR_LIB_NAME` env var now controls both the `cargo:rustc-link-lib` directive and the file name cmake actually produces.

The C API symbols are unchanged — this just lets downstream bundlers ship the dylib under their own name instead of post-processing/renaming it (and, before this, the rename would break the link since build.rs already supported `CRISPASR_LIB_NAME` but the build always emitted `libcrispasr`).