### PR TITLE
fix(audio): preserve unity gain when downsampling

### DIFF
--- a/src/core/audio_resample.cpp
+++ b/src/core/audio_resample.cpp
@@ -122,7 +122,7 @@ std::vector<float> resample_polyphase(const float* in, int n_in, int src_rate, i
         // Compensate for the implicit factor-L upsample (zero-stuffing
         // multiplies the spectrum by 1/L; a corresponding factor-L gain
         // restores unity DC).
-        out[(size_t)i] = (float)(s * (double)up);
+        out[(size_t)i] = (float)(s * (double)L);
     }
     return out;
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -279,6 +279,22 @@ catch_discover_tests(test-cpu-ops-to-f32
     PROPERTIES LABELS "unit"
 )
 
+# Regression guard for polyphase resampler gain compensation.
+add_executable(test-audio-resample
+    test-audio-resample.cpp
+    ${PROJECT_SOURCE_DIR}/src/core/audio_resample.cpp
+)
+target_include_directories(test-audio-resample PRIVATE
+    ${PROJECT_SOURCE_DIR}/src
+)
+target_link_libraries(test-audio-resample PRIVATE
+    Catch2::Catch2WithMain
+)
+catch_discover_tests(test-audio-resample
+    TEST_SPEC "[unit]"
+    PROPERTIES LABELS "unit"
+)
+
 # ─── test-core-rvq — core_rvq::encode_euclidean vs full-distance reference ─────
 # Proves the 2·x·E−‖E‖² shootout selects the same codes as a direct argmin
 # (the correctness property behind §176l routing kyutai through core_rvq).

--- a/tests/test-audio-resample.cpp
+++ b/tests/test-audio-resample.cpp
@@ -1,0 +1,45 @@
+#include "core/audio_resample.h"
+
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
+
+#include <cstddef>
+#include <vector>
+
+namespace {
+
+float interior_mean(const std::vector<float>& samples) {
+    constexpr size_t edge = 128;
+    REQUIRE(samples.size() > 2 * edge);
+
+    double sum = 0.0;
+    for (size_t i = edge; i < samples.size() - edge; ++i) {
+        sum += samples[i];
+    }
+    return static_cast<float>(sum / static_cast<double>(samples.size() - 2 * edge));
+}
+
+} // namespace
+
+TEST_CASE("polyphase resampling preserves DC gain", "[unit][audio-resample]") {
+    constexpr float level = 0.25f;
+    const std::vector<float> input(48000, level);
+
+    SECTION("48 kHz to 24 kHz") {
+        const auto output = core_audio::resample_polyphase(input.data(), static_cast<int>(input.size()), 48000, 24000);
+        REQUIRE(output.size() == 24000);
+        REQUIRE(interior_mean(output) == Catch::Approx(level).margin(5e-4f));
+    }
+
+    SECTION("24 kHz to 16 kHz") {
+        const auto output = core_audio::resample_polyphase(input.data(), static_cast<int>(input.size()), 24000, 16000);
+        REQUIRE(output.size() == 32000);
+        REQUIRE(interior_mean(output) == Catch::Approx(level).margin(5e-4f));
+    }
+
+    SECTION("24 kHz to 48 kHz") {
+        const auto output = core_audio::resample_polyphase(input.data(), static_cast<int>(input.size()), 24000, 48000);
+        REQUIRE(output.size() == 96000);
+        REQUIRE(interior_mean(output) == Catch::Approx(level).margin(5e-4f));
+    }
+}


### PR DESCRIPTION
## Summary

- use the reduced rational ratio's interpolation factor `L` for polyphase gain compensation
- prevent downsampling from amplifying audio (2x at 48 kHz -> 24 kHz; 1.5x at 24 kHz -> 16 kHz)
- add a focused regression test covering two downsampling ratios and one upsampling ratio

## Why

The filter compensates for zero-stuffing by multiplying by the interpolation factor `L`. The previous code multiplied by `max(L, M)`, which is only equivalent while upsampling. When `M > L`, output amplitude was scaled by `M / L`.

## Validation

- clang-format 18 check passes
- `test-audio-resample [unit]`: 9 assertions pass
- tested 48 -> 24 kHz, 24 -> 16 kHz, and 24 -> 48 kHz DC gain preservation

## AI provenance

The regression analysis, implementation, tests, and PR description were produced by **OpenAI Codex, GPT-5.6-sol (high reasoning)** under @KevinAHM's direction. Codex also executed the local formatting, build, and test validation reported above.