### PR TITLE
fix(omnivoice): restore reference loudness after decoding

### DIFF
--- a/src/omnivoice.cpp
+++ b/src/omnivoice.cpp
@@ -378,6 +378,7 @@ struct omnivoice_context {
     // Voice cloning state
     std::vector<int32_t> ref_audio_codes; // (n_codebooks, T_ref) row-major
     int ref_T = 0;
+    float ref_rms = 0.0f;
     std::string ref_text;
 
     // Language / instruct
@@ -3363,6 +3364,7 @@ int omnivoice_set_voice_prompt(struct omnivoice_context* ctx, const char* wav_pa
     if (!wav_path || !*wav_path) {
         ctx->ref_audio_codes.clear();
         ctx->ref_T = 0;
+        ctx->ref_rms = 0.0f;
         ctx->ref_text.clear();
         return 0;
     }
@@ -3470,6 +3472,7 @@ int omnivoice_set_voice_prompt(struct omnivoice_context* ctx, const char* wav_pa
     }
     ctx->ref_audio_codes = std::move(codes);
     ctx->ref_T = T_ref;
+    ctx->ref_rms = rms;
     return 0;
 }
 
@@ -3550,6 +3553,15 @@ float* omnivoice_decode_codes(struct omnivoice_context* ctx, const int32_t* code
     if (pcm.empty()) {
         *out_n_samples = 0;
         return nullptr;
+    }
+
+    // Match the reference implementation's post-processing: quiet prompts are
+    // normalized to 0.1 RMS for encoding, then decoded audio is restored to the
+    // prompt's original loudness.
+    if (ctx->ref_rms > 0.0f && ctx->ref_rms < 0.1f) {
+        const float gain = ctx->ref_rms / 0.1f;
+        for (float& sample : pcm)
+            sample *= gain;
     }
 
     int n = (int)pcm.size();


### PR DESCRIPTION
## Summary

- retain the reference prompt's original RMS before the existing 0.1-RMS encoder normalization
- restore decoded audio to that original loudness when a quiet prompt was normalized
- clear the stored RMS when the voice prompt is cleared

## Why

The official OmniVoice inference path normalizes quiet reference audio to 0.1 RMS before encoding and applies the inverse gain after decoding. CrispASR already performed the encoder-side normalization but discarded the original RMS, leaving decoded speech at the normalized level and making it substantially louder than the prompt.

This PR adds the missing post-processing without changing the public API or server/Python layers.

## Relationship to #277

This is complementary to #277 and is kept separate for reviewability. For quiet prompts already at 24 kHz, this change stands alone. For prompts that require resampling, #277 should also land so the original RMS is measured at unity gain.

## Validation

- clang-format 18 check passes
- focused `omnivoice` native target compiles and links successfully
- combined end-to-end CUDA validation on the reported voice reduced output from RMS 0.1488 / peak 1.0 with clipping to RMS 0.0667 / peak 0.539 with no clipped samples

## AI provenance

The reference comparison, root-cause analysis, implementation, validation, and PR description were produced by **OpenAI Codex, GPT-5.6-sol (high reasoning)** under @KevinAHM's direction. Codex executed the local formatting, build, and audio-output validation reported above.