### PR TITLE
fix(omnivoice): honor TTS seed controls

### DIFF
--- a/src/crispasr_c_api.cpp
+++ b/src/crispasr_c_api.cpp
@@ -2644,6 +2644,7 @@ CA_EXPORT crispasr_session* crispasr_session_open_explicit(const char* model_pat
         p.verbosity = g_open_verbosity_tls;
         p.use_gpu = g_open_use_gpu_tls;
         p.flash_attn = g_open_flash_attn_tls;
+        p.seed = g_open_seed_tls;
         s->omnivoice_ctx = omnivoice_init_from_file(model_path, p);
         if (!s->omnivoice_ctx) {
             delete s;
@@ -9216,9 +9217,8 @@ CA_EXPORT int crispasr_session_set_temperature(crispasr_session* s, float temper
     return touched > 0 ? 0 : -2;
 }
 
-// Set the seed for sampling-capable TTS backends. This currently
-// covers chatterbox, vibevoice, qwen3-tts, and orpheus. Other
-// backends silently no-op (rc=-2).
+// Set the seed for sampling-capable TTS backends. Unsupported backends
+// silently no-op (rc=-2).
 CA_EXPORT int crispasr_session_set_tts_seed(crispasr_session* s, uint64_t seed) {
     if (!s)
         return -1;
@@ -9304,6 +9304,12 @@ CA_EXPORT int crispasr_session_set_tts_seed(crispasr_session* s, uint64_t seed) 
 #ifdef CA_HAVE_MOSS_TTS_LOCAL
     if (s->moss_tts_local_ctx) {
         moss_tts_local_set_seed(s->moss_tts_local_ctx, (uint32_t)seed);
+        touched++;
+    }
+#endif
+#ifdef CA_HAVE_OMNIVOICE
+    if (s->omnivoice_ctx) {
+        omnivoice_set_seed(s->omnivoice_ctx, seed);
         touched++;
     }
 #endif

--- a/src/omnivoice.cpp
+++ b/src/omnivoice.cpp
@@ -3502,6 +3502,13 @@ int omnivoice_set_num_steps(struct omnivoice_context* ctx, int num_steps) {
     return 0;
 }
 
+int omnivoice_set_seed(struct omnivoice_context* ctx, uint64_t seed) {
+    if (!ctx)
+        return -1;
+    ctx->gen.seed = seed;
+    return 0;
+}
+
 int32_t* omnivoice_synthesize_codes(struct omnivoice_context* ctx, const char* text, int* out_n_codes) {
     if (!ctx || !text || !out_n_codes)
         return nullptr;

--- a/src/omnivoice.h
+++ b/src/omnivoice.h
@@ -74,6 +74,9 @@ int omnivoice_set_speed(struct omnivoice_context* ctx, float speed);
 // Read live per synthesize (no reload). Values <1 are ignored. (#254)
 int omnivoice_set_num_steps(struct omnivoice_context* ctx, int num_steps);
 
+// Set the sampling seed for subsequent synthesis calls.
+int omnivoice_set_seed(struct omnivoice_context* ctx, uint64_t seed);
+
 // Run the masked iterative generation: text → 8-codebook audio codes.
 // Returns malloc'd int32_t array of shape (n_codebooks * T) row-major
 // [cb0_t0, cb1_t0, ..., cb7_t0, cb0_t1, ...].


### PR DESCRIPTION
## Summary

- pass the configured session-open seed into the OmniVoice context
- route live `crispasr_session_set_tts_seed` calls to OmniVoice
- expose a small backend setter so subsequent syntheses use the requested seed

## Why

OmniVoice already samples from a generator-local `std::mt19937`, but the C API never forwarded either the session-open seed or later `set_tts_seed` calls to that generator. The setter therefore returned the unsupported-backend result and different requested seeds produced the same output.

This PR connects the existing seed controls without changing the public API or the server/Python layers.

## Validation

- clang-format 18 check passes
- focused `omnivoice` target and `crispasr_c_api.cpp` translation unit compile successfully
- all 26 existing session-setter tests pass
- end-to-end CUDA validation on one live session with seeds `111`, `222`, then `111` produced byte-identical codes for the repeated seed, while the two different seeds differed at 97.45% of code positions

## AI provenance

The root-cause analysis, implementation, validation, and PR description were produced by **OpenAI Codex, GPT-5.6-sol (high reasoning)** under @KevinAHM's direction. Codex executed the local formatting, build, session-setter tests, and end-to-end seed validation reported above.