### PR TITLE
fix(session): load dynamic GPU backends for library consumers

### DIFF
--- a/src/crispasr_c_api.cpp
+++ b/src/crispasr_c_api.cpp
@@ -1492,6 +1492,15 @@ static thread_local int g_open_n_gpu_layers_tls = -1;
 static thread_local float g_open_temperature_tls = 0.0f;
 static thread_local uint64_t g_open_seed_tls = 0;
 
+// CLI entry points load dynamic GGML plugins during startup, but direct C ABI
+// consumers (Python, Dart, Rust, Go) have no CLI main(). Load them lazily on
+// the first GPU session open, once across all caller threads.
+static std::once_flag g_dynamic_backends_once;
+
+static void ensure_dynamic_backends_loaded() {
+    std::call_once(g_dynamic_backends_once, []() { ggml_backend_load_all(); });
+}
+
 // Defined ahead of crispasr_session so the session can hold its own
 // streamed-segment polling buffer (see the Dart FFI polling API below).
 struct crispasr_session_seg {
@@ -2226,6 +2235,9 @@ CA_EXPORT crispasr_session* crispasr_session_open_explicit(const char* model_pat
                                                            int n_threads) {
     if (!model_path || !backend_name)
         return nullptr;
+
+    if (g_open_use_gpu_tls)
+        ensure_dynamic_backends_loaded();
 
     auto* s = new crispasr_session();
     s->model_path = model_path;


### PR DESCRIPTION
## Summary

- Load dynamic GGML backends before the first GPU-enabled unified session opens.
- Use `std::call_once` so concurrent C-ABI consumers cannot race plugin registration.
- Leave CPU-only session opens unchanged.

## Why

CrispASR CLI entry points call `ggml_backend_load_all()` during startup. Direct library consumers—Python ctypes, Dart FFI, Rust, and Go—have no CLI startup path, so CUDA/Vulkan DLLs can be present while a unified session silently selects CPU.

This change belongs in a separate PR from the upcoming Sidon backend because the behavior is backend-agnostic and independently useful to every library consumer.

## Validation

- `clang-format` 18.1.8: clean
- MSVC Release build: `crispasr-lib`
- ctypes runtime with the packaged compatible GGML/CUDA DLL set:
  - `ggml-cuda.dll` loaded from a normal session open
  - RTX 5070 Ti detected (16,302 MiB VRAM)
  - `GetModuleHandleW(ggml-cuda.dll)` confirmed the plugin remained loaded
- 16 concurrent session opens completed; CUDA initialization ran once
- `git diff --check`: clean

The current upstream Windows tree has a separate [pre-existing `webrtc_vad.cpp` MSVC issue](https://github.com/CrispStrobe/CrispASR/pull/279); the build used that known build-only workaround, then reverted it. This PR contains exactly one changed source file.

## AI provenance

Implemented and validated with **OpenAI Codex, GPT-5.6-sol (high reasoning)**, under user direction. Codex inspected the C-ABI/CLI initialization paths, applied the one-file change, ran the formatter and MSVC build, and performed the CUDA DLL and concurrency runtime checks described above.