### PR TITLE
moss-tts: wire missing synthesis params (duration, sampling, max_tokens)

### DIFF
--- a/examples/cli/crispasr_backend_moss_tts.cpp
+++ b/examples/cli/crispasr_backend_moss_tts.cpp
@@ -159,6 +159,18 @@ public:
             sp.text_temperature = params.temperature;
             sp.audio_temperature = params.temperature;
         }
+        if (params.max_new_tokens > 0)
+            sp.max_new_tokens = params.max_new_tokens;
+        // Duration control: max_speech_tokens maps to MOSS-TTS max_audio_frames.
+        // 1s ≈ 12.5 tokens, so max_audio_frames is the token-level AR cap.
+        if (params.tts_max_speech_tokens >= 0)
+            sp.max_audio_frames = params.tts_max_speech_tokens;
+        if (params.tts_top_p >= 0.0f)
+            sp.audio_top_p = params.tts_top_p;
+        if (params.tts_top_k >= 0)
+            sp.audio_top_k = params.tts_top_k;
+        if (params.tts_repetition_penalty >= 0.0f)
+            sp.audio_repetition_penalty = params.tts_repetition_penalty;
         std::string lang;
         if (!params.language.empty() && params.language != "auto") {
             lang = crispasr_iso_to_english_lang(params.language);

--- a/examples/cli/crispasr_backend_moss_tts_local.cpp
+++ b/examples/cli/crispasr_backend_moss_tts_local.cpp
@@ -123,6 +123,16 @@ public:
             sp.text_temperature = params.temperature;
             sp.audio_temperature = params.temperature;
         }
+        if (params.max_new_tokens > 0)
+            sp.max_new_frames = params.max_new_tokens;
+        if (params.tts_max_speech_tokens >= 0)
+            sp.max_audio_frames = params.tts_max_speech_tokens;
+        if (params.tts_top_p >= 0.0f)
+            sp.audio_top_p = params.tts_top_p;
+        if (params.tts_top_k >= 0)
+            sp.audio_top_k = params.tts_top_k;
+        if (params.tts_repetition_penalty >= 0.0f)
+            sp.audio_repetition_penalty = params.tts_repetition_penalty;
         std::string lang;
         if (!params.language.empty() && params.language != "auto") {
             lang = crispasr_iso_to_english_lang(params.language);


### PR DESCRIPTION
Wire tts_max_speech_tokens -> max_audio_frames for token-level duration control (1s ~ 12.5 tokens), and expose audio_top_p, audio_top_k, audio_repetition_penalty, max_new_tokens from the CLI/server layer to both the 8B (moss-tts) and 4B (moss-tts-local) backends.

Previously these params were silently ignored, leaving the backends at hardcoded defaults. Follows the same pattern as chatterbox's adapter.