### PR TITLE
ci(windows): add Tesla P100 to CUDA release targets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1367,7 +1367,7 @@ jobs:
           fail_on_unmatched_files: false
 
   # ── Windows x86_64 shared libs + headers (CUDA) ──────────────────────────────
-  # CUDA 12.8 toolkit (Blackwell-aware). Unlike the Linux CUDA tarball,
+  # CUDA 12.8 toolkit (Tesla P100 through Blackwell). Unlike the Linux CUDA tarball,
   # we bundle the CUDA runtime DLLs (cudart / cublas / cublasLt) so the
   # tarball is self-contained for downstream Windows consumers — matches
   # the existing build-windows-cuda EXE bundle's pattern.
@@ -1401,7 +1401,7 @@ jobs:
             -DCRISPASR_BUILD_EXAMPLES=OFF ^
             -DCRISPASR_BUILD_SERVER=OFF ^
             -DGGML_CUDA=ON ^
-            -DCMAKE_CUDA_ARCHITECTURES="75-real;86-real;89-real;120-real;120-virtual" ^
+            -DCMAKE_CUDA_ARCHITECTURES="60-real;75-real;86-real;89-real;120-real;120-virtual" ^
             -DGGML_NATIVE=OFF ^
             -DGGML_AVX2=ON -DGGML_FMA=ON -DGGML_F16C=ON ^
             -DCRISPASR_OPUS_FETCH=ON
@@ -1632,10 +1632,10 @@ jobs:
           submodules: recursive
           ref: ${{ inputs.tag || github.ref }}
 
-      # CUDA 12.8 is the minimum that ships sm_120 SASS for Blackwell
-      # consumer GPUs (RTX 50xx). Earlier toolkits (12.4 etc.) only know
-      # up to sm_90, so RTX 5060/5070/5080/5090 fail at runtime with
-      # 'no kernel image is available'.
+      # CUDA 12.8 covers the release range from sm_60 (Tesla P100) through
+      # sm_120 (Blackwell consumer GPUs, RTX 50xx). Earlier toolkits (12.4
+      # etc.) only know up to sm_90, so RTX 5060/5070/5080/5090 fail at
+      # runtime with 'no kernel image is available'.
       - name: Install CUDA Toolkit 12.8.0
         # v0.2.19 only knows up to CUDA 12.4; v0.2.35 added 12.8 + 12.9
         # support. Required for sm_120 (RTX 50xx, Blackwell consumer) builds.
@@ -1653,7 +1653,7 @@ jobs:
           cmake -S . -B build -G Ninja ^
             -DCMAKE_BUILD_TYPE=Release ^
             -DGGML_CUDA=ON ^
-            -DCMAKE_CUDA_ARCHITECTURES="75-real;86-real;89-real;120-real;120-virtual" ^
+            -DCMAKE_CUDA_ARCHITECTURES="60-real;75-real;86-real;89-real;120-real;120-virtual" ^
             -DGGML_NATIVE=OFF ^
             -DGGML_AVX2=ON -DGGML_FMA=ON -DGGML_F16C=ON ^
             -DCRISPASR_OPUS_FETCH=ON

--- a/docs/install.md
+++ b/docs/install.md
@@ -100,7 +100,12 @@ Produces `build\bin\crispasr.exe`. Extra CMake flags can be appended:
 ```cmd
 build-windows.bat -DCRISPASR_CURL=ON   :: enable libcurl fallback
 build-windows.bat -DGGML_CUDA=ON       :: NVIDIA GPU (CUDA must be installed)
+build-windows.bat -DGGML_CUDA=ON -DCMAKE_CUDA_ARCHITECTURES=60  :: Tesla P100
 ```
+
+Tesla P100 is a Pascal GPU with compute capability 6.0 (`sm_60`). Use a
+CUDA 12.x toolkit when building for it; CUDA 13 no longer generates code
+for Pascal GPUs.
 
 What it does:
 1. Locates `vswhere.exe` under `%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\`.


### PR DESCRIPTION
## Summary

Add Tesla P100 (`sm_60`) SASS to the two existing Windows CUDA 12.8
release artifacts:

- `crispasr-windows-x86_64-cuda.zip`
- `libcrispasr-windows-x86_64-cuda.tar.gz`

Also document the equivalent local Windows build command.

## Problem

Tesla P100 is a Pascal GPU with compute capability 6.0. CrispASR already
builds and runs on it when `CMAKE_CUDA_ARCHITECTURES=60` is set, but the
official Windows CUDA artifacts currently start at `sm_75`. Loading those
artifacts on a P100 can therefore fail with:

```text
no kernel image is available for execution on the device
```

## Changes

- Prepend `60-real` to the architecture list in the Windows CUDA CLI release
  job.
- Prepend `60-real` to the architecture list in the Windows CUDA shared-library
  release job.
- Add a P100 example to the Windows build documentation.
- Document that Pascal builds require CUDA 12.x because CUDA 13 no longer
  generates Pascal code.

Artifact names and public APIs are unchanged. Linux, CUDA 13, CPU, and Vulkan
release jobs are intentionally unchanged.

## Validation

- The modified GitHub Actions workflow parses successfully as YAML.
- `git diff --check` passes.
- Only the two Windows CUDA 12.8 jobs contain the new `60-real` target.
- A complete Windows CUDA 12.4/Ninja build with
  `CMAKE_CUDA_ARCHITECTURES=60` generated:

  ```text
  --generate-code=arch=compute_60,code=[compute_60,sm_60]
  ```

- That build produced `ggml-cuda.dll` and was validated on a
  Tesla P100-PCIE-16GB reported as compute capability 6.0. The MiMo ASR worker
  initialized on CUDA and completed long-audio transcription tests.

## Release size impact

This deliberately adds another real CUDA architecture to the existing
artifacts, so build time and archive size will increase. For reference, the
v0.8.22 Windows CUDA CLI and shared-library artifacts are approximately
691 MB and 810 MB respectively.
