### PR TITLE
fix(whisper): token_eot corrupted when special tokens aren't serialized, breaking byte-identical decode

### DIFF
--- a/src/crispasr.cpp
+++ b/src/crispasr.cpp
@@ -2141,10 +2141,16 @@ static bool whisper_model_load(struct whisper_model_loader* loader, whisper_cont
             return false;
         };
 
-        const bool has_serialized_specials =
-            set_token_id(vocab.token_eot, "<|endoftext|>") && set_token_id(vocab.token_sot, "<|startoftranscript|>");
+        auto has_token = [&](const char* token) { return vocab.token_to_id.find(token) != vocab.token_to_id.end(); };
+
+        // Probe without assigning: set_token_id() mutates its destination, so calling it here would
+        // leave a partially-resolved id behind when the && short-circuits, and the legacy fixup below
+        // would then increment an id that is already correct.
+        const bool has_serialized_specials = has_token("<|endoftext|>") && has_token("<|startoftranscript|>");
 
         if (has_serialized_specials) {
+            set_token_id(vocab.token_eot, "<|endoftext|>");
+            set_token_id(vocab.token_sot, "<|startoftranscript|>");
             set_token_id(vocab.token_translate, "<|translate|>");
             set_token_id(vocab.token_transcribe, "<|transcribe|>");
             set_token_id(vocab.token_solm, "<|startoflm|>");


### PR DESCRIPTION
## Summary

`whisper_model_load()` resolves `vocab.token_eot` to the wrong id (50258 instead of 50257) on any
multilingual Whisper model whose serialized vocab contains `<|endoftext|>` but not
`<|startoftranscript|>` — which is every model converted by upstream whisper.cpp's
`convert-h5-to-ggml.py`. The corrupted id aliases `<|startoftranscript|>`, which is unconditionally
suppressed during decoding, so the decoder can never emit EOT and cannot end a segment at a
timestamp.

This breaks the "byte-identical to upstream whisper.cpp" property documented at `README.md:572` and
the bit-identical gate in `ARCHITECTURE.md:167`.

## Root cause

Introduced in 09fb4655 ("whisper: support serialized custom special tokens"), `src/crispasr.cpp:2144-2145`:

```cpp
const bool has_serialized_specials =
    set_token_id(vocab.token_eot, "<|endoftext|>") && set_token_id(vocab.token_sot, "<|startoftranscript|>");
```

`set_token_id()` **assigns its destination before returning true**, and it sits on the left of a
short-circuit `&&`. When the second lookup fails, the flag is correctly `false` — but
`vocab.token_eot` has already been overwritten with the resolved id, and nothing rolls it back. The
legacy multilingual fixup at `src/crispasr.cpp:2175` then runs (`token_eot++`) on a value that was
already fully resolved, pushing 50257 → 50258.

Note the irony: the name lookup found the *correct* id. The fixup cannot distinguish "still at the
50256 default" from "already resolved to 50257", so it corrupts a correct value.

## Why it is model-dependent

Upstream's converter serializes `vocab.json` only; `added_tokens.json` never reaches the `.bin`.
Whether `<|endoftext|>` is present therefore depends on the HF repo:

| model | vocab.json entries | `<\|endoftext\|>` | `<\|startoftranscript\|>` | resulting `token_eot` |
|---|---|---|---|---|
| whisper-tiny | 50258 | id 50257 | absent | **50258 (wrong)** |
| whisper-base | 50258 | id 50257 | absent | **50258 (wrong)** |
| whisper-small | 50258 | id 50257 | absent | **50258 (wrong)** |
| whisper-large-v3 | 50257 | absent | absent | 50257 (correct) |

large-v3 escapes only because its base BPE vocab stops one short of `<|endoftext|>`, so the probe
writes nothing and the fallback runs cleanly.

The triggering condition is exactly: `<|endoftext|>` serialized **and** `<|startoftranscript|>` not
serialized **and** `is_multilingual()`. Quantization is irrelevant — it is a property of the source
HF repo. I verified tiny / base-q5_0 / small-q5_0 / large-v3-q5_0 both in the HF `vocab.json` and in
the serialized `.bin`; medium and the `.en` variants are untested.

## Why it changes decoding

With `token_eot == token_sot == 50258`:

1. The timestamp-pair rule masks `for (i = 0; i < vocab.token_eot; ++i) logits[i] = -INFINITY`, which
   now covers `[0, 50258)` — **including the real EOT at 50257**. After a timestamp the decoder is
   structurally forbidden from ending the segment.
2. `whisper_process_logits()` unconditionally does `logits[vocab.token_sot] = -INFINITY`, so every
   read of "EOT" lands on a permanently suppressed slot, and `token.id == whisper_token_eot(ctx)` can
   never match a sampled token.

Segments can then only terminate via the end-of-audio condition, so the decoder runs to the end of
the clip and transcribes whatever is there. On a clip with trailing non-speech, upstream stops at the
last speech timestamp while CrispASR emits an extra segment (in my case a bracketed applause tag on a
JFK clip with applause after the speech).

There is a cosmetic tell too: because `i == vocab.token_eot` is tested before `i == vocab.token_sot`
in the extra-token naming loop, id 50258 is labelled `[_EOT_]` and `[_SOT_]` never appears in
`id_to_token` for affected models.

## The fix

Probe with a non-mutating lookup; move the two assignments inside the branch. Behaviour when specials
*are* serialized (the 09fb4655 custom-vocab path) is unchanged by construction — the same two
`set_token_id()` calls run, just explicitly.

## Verification

Decode of a 12.1 s clip on the same weights, CrispASR vs upstream `whisper-cli` (both beam 5, lang
`en`, default thresholds), after the fix:

| model | CrispASR | whisper.cpp |
|---|---|---|
| tiny | `[0.00→8.00]` | identical |
| base-q5_0 | `[0.00→8.00]` | identical |
| small-q5_0 | `[0.00→5.94]`, `[5.94→8.20]` | identical |
| large-v3-q5_0 | `[0.00→4.60]`, `[4.60→8.22]` | identical (unchanged) |

Segment-for-segment and centisecond-for-centisecond, including the tiers that previously diverged.
large-v3, which already took the correct path, is unaffected.

Minimal reproduction without audio: load `ggml-tiny.bin` and check `vocab.token_eot` — 50258 before,
50257 after.

`clang-format-18` clean. clang-tidy could not be run locally (LLVM 18 cannot parse the macOS SDK's
libc++ headers — unrelated to this change).

## Follow-ups for maintainer consideration — deliberately NOT in this PR

1. **The predicate is weaker than the branch it gates.** It checks only `<|endoftext|>` and
   `<|startoftranscript|>`, but the branch also resolves `<|0.00|>` → `token_beg`, which is the pivot
   for every timestamp rule in `whisper_process_logits()`. A model serializing the first two but not
   `<|0.00|>` would get name-resolved `eot`/`sot` alongside a `token_beg` stuck at the English-layout
   default 50363 with no `dt` shift — worse than either current path. Since #258 is specifically about
   models with unusual special-token sets, widening the predicate (or at least requiring `<|0.00|>`)
   may be worth it, but it could change behaviour for the case the feature was written for, so I left
   it to you.

2. **The serialized-specials branch is currently unreachable for upstream-converted models.**
   `<|startoftranscript|>` is an added token and never appears in `vocab.json`, so the branch only
   engages for models converted with CrispASR's own converter (post-09fb4655). Worth knowing that the
   fallback is the common path for anything downloaded via `download-ggml-model.sh`.

3. **This changes decode output for affected models.** Any stored reference transcripts for
   tiny/base/small — e.g. in the regression matrix or `tools/test-all-backends.py` — will shift, in
   the direction of matching upstream.

Authored by Claude Opus 5.