### PR TITLE
feat(moss-tts): add min_speech_tokens for exact-duration synthesis

### DIFF
--- a/docs/server.md
+++ b/docs/server.md
@@ -340,6 +340,8 @@ curl http://localhost:8080/v1/audio/speech \
 | `seed` | `0` | RNG seed for sampling. `0` = non-deterministic. Same-seed + same-text produces bit-identical audio on all sampling-capable TTS backends (qwen3-tts, chatterbox, vibevoice, orpheus). |
 | `temperature` | server's `--temperature` | Sampling temperature for AR TTS backends. `0` = greedy; backends apply their own default (e.g. 0.8 for qwen3-tts) when the global default of 0.0 is unchanged. |
 | `max_new_tokens` | server's `--max-new-tokens` | AR token generation cap. `<= 0` clears the override and uses the backend default. |
+| `max_speech_tokens` | backend default | MOSS-TTS / moss-tts-local hard cap on generated audio frames (~12.5 frames/sec). The decode loop is forced to end once this many frames are produced, so it bounds the worst-case synthesis length even when the model never emits its end token. Per request. |
+| `min_speech_tokens` | backend default | MOSS-TTS / moss-tts-local minimum number of generated audio frames (~12.5 frames/sec). The decode loop is forbidden from ending until this many frames are produced. **Setting `min_speech_tokens == max_speech_tokens` yields exact-duration synthesis** — the model generates precisely that window of audio (within one frame ≈ 80 ms) with no post-hoc tempo change, which is what game-dubbing / lip-sync work needs. Per request. |
 | `frequency_penalty` | `0.0` | Opt-in repeated generated-token penalty for AR TTS backends. `0.0` disabled. |
 | `top_p` | backend default | Nucleus-sampling cutoff for AR TTS backends (tada, chatterbox). Applied per request; omit to keep the backend default. |
 | `top_k` | backend default | Top-k sampling cutoff (`0` = disabled). Honoured by tada. Per request. |

--- a/examples/cli/crispasr_backend_moss_tts.cpp
+++ b/examples/cli/crispasr_backend_moss_tts.cpp
@@ -169,6 +169,11 @@ public:
         // 1s ≈ 12.5 tokens, so max_audio_frames is the token-level AR cap.
         if (params.tts_max_speech_tokens >= 0)
             sp.max_audio_frames = params.tts_max_speech_tokens;
+        // min_speech_tokens maps to min_audio_frames: when both min and max are
+        // set to the same value, the model is forced to generate exactly that
+        // many frames — exact-duration synthesis (lip-sync / game dubbing).
+        if (params.tts_min_speech_tokens >= 0)
+            sp.min_audio_frames = params.tts_min_speech_tokens;
         if (params.tts_top_p >= 0.0f)
             sp.audio_top_p = params.tts_top_p;
         if (params.tts_top_k >= 0)

--- a/examples/cli/crispasr_backend_moss_tts_local.cpp
+++ b/examples/cli/crispasr_backend_moss_tts_local.cpp
@@ -185,6 +185,8 @@ public:
             sp.max_new_frames = params.max_new_tokens;
         if (params.tts_max_speech_tokens >= 0)
             sp.max_audio_frames = params.tts_max_speech_tokens;
+        if (params.tts_min_speech_tokens >= 0)
+            sp.min_audio_frames = params.tts_min_speech_tokens;
         if (params.tts_top_p >= 0.0f)
             sp.audio_top_p = params.tts_top_p;
         if (params.tts_top_k >= 0)

--- a/examples/cli/crispasr_server.cpp
+++ b/examples/cli/crispasr_server.cpp
@@ -2399,6 +2399,8 @@ int crispasr_run_server(whisper_params& params, const std::string& host, int por
             rp.tts_speaker_id = body["speaker_id"].get<int>();
         if (body.contains("max_speech_tokens") && body["max_speech_tokens"].is_number_integer())
             rp.tts_max_speech_tokens = body["max_speech_tokens"].get<int>();
+        if (body.contains("min_speech_tokens") && body["min_speech_tokens"].is_number_integer())
+            rp.tts_min_speech_tokens = body["min_speech_tokens"].get<int>();
 
         // Wire speed into params so backends with native duration control
         // (e.g. melotts length_scale, piper noise_w) can use it directly.

--- a/examples/cli/whisper_params.h
+++ b/examples/cli/whisper_params.h
@@ -583,6 +583,7 @@ struct whisper_params {
     float tts_exaggeration = -1.0f; // chatterbox expressiveness
     int tts_speaker_id = -1;        // piper multi-speaker model
     int tts_max_speech_tokens = -1; // chatterbox max AR tokens
+    int tts_min_speech_tokens = -1; // moss-tts min AR audio frames (exact-window fill)
 
     // CLI: --tts-play plays synthesised output on the local default speaker.
     // --tts-play-device N selects a non-default device by index (-1 = default).

--- a/src/moss_tts_local.cpp
+++ b/src/moss_tts_local.cpp
@@ -1270,7 +1270,10 @@ static bool mtl_generate_grid(moss_tts_local_context* ctx, const char* text, con
             fprintf(stderr, "moss_tts_local[dbg] frame %d: stop_head continue=%.4f stop=%.4f -> %s\n", f, tl[0], tl[1],
                     stop_idx == 1 ? "STOP" : "cont");
         free(tl);
-        if (stop_idx == 1 && forced.empty()) { // audio_end -> stop (ignored under teacher-forcing)
+        // audio_end -> stop (ignored under teacher-forcing). min_audio_frames
+        // overrides the stop head: keep generating until the floor is reached —
+        // paired with max_audio_frames it yields exact-duration synthesis.
+        if (stop_idx == 1 && forced.empty() && (int)frames.size() >= sp.min_audio_frames) {
             free(lh);
             if (dbg)
                 fprintf(stderr, "moss_tts_local[dbg] stop head fired at frame %d\n", f);


### PR DESCRIPTION
## Summary

Adds `min_speech_tokens` to the `POST /v1/audio/speech` request body and wires it to the moss-tts / moss-tts-local `min_audio_frames` synthesis parameter. When paired with `max_speech_tokens` at the same value, synthesis produces a **fixed-duration audio window** (~12.5 codec frames/sec) with no post-hoc tempo/speed change.

## Why

In order to speech to land in the exact time slot of the original line. The current API only exposes `max_speech_tokens` (a hard ceiling): the model stops at its *natural* duration.

The moss-tts engine already had the `min_audio_frames` mechanism (the decode loop masks the "end audio" token until the floor is reached) but it was unreachable from the HTTP API — only `max_speech_tokens` was exposed. This PR closes that gap:

```json
{
  "input": "…",
  "voice": "voices/ref.wav",
  "min_speech_tokens": 250,
  "max_speech_tokens": 250,
  "max_new_tokens": 600
}
```

→ exactly 250 frames = 20.000 s (±1 frame ≈ 80 ms).

## What changed

- `examples/cli/whisper_params.h` — new `tts_min_speech_tokens` field (default `-1` = unset)
- `examples/cli/crispasr_server.cpp` — parse `min_speech_tokens` from the request body (mirrors `max_speech_tokens`)
- `examples/cli/crispasr_backend_moss_tts.cpp` — map to `sp.min_audio_frames`
- `examples/cli/crispasr_backend_moss_tts_local.cpp` — map to `sp.min_audio_frames`
- `src/moss_tts_local.cpp` — the stop head previously ignored `min_audio_frames` entirely; it now refuses to stop before the floor is reached
- `docs/server.md` — document `min_speech_tokens` (and `max_speech_tokens`, previously undocumented)

## Notes

- `min_audio_frames` was already honoured by the moss-tts backend's delay-pattern sampler; this PR only exposes and completes it.
- `min > max` degrades gracefully to `max` (the cap check runs first in the sampler).
- Backend defaults are unchanged — both fields are opt-in per request.

## Testing

Changes are minimal and mirror the existing `max_speech_tokens` wiring exactly.