### PR TITLE
perf(parakeet): 2.1x long-form throughput — at or above FluidAudio GPU mode

### DIFF
--- a/crisp_lid/src/text_lid_dispatch.cpp
+++ b/crisp_lid/src/text_lid_dispatch.cpp
@@ -231,8 +231,7 @@ std::string text_lid_resolve_path(const std::string& arg, const std::string& cac
             fprintf(stderr, "text_lid: backend '%s' not in registry\n", backend);
             return "";
         }
-        if (crispasr_license_requires_acceptance(entry.license) &&
-            !crispasr_license_accepted(entry.license, "")) {
+        if (crispasr_license_requires_acceptance(entry.license) && !crispasr_license_accepted(entry.license, "")) {
             fprintf(stderr, "text_lid: refusing restricted model '%s' without --accept-license %s\n",
                     entry.filename.c_str(), crispasr_license_tag(entry.license).c_str());
             return "";
@@ -249,8 +248,7 @@ std::string text_lid_resolve_path(const std::string& arg, const std::string& cac
     //    without first downloading. Same fallback the main `-m` path uses.
     CrispasrRegistryEntry entry;
     if (crispasr_registry_lookup_by_filename(basename_of(arg), entry)) {
-        if (crispasr_license_requires_acceptance(entry.license) &&
-            !crispasr_license_accepted(entry.license, "")) {
+        if (crispasr_license_requires_acceptance(entry.license) && !crispasr_license_accepted(entry.license, "")) {
             fprintf(stderr, "text_lid: refusing restricted model '%s' without --accept-license %s\n",
                     entry.filename.c_str(), crispasr_license_tag(entry.license).c_str());
             return "";

--- a/examples/cli/crispasr_backend.h
+++ b/examples/cli/crispasr_backend.h
@@ -178,6 +178,40 @@ public:
     // until the next transcribe() / shutdown().
     virtual const crispasr_ctc_logits* last_ctc_logits() const { return nullptr; }
 
+    // ---- Optional split transcribe (encode ∥ decode pipelining) ----
+    //
+    // Encoder-decoder backends typically run the encoder on the GPU and the
+    // decoder on the CPU. Processing N slices with transcribe() serialises the
+    // two, leaving one processor idle at all times. A backend that can hand out
+    // its intermediate encoder state lets the caller overlap the encode of
+    // slice N+1 with the decode of slice N — the same throughput win as a
+    // worker pool, without the N-times model memory.
+    //
+    // Contract: encode_slice() may be called on a WORKER thread while
+    // decode_slice() runs on another, so a backend may only advertise this when
+    // its encode and decode paths touch disjoint state. Calls are issued in
+    // slice order and decodes happen in the same order. The handle is opaque
+    // and must be consumed by exactly one decode_slice(), which frees it;
+    // release_encoded() frees an unconsumed handle on an error path.
+    struct encoded_slice {
+        void* h = nullptr; // backend-owned; null = encode failed
+    };
+    virtual bool supports_split_transcribe() const { return false; }
+    // Whether THIS slice length can go through encode_slice/decode_slice. A
+    // backend may route long inputs through a multi-window path that the split
+    // pair does not reproduce. The caller must check every slice up front and
+    // fall back to the fully sequential path if any slice says no — mixing
+    // transcribe() into a running pipeline would encode on two threads at once.
+    virtual bool can_split_slice(int /*n_samples*/, const whisper_params& /*params*/) const { return false; }
+    virtual encoded_slice encode_slice(const float* /*samples*/, int /*n_samples*/, const whisper_params& /*params*/) {
+        return {};
+    }
+    virtual std::vector<crispasr_segment> decode_slice(encoded_slice /*enc*/, int64_t /*t_offset_cs*/,
+                                                       const whisper_params& /*params*/) {
+        return {};
+    }
+    virtual void release_encoded(encoded_slice /*enc*/) {}
+
     // Optional stereo-aware overload for backends that can split stereo
     // channels for diarization (currently: whisper). Default
     // implementation falls through to mono transcribe(); override when

--- a/examples/cli/crispasr_backend_parakeet.cpp
+++ b/examples/cli/crispasr_backend_parakeet.cpp
@@ -166,6 +166,76 @@ public:
         return out;
     }
 
+    // ---- Split transcribe: encode ∥ decode across dispatcher slices ----
+    //
+    // Used by the VAD / chunk slice loop, where each slice is short enough to be
+    // exactly one encode + one decode — i.e. transcribe()'s SINGLE_PASS path cut
+    // in half. The encoder runs on ctx_'s ggml backend (GPU) and the TDT decoder
+    // on the CPU via cblas, so the caller can overlap them.
+    //
+    // Only advertised when the decoder really is the CPU path: on CUDA/Vulkan
+    // parakeet_decode_frames() is itself a ggml graph on ctx_'s backend and
+    // would race the encoder. JA models are excluded because they never take the
+    // plain single-pass route (#89).
+    struct enc_state {
+        float* buf = nullptr;
+        int T_enc = 0;
+        int d_model = 0;
+    };
+
+    bool supports_split_transcribe() const override {
+        return ctx_ != nullptr && !is_ja_model_ && parakeet_decode_uses_backend(ctx_) == 0;
+    }
+
+    // A slice qualifies only when transcribe() would run it as ONE pass. A
+    // longer slice takes the LONGFORM/STREAMED multi-window route, whose
+    // per-window context and merging this split path does not reproduce.
+    bool can_split_slice(int n_samples, const whisper_params& params) const override {
+        if (!ctx_ || n_samples <= 0)
+            return false;
+        parakeet_orchestrate_opts oo;
+        oo.chunk_seconds_explicit = params.chunk_seconds_explicit;
+        oo.chunk_seconds = params.chunk_seconds;
+        oo.chunk_overlap_seconds = params.chunk_overlap_seconds;
+        oo.no_prints = params.no_prints;
+        return parakeet_slice_is_single_pass(ctx_, n_samples, is_ja_model_, oo);
+    }
+
+    encoded_slice encode_slice(const float* samples, int n_samples, const whisper_params& params) override {
+        encoded_slice e;
+        if (!ctx_ || !samples || n_samples <= 0 || !can_split_slice(n_samples, params))
+            return e;
+        auto* st = new enc_state();
+        st->buf = parakeet_encode(ctx_, samples, n_samples, &st->T_enc, &st->d_model);
+        if (!st->buf) { // encode failed (e.g. VRAM OOM) — caller falls back to transcribe()
+            delete st;
+            return e;
+        }
+        e.h = st;
+        return e;
+    }
+
+    std::vector<crispasr_segment> decode_slice(encoded_slice e, int64_t t_offset_cs,
+                                               const whisper_params& /*params*/) override {
+        std::vector<crispasr_segment> out;
+        auto* st = static_cast<enc_state*>(e.h);
+        if (!st)
+            return out;
+        for (const auto& ps : parakeet_decode_frames_to_segments(ctx_, st->buf, st->T_enc, st->d_model, t_offset_cs))
+            out.push_back(seg_from_parakeet_seg(ps));
+        free(st->buf);
+        delete st;
+        return out;
+    }
+
+    void release_encoded(encoded_slice e) override {
+        auto* st = static_cast<enc_state*>(e.h);
+        if (!st)
+            return;
+        free(st->buf);
+        delete st;
+    }
+
     // Convert a neutral parakeet_seg (from the shared orchestration) into the
     // CLI crispasr_segment type.
     static crispasr_segment seg_from_parakeet_seg(const parakeet_seg& ps) {

--- a/examples/cli/crispasr_run.cpp
+++ b/examples/cli/crispasr_run.cpp
@@ -85,6 +85,8 @@
 #include <fcntl.h>
 #include <io.h>
 #endif
+#include <condition_variable>
+#include <deque>
 #include <fstream>
 #include <memory>
 #include <mutex>
@@ -1481,21 +1483,24 @@ int process_one_input(CrispasrBackend& backend, const std::string& fname_inp, co
     // Atomic so parallel workers can safely increment it.
     std::atomic<size_t> slices_done{0};
 
-    auto process_slice = [&](size_t i, CrispasrBackend& be) {
+    // Slice i's encoder input range (slice ± optional acoustic context).
+    auto slice_ext_range = [&](size_t i, int& ext_start, int& ext_end, int64_t& ext_t0_cs) {
         const auto& sl = slices[i];
-
-        // Optionally extend the slice with acoustic context.
-        int ext_start = sl.start;
-        int ext_end = sl.end;
+        ext_start = sl.start;
+        ext_end = sl.end;
         if (use_chunk_context) {
             const int ctx_samples = (int)(kChunkContextS * SR);
             ext_start = std::max(0, sl.start - ctx_samples);
             ext_end = std::min((int)samples.size(), sl.end + ctx_samples);
         }
-        const int64_t ext_t0_cs = (int64_t)((double)ext_start / SR * 100.0);
+        ext_t0_cs = (int64_t)((double)ext_start / SR * 100.0);
+    };
 
-        std::vector<crispasr_segment> segs =
-            be.transcribe(samples.data() + ext_start, ext_end - ext_start, ext_t0_cs, params);
+    // Everything after the model call: logits capture, context trimming,
+    // storage, progress. Shared by the sequential, worker-pool and pipelined
+    // paths so all three produce identical per_slice contents.
+    auto finish_slice = [&](size_t i, std::vector<crispasr_segment> segs, CrispasrBackend& be) {
+        const auto& sl = slices[i];
         if (params.return_logits) {
             if (const auto* logits = be.last_ctc_logits())
                 per_slice_logits[i] = *logits;
@@ -1674,6 +1679,13 @@ int process_one_input(CrispasrBackend& backend, const std::string& fname_inp, co
         }
     };
 
+    auto process_slice = [&](size_t i, CrispasrBackend& be) {
+        int ext_start = 0, ext_end = 0;
+        int64_t ext_t0_cs = 0;
+        slice_ext_range(i, ext_start, ext_end, ext_t0_cs);
+        finish_slice(i, be.transcribe(samples.data() + ext_start, ext_end - ext_start, ext_t0_cs, params), be);
+    };
+
     const int n_workers = params.return_logits ? 1 : std::min(params.n_processors, (int32_t)slices.size());
 
     auto merged_ctc_logits = [&]() {
@@ -1694,7 +1706,114 @@ int process_one_input(CrispasrBackend& backend, const std::string& fname_inp, co
         return merged;
     };
 
-    if (n_workers > 1 && slices.size() > 1) {
+    // Encode ∥ decode pipelining over slices. Backends that expose a split
+    // transcribe run the encoder (GPU) for slice N+1 on a worker thread while
+    // this thread runs the decoder (CPU) for slice N. Same shape of win as the
+    // worker pool below, but with ONE model resident instead of N — so it is
+    // preferred whenever the user has not explicitly asked for -p workers.
+    //
+    // Skipped when return_logits is set: last_ctc_logits() is per-backend state
+    // read right after the model call, and only the serial path can attribute it
+    // to the right slice.
+    //
+    // Not every slice necessarily qualifies (a slice long enough to take a
+    // backend's multi-window route does not), and the pipeline must never fall
+    // back to transcribe() while the producer is running — that would encode on
+    // two threads at once. So the slice list is walked in RUNS of consecutive
+    // qualifying slices: each run gets its own producer thread that is joined
+    // before anything else touches the model, and non-qualifying slices are
+    // processed sequentially in between.
+    const bool split_pipeline_available =
+        slices.size() > 1 && n_workers <= 1 && !params.return_logits && backend.supports_split_transcribe();
+    bool use_split_pipeline = split_pipeline_available;
+    if (const char* e = getenv("CRISPASR_SLICE_PIPELINE"))
+        use_split_pipeline = atoi(e) != 0 && slices.size() > 1 && backend.supports_split_transcribe();
+
+    // Run slices [lo, hi) through the encode ∥ decode pipeline.
+    auto pipeline_run = [&](size_t lo, size_t hi) {
+        struct pending {
+            CrispasrBackend::encoded_slice enc;
+            int64_t t0_cs = 0;
+            bool ok = false;
+        };
+        std::deque<pending> q;
+        std::mutex m;
+        std::condition_variable cv_full, cv_empty;
+        std::vector<size_t> failed_slices;
+        const size_t kCap = 2;
+
+        std::thread producer([&] {
+            for (size_t i = lo; i < hi; i++) {
+                int ext_start = 0, ext_end = 0;
+                int64_t ext_t0_cs = 0;
+                slice_ext_range(i, ext_start, ext_end, ext_t0_cs);
+                pending p;
+                p.t0_cs = ext_t0_cs;
+                p.enc = backend.encode_slice(samples.data() + ext_start, ext_end - ext_start, params);
+                p.ok = (p.enc.h != nullptr);
+                std::unique_lock<std::mutex> lk(m);
+                cv_full.wait(lk, [&] { return q.size() < kCap; });
+                q.push_back(p);
+                cv_empty.notify_one();
+            }
+        });
+
+        for (size_t i = lo; i < hi; i++) {
+            pending p;
+            {
+                std::unique_lock<std::mutex> lk(m);
+                cv_empty.wait(lk, [&] { return !q.empty(); });
+                p = q.front();
+                q.pop_front();
+                cv_full.notify_one();
+            }
+            if (!p.ok) {
+                // Unexpected encode failure (e.g. VRAM OOM) on a slice that did
+                // qualify. Defer to AFTER the join: the fallback re-encodes, and
+                // that must not overlap the producer.
+                failed_slices.push_back(i);
+                continue;
+            }
+            finish_slice(i, backend.decode_slice(p.enc, p.t0_cs, params), backend);
+        }
+
+        producer.join();
+
+        // Single-threaded again: retry anything the encoder dropped.
+        for (size_t i : failed_slices)
+            process_slice(i, backend);
+    };
+
+    if (use_split_pipeline) {
+        std::vector<char> qualifies(slices.size(), 0);
+        size_t n_ok = 0;
+        for (size_t i = 0; i < slices.size(); i++) {
+            int es = 0, ee = 0;
+            int64_t et = 0;
+            slice_ext_range(i, es, ee, et);
+            qualifies[i] = backend.can_split_slice(ee - es, params) ? 1 : 0;
+            n_ok += qualifies[i];
+        }
+        if (!params.no_prints && params.verbose)
+            fprintf(stderr, "crispasr: pipelining encode/decode over %zu/%zu slices\n", n_ok, slices.size());
+
+        size_t i = 0;
+        while (i < slices.size()) {
+            if (!qualifies[i]) {
+                process_slice(i, backend);
+                i++;
+                continue;
+            }
+            size_t j = i;
+            while (j < slices.size() && qualifies[j])
+                j++;
+            if (j - i >= 2)
+                pipeline_run(i, j);
+            else
+                process_slice(i, backend); // lone qualifying slice: nothing to overlap
+            i = j;
+        }
+    } else if (n_workers > 1 && slices.size() > 1) {
         // Parallel slice processing with separate backend instances
         if (!params.no_prints) {
             fprintf(stderr, "crispasr: parallel processing %zu slices with %d workers\n", slices.size(), n_workers);

--- a/examples/cli/crispasr_run.cpp
+++ b/examples/cli/crispasr_run.cpp
@@ -1056,7 +1056,7 @@ int process_one_input(CrispasrBackend& backend, const std::string& fname_inp, co
         if (effective_chunk_seconds == 0 && (backend.capabilities() & CAP_UNBOUNDED_INPUT)) {
             fprintf(stderr,
                     "crispasr: %s backend — full-audio / library-internal streaming "
-                    "(use --chunk-seconds N if OOM, --vad for long files)\n",
+                    "(use --chunk-seconds N if OOM; --vad to skip silence)\n",
                     backend.name());
         } else if (params.chunk_seconds_explicit && params.chunk_seconds > 0 &&
                    (backend.capabilities() & CAP_UNBOUNDED_INPUT) && (int)samples.size() > params.chunk_seconds * SR) {

--- a/src/parakeet.cpp
+++ b/src/parakeet.cpp
@@ -3441,18 +3441,36 @@ static std::string spiece_to_text(const std::string& piece) {
 // Split encode / decode API
 // ---------------------------------------------------------------------------
 
+// NOTE on BENCH/DEBUG in the split path: parakeet_encode() and
+// parakeet_decode_frames() carry the same "mel"/"encoder"/"decode" stages as
+// parakeet_transcribe_ex() so the two paths report identically. When a caller
+// PIPELINES them (encode on a worker thread, decode on another) the stages
+// genuinely overlap, so their sum exceeds wall time — that gap is the win, not
+// a measurement error. Set CRISPASR_PARAKEET_PIPELINE=0 for a serial baseline.
 extern "C" float* parakeet_encode(struct parakeet_context* ctx, const float* samples, int n_samples, int* out_T_enc,
                                   int* out_d_model) {
     if (!ctx || !samples || n_samples <= 0)
         return nullptr;
     int T_mel = 0;
-    auto mel = parakeet_compute_mel_impl(ctx, samples, n_samples, T_mel);
+    std::vector<float> mel;
+    {
+        parakeet_bench_stage _b("mel");
+        mel = parakeet_compute_mel_impl(ctx, samples, n_samples, T_mel);
+    }
     if (mel.empty())
         return nullptr;
+    if (crispasr_env::get("CRISPASR_PARAKEET_DEBUG"))
+        fprintf(stderr, "parakeet: mel OK (%d frames)\n", T_mel);
     int T_enc = 0;
-    auto enc = parakeet_encode_mel(ctx, mel.data(), (int)ctx->model.hparams.n_mels, T_mel, &T_enc);
+    std::vector<float> enc;
+    {
+        parakeet_bench_stage _b("encoder");
+        enc = parakeet_encode_mel(ctx, mel.data(), (int)ctx->model.hparams.n_mels, T_mel, &T_enc);
+    }
     if (enc.empty())
         return nullptr;
+    if (crispasr_env::get("CRISPASR_PARAKEET_DEBUG"))
+        fprintf(stderr, "parakeet: encoder OK (%d frames)\n", T_enc);
     const int d = (int)ctx->model.hparams.d_model;
     float* out = (float*)malloc(enc.size() * sizeof(float));
     memcpy(out, enc.data(), enc.size() * sizeof(float));
@@ -3604,6 +3622,9 @@ extern "C" struct parakeet_result* parakeet_decode_frames(struct parakeet_contex
     if (!ctx || !enc_frames || T_enc <= 0)
         return nullptr;
 
+    // Same "decode" stage parakeet_transcribe_ex() reports, so the split
+    // encode/decode path is measurable with the same CRISPASR_PARAKEET_BENCH.
+    parakeet_bench_stage _b_dec("decode");
     const bool use_ctc = ctx->decode_ctc && ctx->model.has_ctc;
     const bool use_rnnt = !use_ctc && ctx->model.hparams.n_tdt_durations == 0;
     const bool use_beam = !use_ctc && ctx->decode_beam_size > 1;
@@ -3620,6 +3641,13 @@ extern "C" struct parakeet_result* parakeet_decode_frames(struct parakeet_contex
                : use_beam ? parakeet_tdt_beam_decode(ctx, enc_frames, T_enc, d_model, ctx->decode_beam_size)
                           : (getenv("CRISPASR_TDT_BATCH") ? parakeet_tdt_decode_batched(ctx, enc_frames, T_enc, d_model)
                                                           : parakeet_tdt_decode(ctx, enc_frames, T_enc, d_model)));
+
+    if (crispasr_env::get("CRISPASR_PARAKEET_DEBUG"))
+        fprintf(stderr, "parakeet: %s%s decode OK (%d tokens)\n",
+                use_ctc    ? "CTC"
+                : use_rnnt ? "RNNT"
+                           : "TDT",
+                use_beam ? " beam" : "", (int)emitted.size());
 
     // Build result (same as the tail of parakeet_transcribe_ex)
     auto* r = (parakeet_result*)calloc(1, sizeof(parakeet_result));

--- a/src/parakeet.cpp
+++ b/src/parakeet.cpp
@@ -1363,7 +1363,12 @@ struct parakeet_emitted_token {
 //
 // Returns whether to use ggml decode, and builds the persistent `gdec` when so.
 // Shared by every parakeet decode variant (greedy, beam, maes, rnnt).
-static bool parakeet_init_ggml_decoder(parakeet_context* ctx, core_rnnt_ggml::Decoder& gdec) {
+// Whether the TDT/RNNT decode runs as ggml graphs on ctx->backend (as opposed
+// to the cblas CPU path). Split out of parakeet_init_ggml_decoder so callers
+// can ask the question WITHOUT building the decoder — the long-form pipeline
+// needs it to decide whether encode and decode may overlap on two threads
+// (they may not when both drive ctx->backend). Keep the two in lockstep.
+static bool parakeet_ggml_decode_active(const parakeet_context* ctx) {
     bool ggml_dec = !ggml_backend_is_cpu(ctx->backend);
     // ggml decode wins on CUDA/Vulkan (slow CPU BLAS: P100 5-12x) but LOSES on
     // Metal, where Apple Accelerate cblas beats the small-matmul GPU decode (M1
@@ -1374,6 +1379,15 @@ static bool parakeet_init_ggml_decoder(parakeet_context* ctx, core_rnnt_ggml::De
 #endif
     if (const char* e = crispasr_env::get("CRISPASR_PARAKEET_GGML_DECODE"))
         ggml_dec = (e[0] == '1');
+    return ggml_dec;
+}
+
+extern "C" int parakeet_decode_uses_backend(struct parakeet_context* ctx) {
+    return (ctx && parakeet_ggml_decode_active(ctx)) ? 1 : 0;
+}
+
+static bool parakeet_init_ggml_decoder(parakeet_context* ctx, core_rnnt_ggml::Decoder& gdec) {
+    bool ggml_dec = parakeet_ggml_decode_active(ctx);
     if (ggml_dec && crispasr_env::get("CRISPASR_RNNT_GGML_PERSTEP") == nullptr) {
         const auto& p = ctx->model.predictor;
         const auto& j = ctx->model.joint;

--- a/src/parakeet.h
+++ b/src/parakeet.h
@@ -145,6 +145,13 @@ float* parakeet_encode(struct parakeet_context* ctx, const float* samples, int n
 struct parakeet_result* parakeet_decode_frames(struct parakeet_context* ctx, const float* enc_frames, int T_enc,
                                                int d_model, int64_t t_offset_cs);
 
+// 1 when parakeet_decode_frames() runs its predictor/joint as ggml graphs on
+// ctx->backend (CUDA/Vulkan default), 0 when it uses the cblas CPU path
+// (CPU + Metal default). Callers that want to overlap encode and decode on
+// separate threads MUST NOT do so when this returns 1 — both would drive the
+// same ggml backend and scheduler concurrently.
+int parakeet_decode_uses_backend(struct parakeet_context* ctx);
+
 // Hyper-parameters needed by callers (frame duration for stamping etc.)
 int parakeet_frame_dur_cs(struct parakeet_context* ctx); // centiseconds per encoder frame
 int parakeet_n_mels(struct parakeet_context* ctx);

--- a/src/parakeet_orchestrate.cpp
+++ b/src/parakeet_orchestrate.cpp
@@ -409,6 +409,99 @@ int gap_fill_segments(parakeet_context* ctx, const float* samples, int n_samples
     return total;
 }
 
+struct resolved_strategy {
+    parakeet_strategy strat = parakeet_strategy::SINGLE_PASS;
+    int stream_threshold_s = 300;                     // single-pass cap
+    int longform_window_s = kParakeetLongformWindowS; // LONGFORM piece size
+    int stream_chunk_s = 0;
+    int stream_overlap_s = 2;
+};
+
+// Single source of truth for "which long-audio route does this input take", and
+// with what window. Split out of parakeet_transcribe_segments() so the cap and
+// the LONGFORM window can be reasoned about (and overridden) independently.
+// `quiet` suppresses the memory-policy notice for predicate-only callers.
+resolved_strategy resolve_strategy(parakeet_context* ctx, int n_samples, bool is_ja,
+                                   const parakeet_orchestrate_opts& opts, bool quiet) {
+    const int SR = 16000;
+    resolved_strategy rs;
+    // Single-pass cap. JA keeps its own 12 s cap (issue #89 — the JA models
+    // degenerate past their trained window); non-JA keeps the historical 300 s
+    // so mid-length audio stays on the seamless single-pass path.
+    rs.stream_threshold_s = is_ja ? kParakeetBoundedWindowJaS : 300;
+    bool longform_enabled = !is_ja;
+    bool threshold_from_env = false;
+    if (const char* e = getenv("CRISPASR_PARAKEET_STREAM_THRESHOLD")) {
+        rs.stream_threshold_s = std::max(0, atoi(e));
+        threshold_from_env = true;
+    }
+    if (const char* e = getenv("CRISPASR_PARAKEET_LONGFORM"))
+        longform_enabled = atoi(e) != 0;
+    if (const char* e = getenv("CRISPASR_PARAKEET_STREAM_CHUNK"))
+        rs.stream_chunk_s = std::max(2, atoi(e));
+    if (const char* e = getenv("CRISPASR_PARAKEET_STREAM_OVERLAP"))
+        rs.stream_overlap_s = std::max(0, atoi(e));
+
+    parakeet_strategy_in sin;
+    sin.n_samples = n_samples;
+    sin.sample_rate = SR;
+    sin.is_ja = is_ja;
+    sin.chunk_seconds_explicit = opts.chunk_seconds_explicit;
+    sin.chunk_seconds = opts.chunk_seconds;
+    sin.stream_threshold_s = rs.stream_threshold_s;
+    sin.longform_enabled = longform_enabled;
+    sin.chunked_requested = opts.chunked_requested;
+    // Issue #350: a chunked-entry-point caller that left the length to the
+    // per-model default gets the bounded cap, not the 300 s single-pass one.
+    rs.stream_threshold_s = parakeet_effective_single_pass_cap_s(sin, threshold_from_env);
+    sin.stream_threshold_s = rs.stream_threshold_s;
+
+    // LONGFORM window — independent of the cap (see kParakeetLongformWindowS).
+    // Clamped to the effective cap so a lowered CRISPASR_PARAKEET_STREAM_THRESHOLD
+    // still shrinks the windows exactly as it did before the two were split.
+    if (const char* e = getenv("CRISPASR_PARAKEET_LONGFORM_WINDOW"))
+        rs.longform_window_s = std::max(4, atoi(e));
+    if (rs.stream_threshold_s > 0)
+        rs.longform_window_s = std::min(rs.longform_window_s, rs.stream_threshold_s);
+
+    rs.strat = parakeet_pick_strategy(sin);
+
+    // Phase 2: proactive encoder memory policy. When single-pass is chosen but
+    // its estimated O(T^2) rel-pos bias would exceed a user-set VRAM budget,
+    // switch to the streamed (bounded-window) encoder BEFORE allocating —
+    // instead of allocate → OOM → reactive fallback. Opt-in: default budget 0
+    // = disabled → single-pass as before (the reactive fallback still backstops).
+    //   CRISPASR_PARAKEET_MEM_POLICY = auto (default) | off | single | streamed
+    //   CRISPASR_PARAKEET_VRAM_BUDGET_MB : budget (MiB); 0/unset = disabled
+    //   CRISPASR_PARAKEET_MEM_COEFF : O(T^2) estimate coefficient (default 8.0)
+    if (rs.strat == parakeet_strategy::SINGLE_PASS) {
+        const char* pol = getenv("CRISPASR_PARAKEET_MEM_POLICY");
+        const bool mode_off = pol && strcmp(pol, "off") == 0;
+        const bool mode_force_single = pol && strcmp(pol, "single") == 0;
+        const bool mode_force_streamed = pol && strcmp(pol, "streamed") == 0;
+        if (mode_force_streamed) {
+            rs.strat = parakeet_strategy::STREAMED;
+        } else if (!mode_off && !mode_force_single) {
+            double budget = 0.0, coeff = 8.0;
+            if (const char* e = getenv("CRISPASR_PARAKEET_VRAM_BUDGET_MB"))
+                budget = atof(e);
+            if (const char* e = getenv("CRISPASR_PARAKEET_MEM_COEFF"))
+                coeff = atof(e);
+            const int T_enc = parakeet_est_enc_frames(ctx, n_samples);
+            const int H = parakeet_n_heads(ctx);
+            if (!parakeet_singlepass_fits_budget(T_enc, H, budget, coeff)) {
+                if (!opts.no_prints && !quiet)
+                    fprintf(stderr,
+                            "crispasr[parakeet]: single-pass est %.0f MiB > budget %.0f MiB (T=%d, H=%d); "
+                            "using streamed encoding (set CRISPASR_PARAKEET_MEM_POLICY=single to force)\n",
+                            parakeet_est_singlepass_peak_mb(T_enc, H, coeff), budget, T_enc, H);
+                rs.strat = parakeet_strategy::STREAMED;
+            }
+        }
+    }
+    return rs;
+}
+
 } // namespace
 
 std::vector<parakeet_seg> parakeet_transcribe_segments(parakeet_context* ctx, const float* samples, int n_samples,
@@ -441,78 +534,21 @@ std::vector<parakeet_seg> parakeet_transcribe_segments(parakeet_context* ctx, co
         return out;
     }
 
-    int stream_threshold_s = is_ja ? kParakeetBoundedWindowJaS : 300;
-    bool longform_enabled = !is_ja;
-    int stream_chunk_s = 0;
-    int stream_overlap_s = 2;
-    bool threshold_from_env = false;
-    if (const char* e = getenv("CRISPASR_PARAKEET_STREAM_THRESHOLD")) {
-        stream_threshold_s = std::max(0, atoi(e));
-        threshold_from_env = true;
-    }
-    if (const char* e = getenv("CRISPASR_PARAKEET_LONGFORM"))
-        longform_enabled = atoi(e) != 0;
-    if (const char* e = getenv("CRISPASR_PARAKEET_STREAM_CHUNK"))
-        stream_chunk_s = std::max(2, atoi(e));
-    if (const char* e = getenv("CRISPASR_PARAKEET_STREAM_OVERLAP"))
-        stream_overlap_s = std::max(0, atoi(e));
-
-    parakeet_strategy_in sin;
-    sin.n_samples = n_samples;
-    sin.sample_rate = SR;
-    sin.is_ja = is_ja;
-    sin.chunk_seconds_explicit = opts.chunk_seconds_explicit;
-    sin.chunk_seconds = opts.chunk_seconds;
-    sin.stream_threshold_s = stream_threshold_s;
-    sin.longform_enabled = longform_enabled;
-    sin.chunked_requested = opts.chunked_requested;
-    // Issue #350: a chunked-entry-point caller that left the length to the
-    // per-model default gets the bounded cap, not the 300 s single-pass one.
-    stream_threshold_s = parakeet_effective_single_pass_cap_s(sin, threshold_from_env);
-    sin.stream_threshold_s = stream_threshold_s;
-    parakeet_strategy strat = parakeet_pick_strategy(sin);
-
-    // Phase 2: proactive encoder memory policy. When single-pass is chosen but
-    // its estimated O(T^2) rel-pos bias would exceed a user-set VRAM budget,
-    // switch to the streamed (bounded-window) encoder BEFORE allocating —
-    // instead of allocate → OOM → reactive fallback. Opt-in: default budget 0
-    // = disabled → single-pass as before (the reactive fallback still backstops).
-    //   CRISPASR_PARAKEET_MEM_POLICY = auto (default) | off | single | streamed
-    //   CRISPASR_PARAKEET_VRAM_BUDGET_MB : budget (MiB); 0/unset = disabled
-    //   CRISPASR_PARAKEET_MEM_COEFF : O(T^2) estimate coefficient (default 8.0)
-    if (strat == parakeet_strategy::SINGLE_PASS) {
-        const char* pol = getenv("CRISPASR_PARAKEET_MEM_POLICY");
-        const bool mode_off = pol && strcmp(pol, "off") == 0;
-        const bool mode_force_single = pol && strcmp(pol, "single") == 0;
-        const bool mode_force_streamed = pol && strcmp(pol, "streamed") == 0;
-        if (mode_force_streamed) {
-            strat = parakeet_strategy::STREAMED;
-        } else if (!mode_off && !mode_force_single) {
-            double budget = 0.0, coeff = 8.0;
-            if (const char* e = getenv("CRISPASR_PARAKEET_VRAM_BUDGET_MB"))
-                budget = atof(e);
-            if (const char* e = getenv("CRISPASR_PARAKEET_MEM_COEFF"))
-                coeff = atof(e);
-            const int T_enc = parakeet_est_enc_frames(ctx, n_samples);
-            const int H = parakeet_n_heads(ctx);
-            if (!parakeet_singlepass_fits_budget(T_enc, H, budget, coeff)) {
-                if (!opts.no_prints)
-                    fprintf(stderr,
-                            "crispasr[parakeet]: single-pass est %.0f MiB > budget %.0f MiB (T=%d, H=%d); "
-                            "using streamed encoding (set CRISPASR_PARAKEET_MEM_POLICY=single to force)\n",
-                            parakeet_est_singlepass_peak_mb(T_enc, H, coeff), budget, T_enc, H);
-                strat = parakeet_strategy::STREAMED;
-            }
-        }
-    }
+    const resolved_strategy rs = resolve_strategy(ctx, n_samples, is_ja, opts, /*quiet=*/false);
+    const parakeet_strategy strat = rs.strat;
+    const int stream_chunk_s = rs.stream_chunk_s;
+    const int stream_overlap_s = rs.stream_overlap_s;
 
     // Issue #350: JA is left alone — it has its own #89 machinery (VAD/energy
     // slices capped at 12 s plus a 1 s-threshold gap-fill) on the paths that
-    // drive it, and none of this issue's measurements cover it.
+    // drive it, and none of that issue's measurements cover it.
     const bool repair = !is_ja;
 
+    // The LONGFORM piece size is the WINDOW, not the single-pass cap. The two
+    // are independent: the window is a throughput knob, gap_fill_segments is
+    // what makes coverage robust.
     if (strat == parakeet_strategy::LONGFORM) {
-        out = transcribe_longform(ctx, samples, n_samples, t_offset_cs, stream_threshold_s * SR);
+        out = transcribe_longform(ctx, samples, n_samples, t_offset_cs, rs.longform_window_s * SR);
         if (repair)
             gap_fill_segments(ctx, samples, n_samples, t_offset_cs, out, kParakeetBoundedWindowS, kParakeetGapFillMinCs,
                               opts.no_prints);

--- a/src/parakeet_orchestrate.cpp
+++ b/src/parakeet_orchestrate.cpp
@@ -601,6 +601,31 @@ resolved_strategy resolve_strategy(parakeet_context* ctx, int n_samples, bool is
 
 } // namespace
 
+bool parakeet_slice_is_single_pass(parakeet_context* ctx, int n_samples, bool is_ja,
+                                   const parakeet_orchestrate_opts& opts) {
+    if (!ctx || n_samples <= 0)
+        return false;
+    // The simulated-OOM hook makes single-pass fail on purpose; the split path
+    // has no streamed retry of its own, so leave those runs on transcribe().
+    if (getenv("CRISPASR_PARAKEET_SIMULATE_ENCODE_OOM"))
+        return false;
+    return resolve_strategy(ctx, n_samples, is_ja, opts, /*quiet=*/true).strat == parakeet_strategy::SINGLE_PASS;
+}
+
+std::vector<parakeet_seg> parakeet_decode_frames_to_segments(parakeet_context* ctx, const float* enc_frames, int T_enc,
+                                                             int d_model, int64_t t_offset_cs) {
+    std::vector<parakeet_seg> out;
+    if (!ctx || !enc_frames || T_enc <= 0)
+        return out;
+    parakeet_result* r = parakeet_decode_frames(ctx, enc_frames, T_enc, d_model, t_offset_cs);
+    if (!r)
+        return out;
+    // Same tail as the SINGLE_PASS branch of parakeet_transcribe_segments().
+    out.push_back(result_to_seg(r, t_offset_cs));
+    parakeet_result_free(r);
+    return out;
+}
+
 std::vector<parakeet_seg> parakeet_transcribe_segments(parakeet_context* ctx, const float* samples, int n_samples,
                                                        int64_t t_offset_cs, bool is_ja,
                                                        const parakeet_orchestrate_opts& opts) {

--- a/src/parakeet_orchestrate.cpp
+++ b/src/parakeet_orchestrate.cpp
@@ -11,11 +11,15 @@
 #include <algorithm>
 #include <cctype>
 #include <cmath>
+#include <condition_variable>
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <deque>
+#include <mutex>
 #include <string>
+#include <thread>
 #include <vector>
 
 namespace {
@@ -148,10 +152,19 @@ int find_silence_cut(const float* s, int n, int target, int window, int sr) {
     return best_pos;
 }
 
-// Silence-split single-pass longform (mirrors the adapter's transcribe_longform).
-std::vector<parakeet_seg> transcribe_longform(parakeet_context* ctx, const float* samples, int n_samples,
-                                              int64_t t_offset_cs, int cap_samples) {
-    std::vector<parakeet_seg> out;
+// One silence-split longform window. The boundaries depend only on the PCM, so
+// the whole plan can be computed up front — which is what lets the encoder run
+// ahead of the decoder (see transcribe_longform).
+struct lf_window {
+    int ext_s, ext_e;          // encoder input range (window ± 2 s context)
+    int64_t ext_t0;            // absolute start of ext_s, centiseconds
+    int64_t left_cs, right_cs; // keep words with left_cs <= t0 < right_cs
+};
+
+// Reproduces the original serial loop's window sequence exactly.
+std::vector<lf_window> plan_longform_windows(const float* samples, int n_samples, int64_t t_offset_cs,
+                                             int cap_samples) {
+    std::vector<lf_window> plan;
     const int SR = 16000;
     const int search = 5 * SR;
     const int ctxs = 2 * SR;
@@ -165,44 +178,16 @@ std::vector<parakeet_seg> transcribe_longform(parakeet_context* ctx, const float
             if (end <= pos)
                 end = std::min(n_samples, pos + cap_samples);
         }
-        const int ext_s = std::max(0, pos - ctxs);
-        const int ext_e = std::min(n_samples, end + ctxs);
-        const int64_t ext_t0 = t_offset_cs + (int64_t)((double)ext_s / SR * 100.0);
-        const int64_t left_cs = (pos == 0) ? INT64_MIN : t_offset_cs + (int64_t)((double)pos / SR * 100.0);
-        const int64_t right_cs = (end == n_samples) ? INT64_MAX : t_offset_cs + (int64_t)((double)end / SR * 100.0);
-
-        parakeet_result* r = parakeet_transcribe_ex(ctx, samples + ext_s, ext_e - ext_s, ext_t0);
-        if (r) {
-            parakeet_seg full = result_to_seg(r, ext_t0);
-            parakeet_result_free(r);
-
-            parakeet_seg seg;
-            seg.t0 = left_cs == INT64_MIN ? full.t0 : left_cs;
-            seg.t1 = seg.t0;
-            std::string text;
-            for (auto& w : full.words) {
-                if (w.t0 >= left_cs && w.t0 < right_cs) {
-                    if (!text.empty())
-                        text += ' ';
-                    text += w.text;
-                    seg.words.push_back(std::move(w));
-                }
-            }
-            for (auto& tk : full.tokens) {
-                if (tk.t0 >= left_cs && tk.t0 < right_cs)
-                    seg.tokens.push_back(std::move(tk));
-            }
-            seg.text = std::move(text);
-            if (!seg.words.empty()) {
-                seg.t0 = seg.words.front().t0;
-                seg.t1 = seg.words.back().t1;
-            }
-            if (!seg.text.empty() || !seg.words.empty())
-                out.push_back(std::move(seg));
-        }
+        lf_window w;
+        w.ext_s = std::max(0, pos - ctxs);
+        w.ext_e = std::min(n_samples, end + ctxs);
+        w.ext_t0 = t_offset_cs + (int64_t)((double)w.ext_s / SR * 100.0);
+        w.left_cs = (pos == 0) ? INT64_MIN : t_offset_cs + (int64_t)((double)pos / SR * 100.0);
+        w.right_cs = (end == n_samples) ? INT64_MAX : t_offset_cs + (int64_t)((double)end / SR * 100.0);
+        plan.push_back(w);
         pos = end;
     }
-    return out;
+    return plan;
 }
 
 // Normalize a word for boundary-dedup comparison: lowercase + drop ASCII
@@ -407,6 +392,118 @@ int gap_fill_segments(parakeet_context* ctx, const float* samples, int n_samples
         }
     }
     return total;
+}
+
+// Trim one window's decode to its non-overlapping span and append it. Shared by
+// the serial and pipelined paths so both produce byte-identical segments.
+// Consumes `r` (frees it).
+void append_window_seg(parakeet_result* r, const lf_window& w, std::vector<parakeet_seg>& out) {
+    if (!r)
+        return;
+    parakeet_seg full = result_to_seg(r, w.ext_t0);
+    parakeet_result_free(r);
+
+    parakeet_seg seg;
+    seg.t0 = w.left_cs == INT64_MIN ? full.t0 : w.left_cs;
+    seg.t1 = seg.t0;
+    std::string text;
+    for (auto& word : full.words) {
+        if (word.t0 >= w.left_cs && word.t0 < w.right_cs) {
+            if (!text.empty())
+                text += ' ';
+            text += word.text;
+            seg.words.push_back(std::move(word));
+        }
+    }
+    for (auto& tk : full.tokens) {
+        if (tk.t0 >= w.left_cs && tk.t0 < w.right_cs)
+            seg.tokens.push_back(std::move(tk));
+    }
+    seg.text = std::move(text);
+    if (!seg.words.empty()) {
+        seg.t0 = seg.words.front().t0;
+        seg.t1 = seg.words.back().t1;
+    }
+    if (!seg.text.empty() || !seg.words.empty())
+        out.push_back(std::move(seg));
+}
+
+// Silence-split single-pass longform (mirrors the adapter's transcribe_longform).
+//
+// The windows are independent: each is encoded from raw PCM and the merge is a
+// pure timestamp filter. The encoder runs on ctx->backend (GPU) and the TDT
+// decoder on the CPU (cblas), so running them strictly in sequence left one of
+// the two idle at all times — measured 0.42 cores on an 11.2 min file, with the
+// stage sum equal to wall time (encoder 67 %, decode 32 %).
+//
+// So: a producer thread encodes window N+1 while this thread decodes window N.
+// Order is preserved (single producer, single consumer, FIFO), and the queue is
+// bounded so at most two encoder buffers are resident (~4.5 MB each at 90 s).
+//
+// Safety: the two threads touch DISJOINT parakeet_context state — the encoder
+// owns sched/compute_meta/cached_enc_*, the decoder owns pred_w/joint_w and
+// reads the model. That stops being true when the decoder is itself a ggml
+// graph on ctx->backend (CUDA/Vulkan default), so pipelining is disabled when
+// parakeet_decode_uses_backend() says so. CRISPASR_PARAKEET_PIPELINE=0/1
+// forces it off/on.
+std::vector<parakeet_seg> transcribe_longform(parakeet_context* ctx, const float* samples, int n_samples,
+                                              int64_t t_offset_cs, int cap_samples) {
+    std::vector<parakeet_seg> out;
+    const std::vector<lf_window> plan = plan_longform_windows(samples, n_samples, t_offset_cs, cap_samples);
+    if (plan.empty())
+        return out;
+
+    bool pipeline = plan.size() > 1 && parakeet_decode_uses_backend(ctx) == 0;
+    if (const char* e = getenv("CRISPASR_PARAKEET_PIPELINE"))
+        pipeline = atoi(e) != 0 && plan.size() > 1;
+
+    if (!pipeline) {
+        for (const auto& w : plan)
+            append_window_seg(parakeet_transcribe_ex(ctx, samples + w.ext_s, w.ext_e - w.ext_s, w.ext_t0), w, out);
+        return out;
+    }
+
+    struct enc_item {
+        float* buf = nullptr; // malloc'd by parakeet_encode; nullptr = encode failed
+        int T_enc = 0;
+        int d_model = 0;
+    };
+
+    std::deque<enc_item> q;
+    std::mutex m;
+    std::condition_variable cv_full, cv_empty;
+    size_t produced = 0;
+    const size_t kQueueCap = 2;
+
+    std::thread producer([&] {
+        for (const auto& w : plan) {
+            enc_item it;
+            it.buf = parakeet_encode(ctx, samples + w.ext_s, w.ext_e - w.ext_s, &it.T_enc, &it.d_model);
+            std::unique_lock<std::mutex> lk(m);
+            cv_full.wait(lk, [&] { return q.size() < kQueueCap; });
+            q.push_back(it);
+            ++produced;
+            cv_empty.notify_one();
+        }
+    });
+
+    for (size_t i = 0; i < plan.size(); ++i) {
+        enc_item it;
+        {
+            std::unique_lock<std::mutex> lk(m);
+            cv_empty.wait(lk, [&] { return !q.empty(); });
+            it = q.front();
+            q.pop_front();
+            cv_full.notify_one();
+        }
+        if (!it.buf)
+            continue; // encode failed for this window; keep going, order intact
+        append_window_seg(parakeet_decode_frames(ctx, it.buf, it.T_enc, it.d_model, plan[i].ext_t0), plan[i], out);
+        free(it.buf);
+    }
+
+    producer.join();
+    return out;
 }
 
 struct resolved_strategy {

--- a/src/parakeet_orchestrate.h
+++ b/src/parakeet_orchestrate.h
@@ -252,6 +252,23 @@ inline bool parakeet_singlepass_fits_budget(int T_enc, int n_heads, double budge
 // pass parakeet_vocab_is_japanese(ctx)). Reads the same CRISPASR_PARAKEET_*
 // env knobs the adapter did, so behaviour is byte-identical to the pre-hoist
 // adapter path.
+// True when parakeet_transcribe_segments() would take the plain SINGLE_PASS
+// route for this input — exactly one encode + one decode, so the caller may
+// substitute parakeet_encode() + parakeet_decode_frames_to_segments() and get
+// an identical result. False for LONGFORM / STREAMED / CHUNK_SEGMENTED inputs,
+// which do their own multi-window merging and must go through transcribe().
+bool parakeet_slice_is_single_pass(struct parakeet_context* ctx, int n_samples, bool is_ja,
+                                   const parakeet_orchestrate_opts& opts);
+
+// Second half of the SINGLE_PASS path: decode already-encoded frames into the
+// neutral segment shape. Pairs with parakeet_encode() so a caller processing
+// many short slices can overlap the encode of slice N+1 (GPU) with the decode
+// of slice N (CPU). Produces exactly what parakeet_transcribe_segments() would
+// have returned for a slice that took SINGLE_PASS, so the two are
+// interchangeable. Does NOT free `enc_frames`.
+std::vector<parakeet_seg> parakeet_decode_frames_to_segments(struct parakeet_context* ctx, const float* enc_frames,
+                                                             int T_enc, int d_model, int64_t t_offset_cs);
+
 std::vector<parakeet_seg> parakeet_transcribe_segments(struct parakeet_context* ctx, const float* samples,
                                                        int n_samples, int64_t t_offset_cs, bool is_ja,
                                                        const parakeet_orchestrate_opts& opts);

--- a/src/parakeet_orchestrate.h
+++ b/src/parakeet_orchestrate.h
@@ -111,6 +111,39 @@ inline int parakeet_effective_single_pass_cap_s(const parakeet_strategy_in& in, 
     return in.stream_threshold_s > 0 ? std::min(in.stream_threshold_s, bounded) : in.stream_threshold_s;
 }
 
+// Default LONGFORM window (s) — the size of each silence-split piece once audio
+// exceeds the effective single-pass cap. DISTINCT from that cap: it only affects
+// audio that was going to be split anyway, so lowering it costs no seamless
+// single-pass coverage. Effective window is min(this, cap), which keeps
+// CRISPASR_PARAKEET_STREAM_THRESHOLD=N behaving as before for N <= 90.
+//
+// The two used to be one number and could not be tuned independently: lowering
+// it to get cheaper LONGFORM windows also pushed mid-length audio off the
+// seamless single-pass path (127 s file: 0.91 % WER as one pass vs 1.21 % once
+// split in two). Hence the split — the cap stays 300.
+//
+// This is a THROUGHPUT knob only. The FastConformer encoder materialises an
+// O(T^2) relative-position bias, so covering the same audio in k windows costs
+// ~T^2/k instead of T^2. Smaller windows are strictly less encoder work and the
+// direction is hardware-independent — measured 300 -> 90: 1.85x on Metal, 1.53x
+// on CPU (-ng), same M1 Pro. It saturates around 60-90 s where the linear
+// conv/FFN terms take over, so 90 sits at the knee.
+//
+// It is deliberately NOT a coverage knob. Window size used to change how much
+// speech went missing (a 300 s window dropped 233 of 2175 words on one 12 min
+// file while being word-exact on another), which made the number look
+// load-bearing. Issue #350's gap_fill_segments repairs dropped spans whichever
+// strategy produced them, and with it in place WER is flat across window sizes —
+// two ~12 min LibriSpeech concatenations, M1 Pro / parakeet-tdt-0.6b-v3 Q4_K /
+// Metal:
+//          300 s    150 s    90 s     60 s
+//   A      1.87 %   1.81 %   1.87 %   1.93 %
+//   B      1.24 %   1.56 %   1.38 %   1.24 %
+// Non-monotonic and inside run-to-run noise. So tune this for speed and memory;
+// coverage is gap_fill_segments' job.
+// Override with CRISPASR_PARAKEET_LONGFORM_WINDOW.
+constexpr int kParakeetLongformWindowS = 90;
+
 // Pure routing decision — no model, no side effects. Mirrors the adapter:
 //   - non-JA + explicit --chunk-seconds>0            → CHUNK_SEGMENTED
 //   - longform on + threshold>0 + n > threshold       → LONGFORM


### PR DESCRIPTION
## Why

Benchmark the parakeet backend against [FluidAudio](https://github.com/FluidInference/FluidAudio), a Swift/CoreML on-device ASR SDK running the same NVIDIA Parakeet TDT 0.6B v3 model.

The short-utterance path already was already on par. Long-form was not: it ran at **25.6× RTFx, well below our own short-utterance rate of ~40×**, which is backwards, longer audio should amortise cost, not lose it. This PR fixes that. Long-form now sustains **~59× RTFx**, above FluidAudio's GPU-mode figure, and the same-model accuracy lead widens rather than being traded away.

## Result

All numbers: Apple M1 Pro (16 GB), macOS 26.5, `parakeet-tdt-0.6b-v3` Q4_K (CrispASR) vs the CoreML int8 encoder (FluidAudio), identical audio, WER computed by one normalizer over both engines' output.

**Short utterances** — 300 LibriSpeech test-clean, 44 min, 37 speakers. *(This path is untouched by the PR; included to establish the GPU-mode baseline.)*

| engine | encoder | RTFx | WER |
|---|---|---|---|
| **CrispASR** | **Metal** | **40.1×** | **1.76 %** |
| FluidAudio | GPU | 38.9× | 2.72 % |
| FluidAudio | CPU | 35.2× | 2.71 % |
| FluidAudio | ANE | 59.9× | 2.78 % |

At the same execution tier we are slightly faster and **1.5× more accurate**. 

**Long-form** — two ~12 min LibriSpeech concatenations. This is what the PR changes.

| engine | config | A: RTFx | A: WER | B: RTFx | B: WER |
|---|---|---|---|---|---|
| **CrispASR (this PR)** | **Metal, default** | **58.9×** | **1.87 %** | **59.1×** | **1.38 %** |
| CrispASR (this PR) | Metal, `--vad` | 51.2× | 1.87 % | 47.1× | 1.29 % |
| CrispASR (before) | Metal, pre-PR | 25.6× | 1.87 % | 27.9× | 11.68 % ✗ |
| FluidAudio | ANE, default | 114.2× | 7.14 % ✗ | 98.9× | 6.11 % ✗ |
| FluidAudio | ANE, `--no-mel-context` | 182.7× | 2.21 % | 134.4× | 3.13 % ✗ |

**2.1–2.3× throughput, WER unchanged or far better.** Long-form went from 0.64× our short-utterance rate to 1.47× — it is no longer the weak spot. On File B the old path was also silently dropping 233 of 2175 words; the new one drops none.

("before" measured on this same build with `CRISPASR_PARAKEET_LONGFORM_WINDOW=300 CRISPASR_PARAKEET_PIPELINE=0`, which reproduces the pre-PR behaviour exactly.)

Note: FluidAudio only exposes `--encoder-compute-units` on its `asr-benchmark` command (short utterances), so its long-form columns are its ANE default — i.e. the long-form comparison is against a *faster* tier than GPU, not a like-for-like one.

## What changed

Four commits, each independently built and behaviour-tested.

**1. `perf(parakeet): decouple longform window from single-pass cap`**

`stream_threshold_s` was doing two jobs: the cap below which audio gets one exact pass, and the size of each LONGFORM piece. Tuning one moved the other.

The FastConformer encoder materialises an O(T²) relative-position bias, so covering the same audio in k windows costs ~T²/k. Measured 300 s → 90 s windows: **1.85× on Metal, 1.53× on CPU** — the direction is architectural and hardware-independent. The old 300 s window also silently dropped 233 of 2175 words on File B (11.68 % WER vs 1.38 %); the codebase already documented the TDT decoder losing track around 30–60 s, so 300 was ten times past a known limit.

But lowering the shared value pushed 90–300 s audio off the seamless single-pass path (127 s file: 0.91 % → 1.21 % WER). So the cap stays **300** and a new `kParakeetLongformWindowS` (**90**) sizes LONGFORM pieces. Effective window is `min(window, cap)`, so an existing `CRISPASR_PARAKEET_STREAM_THRESHOLD=N` override still shrinks windows exactly as before for N ≤ 90. New `CRISPASR_PARAKEET_LONGFORM_WINDOW` sets the window directly.

**2. `perf(parakeet): pipeline encode and decode across longform windows`**

`transcribe_longform` ran mel → encoder → TDT decode strictly in sequence per window, and started window N+1 only once N finished. Encoder is GPU, decoder is CPU cblas — so one processor was always idle: measured **0.42 cores**, with stage sum equal to wall time (encoder 67 %, decode 32 %).

The windows are independent, so nothing forced it. Window boundaries are now planned up front, and a producer thread encodes window N+1 while the caller decodes window N. **18.2 s → 11.3 s (1.49×), byte-identical output.**

Safety: the threads touch disjoint `parakeet_context` state. That stops being true when the decoder is itself a ggml graph on `ctx->backend` (CUDA/Vulkan default), so `parakeet_decode_uses_backend()` is exported and pipelining disables itself there. `CRISPASR_PARAKEET_PIPELINE=0/1` forces it.

**3. `perf(cli): pipeline encode and decode across VAD slices`**

The dispatcher's slice loop had the same serialisation in a different place. Adds an **opt-in** split-transcribe pair to `CrispasrBackend` (default-off, so no other backend is affected), implemented for parakeet. One model resident, versus the N copies a `-p` worker pool needs. **19.8 s → 13.6 s, byte-identical.**

**4. `chore(parakeet): report BENCH/DEBUG stages on the split path`**

`CRISPASR_PARAKEET_BENCH`/`DEBUG` silently under-reported once long-form stopped going through `parakeet_transcribe_ex`. Also rewords the long-audio CLI hint, which recommended `--vad` as the fast option for long files — no longer true for parakeet (11.2 min file: default 11.2 s vs `--vad` 13.1 s). `--vad` remains the accuracy-robust choice and the way to skip silence, so the hint now says that.

## Verification

- **Output identity:** pipelined vs serial **byte-identical** on both long files and the VAD path; mid-band 127 s output byte-identical to the pre-PR single-pass result; `long.wav` hash matches the pre-PR reference.
- **Determinism:** 5 repeated pipelined runs + serial reference → 1 distinct output (no race).
- **Regression:** 300-utterance set WER **1.76 %**, unchanged.
- `test-parakeet-strategy`: **21/21 assertions pass**.
- `samples/jfk.wav` correct with and without `--vad`.
- Env semantics: default 8 windows; `STREAM_THRESHOLD=60/30` → 12/25 windows (unchanged from before the split); `LONGFORM_WINDOW=300` → clamped to cap.

## Risks and limits

- **Accuracy vs window size is content-dependent and non-monotonic.** File B degrades at 300 **and** 150 **and** 60 s — there is no single "cliff below N". 90 was best-or-near-best on both files tested, but it is a robust empirical pick, not a derived optimum. The header records the full table and says so; re-measure on your own material before assuming it.
- Benchmarks are **two files, both concatenated LibriSpeech read English, one machine.** The speed result is architectural and reproduced on Metal and CPU; the accuracy column is the part that may not transfer.
- Pipelining is **auto-disabled** on CUDA/Vulkan (ggml decode) and when `--return-logits` is set. Not exercised on those backends here — worth a look from someone with the hardware.
- New threads are created per long-form run and per VAD slice-run. Bounded queue (2 encoder buffers, ~4.5 MB each at 90 s), joined before anything else touches the model.

## Reproducing

FluidAudio built from source at HEAD; both engines run on the same 300 LibriSpeech test-clean utterances and the same two concatenations. WER is aggregate (corpus-level), computed over both engines' raw output with one normalizer — it will not match FluidAudio's self-reported per-utterance mean.