### PR TITLE
fix(#356): split covering segment at gap-fill recoveries so output is monotone

### DIFF
--- a/examples/cli/crispasr_gap_fill.h
+++ b/examples/cli/crispasr_gap_fill.h
@@ -14,6 +14,15 @@
 // Gate at the call site on backend.vad_slice_cap_seconds() > 0;
 // CRISPASR_GAP_FILL=0 disables, CRISPASR_GAP_FILL_MIN_CS tunes the trigger
 // (60 measured worse than the default 100: more variant noise, slower).
+//
+// Issue #356: a recovery lands *inside* the span of the segment it was
+// recovered from — the first pass emitted one segment whose sparse words
+// straddle the hole, so its t0..t1 covers the recovered range. Appending the
+// recovery and sorting by t0 alone leaves the covering segment first and every
+// recovery after it reading as a jump backwards in time (SRT/VTT cues overlap
+// by up to the hole length, 10+ s on the reporter's file). After each round
+// the covering segment is now split at the recovered range so the output is
+// monotone: head words, recovery, tail words.
 
 #pragma once
 
@@ -48,6 +57,66 @@ inline std::string crispasr_rebuild_text_from_words(const std::vector<crispasr_w
     if (!rebuilt.empty() && rebuilt[0] == ' ')
         rebuilt = rebuilt.substr(1);
     return rebuilt;
+}
+
+// Issue #356: make a gap-filled segment list monotone. The first pass emits a
+// segment whose sparse words straddle the recovered hole, so its span encloses
+// the recoveries; sorting by t0 alone leaves that segment first and the
+// recoveries overlap it. Resolve by splitting the covering segment at each
+// recovery: words (and tokens) that start at or after the recovery's end move
+// into a new tail segment, the head keeps the rest, and both rebuild their
+// display text from their words — the same convention as the overlap-save trim
+// in crispasr_run.cpp. A covering segment with no words on the far side of the
+// recovery is simply clamped at the recovery's start. Runs to a fixpoint so a
+// span enclosing several recoveries is split at each one; every split strictly
+// reduces the word count of the segment being split, so it terminates.
+inline void crispasr_gap_fill_resolve_overlaps(std::vector<crispasr_segment>& segs) {
+    const auto by_time = [](const crispasr_segment& a, const crispasr_segment& b) {
+        return a.t0 != b.t0 ? a.t0 < b.t0 : a.t1 < b.t1;
+    };
+    bool changed = true;
+    while (changed) {
+        changed = false;
+        std::sort(segs.begin(), segs.end(), by_time);
+        for (size_t i = 1; i < segs.size(); i++) {
+            crispasr_segment& prev = segs[i - 1];
+            crispasr_segment& cur = segs[i];
+            if (cur.t0 >= prev.t1)
+                continue;
+            // prev spans past cur's start. Split when prev still has words on
+            // the far side of cur; otherwise just cap prev's span.
+            if (!prev.words.empty() && prev.words.back().t0 >= cur.t1) {
+                crispasr_segment tail = prev; // copy metadata (speaker, chunk_id, ...)
+                std::vector<crispasr_word> head_words, tail_words;
+                for (auto& w : prev.words)
+                    (w.t0 >= cur.t1 ? tail_words : head_words).push_back(std::move(w));
+                std::vector<crispasr_token> head_tokens, tail_tokens;
+                for (auto& t : prev.tokens)
+                    (t.t0 >= cur.t1 ? tail_tokens : head_tokens).push_back(std::move(t));
+                tail.words = std::move(tail_words);
+                tail.tokens = std::move(tail_tokens);
+                tail.text = crispasr_rebuild_text_from_words(tail.words);
+                tail.t0 = tail.words.front().t0;
+                tail.t1 = tail.words.back().t1;
+                if (head_words.empty()) {
+                    // Nothing left of the recovery — prev *is* the tail.
+                    prev = std::move(tail);
+                } else {
+                    prev.words = std::move(head_words);
+                    prev.tokens = std::move(head_tokens);
+                    prev.text = crispasr_rebuild_text_from_words(prev.words);
+                    prev.t0 = prev.words.front().t0;
+                    prev.t1 = prev.words.back().t1;
+                    segs.push_back(std::move(tail));
+                }
+                changed = true;
+                break; // re-sort and re-scan
+            }
+            // No words past the recovery (or no words at all): clamp. A head
+            // word ending inside cur (boundary tolerance) resolves here too.
+            prev.t1 = std::max(prev.t0, cur.t0);
+        }
+    }
 }
 
 inline void crispasr_gap_fill_slice(CrispasrBackend& be, const whisper_params& params, const float* samples,
@@ -134,7 +203,9 @@ inline void crispasr_gap_fill_slice(CrispasrBackend& be, const whisper_params& p
         }
         if (!recovered_any)
             return;
-        std::sort(segs.begin(), segs.end(),
-                  [](const crispasr_segment& a, const crispasr_segment& b) { return a.t0 < b.t0; });
+        // Issue #356: a plain t0 sort left each recovery inside the span of
+        // the segment it was recovered from — split/clamp instead so the
+        // list comes out monotone.
+        crispasr_gap_fill_resolve_overlaps(segs);
     }
 }

--- a/examples/cli/crispasr_gap_fill.h
+++ b/examples/cli/crispasr_gap_fill.h
@@ -185,10 +185,25 @@ inline void crispasr_gap_fill_slice(CrispasrBackend& be, const whisper_params& p
                 return false;
             };
             for (auto& fseg : fill) {
+                const size_t first_kept = rec.words.size();
                 for (auto& w : fseg.words) {
                     const int64_t mid = (w.t0 + w.t1) / 2;
                     if (mid >= g.first - kCoverSlopCs && mid < g.second + kCoverSlopCs && !mid_is_covered(mid))
                         rec.words.push_back(std::move(w));
+                }
+                // The fill's tokens ride along with the kept words — the
+                // token-level outputs (JSON full, karaoke) read seg.tokens and
+                // a recovery with an empty list vanishes from them. A token
+                // joins at most one word, so a shared word boundary doesn't
+                // duplicate it; a token with no timestamp (t0 == -1) has no
+                // word to join and stays out.
+                for (auto& tk : fseg.tokens) {
+                    for (size_t i = first_kept; i < rec.words.size(); i++) {
+                        if (tk.t0 >= rec.words[i].t0 && tk.t0 <= rec.words[i].t1) {
+                            rec.tokens.push_back(std::move(tk));
+                            break;
+                        }
+                    }
                 }
             }
             if (rec.words.empty())

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2670,6 +2670,32 @@ catch_discover_tests(test-issue-114-chunk-context-gate
     PROPERTIES LABELS "unit;chunk-context;issue-114"
 )
 
+# ─── test-issue-356-gap-fill-overlap — issue #356 regression guard
+#
+# Pins crispasr_gap_fill_resolve_overlaps: the #89 gap-fill second pass used to
+# append recoveries inside the span of the segment they were recovered from and
+# sort by t0 only, so SRT/VTT cues jumped backwards by up to the hole length.
+# Covering segments must be split at each recovery so the list is monotone with
+# no text lost. Scripted fake backend; pure CPU, no model load.
+add_executable(test-issue-356-gap-fill-overlap
+    test-issue-356-gap-fill-overlap.cpp
+)
+target_include_directories(test-issue-356-gap-fill-overlap PRIVATE
+    ${PROJECT_SOURCE_DIR}/include
+    ${PROJECT_SOURCE_DIR}/ggml/include
+    ${PROJECT_SOURCE_DIR}/src
+    ${PROJECT_SOURCE_DIR}/examples
+    ${PROJECT_SOURCE_DIR}/examples/cli
+)
+target_link_libraries(test-issue-356-gap-fill-overlap PRIVATE
+    Catch2::Catch2WithMain
+    crispasr-lib
+)
+catch_discover_tests(test-issue-356-gap-fill-overlap
+    TEST_SPEC "[issue-356]"
+    PROPERTIES LABELS "unit;gap-fill;issue-356"
+)
+
 # ─── test-parakeet-ja-detect — issue #257 regression guard
 #
 # Pins crispasr_parakeet::vocab_looks_japanese so the JA-model detection keys on

--- a/tests/test-issue-356-gap-fill-overlap.cpp
+++ b/tests/test-issue-356-gap-fill-overlap.cpp
@@ -60,8 +60,14 @@ class ScriptedBackend : public CrispasrBackend {
         const int64_t win1 = t_offset_cs + (int64_t)n_samples * 100 / kSampleRate;
         crispasr_segment seg;
         for (const auto& w : script_) {
-            if (w.t0 >= win0 && w.t1 <= win1)
+            if (w.t0 >= win0 && w.t1 <= win1) {
                 seg.words.push_back(w);
+                crispasr_token tk;
+                tk.text = w.text;
+                tk.t0 = w.t0;
+                tk.t1 = w.t1;
+                seg.tokens.push_back(tk);
+            }
         }
         if (seg.words.empty())
             return {};
@@ -125,6 +131,12 @@ TEST_CASE("issue #356: recovery inside a straddling segment splits it, output mo
     REQUIRE(segs[2].text == "暮らすのは好きなんです。");
     REQUIRE(segs[0].t1 <= segs[1].t0);
     REQUIRE(segs[1].t1 <= segs[2].t0);
+
+    // The fill's tokens ride along with the kept words: token-level outputs
+    // read seg.tokens, and a recovery with an empty list vanishes from them.
+    REQUIRE(segs[1].tokens.size() == 3);
+    REQUIRE(segs[1].tokens.front().text == "日本にもそんないない");
+    REQUIRE(segs[1].tokens.back().text == "えっと。");
 }
 
 TEST_CASE("issue #356: segment enclosing two recoveries is split at each", "[unit][gap-fill][issue-356]") {

--- a/tests/test-issue-356-gap-fill-overlap.cpp
+++ b/tests/test-issue-356-gap-fill-overlap.cpp
@@ -1,0 +1,217 @@
+// test-issue-356-gap-fill-overlap.cpp — issue #356 regression guard.
+//
+// The issue #89 gap-fill second pass recovers speech the parakeet-ja encoder
+// blanks inside a slice, but it appended the recovered segments and sorted by
+// t0 only. The first pass emits ONE segment whose sparse words straddle the
+// hole, so its t0..t1 encloses every recovery — sorting cannot fix that, and
+// the SRT/VTT output carried cues jumping backwards by up to the hole length
+// (10.5 s on the downstream reporter's file; the 32.66→43.30 s excerpt below
+// mirrors it). crispasr_gap_fill_resolve_overlaps now splits the covering
+// segment at each recovery so the list comes out monotone with no text lost.
+//
+// Pure CPU, no model load: the backend is a scripted fake that "recovers"
+// preset words for whatever window it is asked to transcribe.
+
+#include "crispasr_gap_fill.h"
+#include "whisper_params.h"
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <string>
+#include <vector>
+
+namespace {
+
+constexpr int kSampleRate = 16000;
+
+crispasr_word make_word(const char* text, int64_t t0_cs, int64_t t1_cs) {
+    crispasr_word w;
+    w.text = text;
+    w.t0 = t0_cs;
+    w.t1 = t1_cs;
+    return w;
+}
+
+crispasr_segment make_segment(std::vector<crispasr_word> words) {
+    crispasr_segment seg;
+    seg.words = std::move(words);
+    seg.text = crispasr_rebuild_text_from_words(seg.words);
+    seg.t0 = seg.words.front().t0;
+    seg.t1 = seg.words.back().t1;
+    return seg;
+}
+
+// Backend whose "audio" contains a fixed script of absolute-timed words: a
+// transcribe() call returns every scripted word that falls inside the
+// requested window. This is exactly the contract gap-fill relies on when it
+// re-transcribes a hole in isolation.
+class ScriptedBackend : public CrispasrBackend {
+  public:
+    explicit ScriptedBackend(std::vector<crispasr_word> script) : script_(std::move(script)) {}
+
+    const char* name() const override { return "scripted"; }
+    uint32_t capabilities() const override { return 0; }
+    bool init(const whisper_params&) override { return true; }
+    void shutdown() override {}
+
+    std::vector<crispasr_segment> transcribe(const float*, int n_samples, int64_t t_offset_cs,
+                                             const whisper_params&) override {
+        const int64_t win0 = t_offset_cs;
+        const int64_t win1 = t_offset_cs + (int64_t)n_samples * 100 / kSampleRate;
+        crispasr_segment seg;
+        for (const auto& w : script_) {
+            if (w.t0 >= win0 && w.t1 <= win1)
+                seg.words.push_back(w);
+        }
+        if (seg.words.empty())
+            return {};
+        seg.t0 = seg.words.front().t0;
+        seg.t1 = seg.words.back().t1;
+        seg.text = crispasr_rebuild_text_from_words(seg.words);
+        return {seg};
+    }
+
+  private:
+    std::vector<crispasr_word> script_;
+};
+
+void require_monotone(const std::vector<crispasr_segment>& segs) {
+    for (size_t i = 1; i < segs.size(); i++) {
+        INFO("segment " << i << " [" << segs[i].t0 << ".." << segs[i].t1 << "] vs previous [" << segs[i - 1].t0 << ".."
+                        << segs[i - 1].t1 << "]");
+        REQUIRE(segs[i].t0 >= segs[i - 1].t1);
+    }
+}
+
+std::string joined_text(const std::vector<crispasr_segment>& segs) {
+    std::string all;
+    for (const auto& s : segs)
+        all += s.text;
+    return all;
+}
+
+} // namespace
+
+TEST_CASE("issue #356: recovery inside a straddling segment splits it, output monotone",
+          "[unit][gap-fill][issue-356]") {
+    // Mirrors the reporter's 32.66→43.30 s slice: the first pass emitted one
+    // segment whose words cover the edges but skip 33.1→39.4 s; gap-fill
+    // recovers the middle from the scripted backend.
+    const crispasr_audio_slice sl = {3250 * kSampleRate / 100, 4330 * kSampleRate / 100, 3250, 4330};
+    std::vector<float> samples((size_t)sl.end, 0.0f);
+
+    std::vector<crispasr_segment> segs;
+    segs.push_back(make_segment({
+        make_word("まずね", 3266, 3310),
+        make_word("暮らすのは好きなんです。", 3946, 4330),
+    }));
+
+    ScriptedBackend be({
+        make_word("日本にもそんないない", 3318, 3454),
+        make_word("です。", 3460, 3518),
+        make_word("えっと。", 3686, 3782),
+    });
+    whisper_params params;
+
+    crispasr_gap_fill_slice(be, params, samples.data(), sl.end, kSampleRate, sl, segs);
+
+    // All three parts present, in reading order, with no overlap: the
+    // covering segment must have been split around the recovery instead of
+    // being left spanning it.
+    require_monotone(segs);
+    REQUIRE(segs.size() == 3);
+    REQUIRE(segs[0].text == "まずね");
+    REQUIRE(segs[1].text == "日本にもそんないないです。えっと。");
+    REQUIRE(segs[2].text == "暮らすのは好きなんです。");
+    REQUIRE(segs[0].t1 <= segs[1].t0);
+    REQUIRE(segs[1].t1 <= segs[2].t0);
+}
+
+TEST_CASE("issue #356: segment enclosing two recoveries is split at each", "[unit][gap-fill][issue-356]") {
+    std::vector<crispasr_segment> segs;
+    segs.push_back(make_segment({
+        make_word("head", 100, 150),
+        make_word("mid", 700, 780),
+        make_word("tail", 1400, 1500),
+    }));
+    segs.push_back(make_segment({make_word("first-recovery", 300, 500)}));
+    segs.push_back(make_segment({make_word("second-recovery", 900, 1200)}));
+
+    crispasr_gap_fill_resolve_overlaps(segs);
+
+    require_monotone(segs);
+    REQUIRE(segs.size() == 5);
+    REQUIRE(segs[0].text == "head");
+    REQUIRE(segs[1].text == "first-recovery");
+    REQUIRE(segs[2].text == "mid");
+    REQUIRE(segs[3].text == "second-recovery");
+    REQUIRE(segs[4].text == "tail");
+}
+
+TEST_CASE("issue #356: recovery before the first word moves the covering segment after it",
+          "[unit][gap-fill][issue-356]") {
+    // The covering segment's span starts at/before the recovery but all its
+    // words sit past the recovery's end — nothing to keep on the left, so the
+    // segment itself becomes the tail.
+    std::vector<crispasr_segment> segs;
+    auto covering = make_segment({make_word("late-words", 800, 1000)});
+    covering.t0 = 200; // span inflated to the left (e.g. by an earlier aligner pass)
+    segs.push_back(covering);
+    segs.push_back(make_segment({make_word("recovery", 250, 600)}));
+
+    crispasr_gap_fill_resolve_overlaps(segs);
+
+    require_monotone(segs);
+    REQUIRE(segs.size() == 2);
+    REQUIRE(segs[0].text == "recovery");
+    REQUIRE(segs[1].text == "late-words");
+    REQUIRE(segs[1].t0 == 800);
+}
+
+TEST_CASE("issue #356: word-less covering segment is clamped at the recovery", "[unit][gap-fill][issue-356]") {
+    std::vector<crispasr_segment> segs;
+    crispasr_segment plain;
+    plain.text = "segment-level only";
+    plain.t0 = 100;
+    plain.t1 = 900;
+    segs.push_back(plain);
+    segs.push_back(make_segment({make_word("recovery", 400, 700)}));
+
+    crispasr_gap_fill_resolve_overlaps(segs);
+
+    require_monotone(segs);
+    REQUIRE(segs.size() == 2);
+    REQUIRE(segs[0].text == "segment-level only");
+    REQUIRE(segs[0].t1 == 400);
+}
+
+TEST_CASE("issue #356: already-monotone segments come through unchanged", "[unit][gap-fill][issue-356]") {
+    std::vector<crispasr_segment> segs;
+    segs.push_back(make_segment({make_word("one", 100, 200)}));
+    segs.push_back(make_segment({make_word("two", 200, 300)}));
+    segs.push_back(make_segment({make_word("three", 500, 600)}));
+    const auto before = joined_text(segs);
+
+    crispasr_gap_fill_resolve_overlaps(segs);
+
+    require_monotone(segs);
+    REQUIRE(segs.size() == 3);
+    REQUIRE(joined_text(segs) == before);
+    REQUIRE(segs[0].t0 == 100);
+    REQUIRE(segs[2].t1 == 600);
+}
+
+TEST_CASE("issue #356: no text is lost when splitting", "[unit][gap-fill][issue-356]") {
+    std::vector<crispasr_segment> segs;
+    segs.push_back(make_segment({
+        make_word("alpha", 0, 100),
+        make_word("omega", 2000, 2100),
+    }));
+    segs.push_back(make_segment({make_word("beta", 500, 900)}));
+    const auto before = std::string("alpha") + "beta" + "omega"; // reading order
+
+    crispasr_gap_fill_resolve_overlaps(segs);
+
+    require_monotone(segs);
+    REQUIRE(joined_text(segs) == before);
+}


### PR DESCRIPTION
Fixes #356.

## What was wrong

The #89 gap-fill second pass recovers speech the parakeet-ja encoder blanks inside a slice, but its final step was:

```cpp
segs.push_back(std::move(rec));
...
std::sort(segs.begin(), segs.end(),
          [](const crispasr_segment& a, const crispasr_segment& b) { return a.t0 < b.t0; });
```

The first pass emits **one** segment whose sparse words straddle the hole, so its `t0..t1` encloses every recovery — a sort cannot fix that. The covering segment sorts first and every recovery after it reads as a jump backwards in time; `--output-srt`/`--output-vtt` carried cues overlapping by up to the hole length (18 of 289 segments on the reporter's 634 s Japanese file, worst 10.5 s — see the trace in #356).

## The fix

`crispasr_gap_fill_resolve_overlaps` replaces the plain sort:

- A covering segment is **split at each recovery**: words/tokens starting at or after the recovery's end move into a new tail segment; both halves rebuild their display text from their words (the same convention as the overlap-save trim in `crispasr_run.cpp`, CJK-space rule included).
- A covering segment with **no words past the recovery** is clamped at the recovery's start (handles the segment-level-only fallback and boundary-tolerance stragglers).
- Runs to a fixpoint, so a span enclosing several recoveries is split at each one. Every split strictly reduces the word count of the segment being split, so it terminates.

No text is added or lost; the list comes out in reading order: head words, recovery, tail words. The server path (`crispasr_server.cpp`) picks the fix up automatically since it calls `crispasr_gap_fill_slice`.

## Tests

`tests/test-issue-356-gap-fill-overlap.cpp` — scripted fake backend, pure CPU, no model load, labeled `[issue-356]`:

- end-to-end through `crispasr_gap_fill_slice`, mirroring the reporter's 32.66→43.30 s slice (fails on the previous sort-only code with exactly the reported symptom: a recovery starting inside the covering segment's span)
- span enclosing two recoveries → split at each, 5 monotone segments
- recovery before the covering segment's first word → covering segment becomes the tail
- word-less covering segment → clamped
- already-monotone input → unchanged
- no text lost when splitting

```
All tests passed (36 assertions in 6 test cases)
```

`test-issue-114-chunk-context-gate` (1157 assertions) and `test-issue-89-long-audio-fallback` (16 assertions) still pass; `crispasr-cli` (which compiles both header consumers) builds warning-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)