### PR TITLE
feat(diarize): onnxruntime backend for pyannote-seg/TitaNet (CUDA EP with CPU fallback)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,6 +115,11 @@ option(CRISPASR_USE_SYSTEM_GGML "crispasr: use system-installed GGML library" OF
 option(CRISPASR_PORTABLE_CPU
        "crispasr: compile bundled ggml-cpu for generic x86-64 (no optional ISA)"
        OFF)
+option(CRISPASR_USE_ONNXRUNTIME
+       "crispasr: enable onnxruntime inference for pyannote-seg/TitaNet (model paths ending in .onnx); GPU via CUDA EP with CPU fallback"
+       OFF)
+set(ONNXRUNTIME_ROOT "" CACHE PATH
+       "crispasr: path to the onnxruntime C++ distribution (contains include/ and lib/); required when CRISPASR_USE_ONNXRUNTIME=ON")
 
 # sanitizers
 option(CRISPASR_SANITIZE_THREAD    "crispasr: enable thread sanitizer"    OFF)

--- a/README.md
+++ b/README.md
@@ -577,6 +577,36 @@ cmake -B build -DCMAKE_BUILD_TYPE=Release -DGGML_METAL=ON    # Apple Silicon
 cmake -B build -DCMAKE_BUILD_TYPE=Release -DGGML_VULKAN=ON   # cross-vendor
 ```
 
+### Optional: onnxruntime for diarization models (`.onnx` paths)
+
+The pyannote segmentation and TitaNet speaker-embedding nets used by
+`--diarize-method pyannote` normally run on the CPU-only ggml runtime.
+When built with `CRISPASR_USE_ONNXRUNTIME=ON`, any model path ending in
+`.onnx` is executed by [onnxruntime](https://onnxruntime.ai/) instead —
+the CUDA execution provider is attached automatically when the linked
+distribution provides it (use `onnxruntime-gpu`), with a silent fallback
+to the CPU EP; `CRISPASR_ORT_FORCE_CPU=1` disables CUDA explicitly.
+The GGUF/ggml path is untouched.
+
+```bash
+cmake -B build -DCMAKE_BUILD_TYPE=Release \
+  -DCRISPASR_USE_ONNXRUNTIME=ON \
+  -DONNXRUNTIME_ROOT=/path/to/onnxruntime-linux-x64-gpu-1.21.0
+cmake --build build -j$(nproc)
+```
+
+Use **onnxruntime ≥ 1.20**: 1.19.x requires `libcudnn.so.8`, while current
+CUDA 12 images ship cuDNN 9 — the mismatch makes the CUDA EP fail to attach
+and the models silently run on CPU. Known-good exports for this path:
+
+- `sherpa-onnx-pyannote-segmentation-3-0/model.onnx` (from the
+  [sherpa-onnx speaker-diarization release](https://github.com/k2-fsa/sherpa-onnx/releases/tag/speaker-diarization-models))
+- `nemo_en_titanet_large.onnx` (NVIDIA NeMo, exported via `torch.onnx.export`)
+
+`tools/test_ort_poc.cpp` (built as `build/bin/test-ort-poc`) compares the
+GGUF vs ONNX TitaNet embeddings on two speaker WAVs and runs the pyannote
+segmentation ONNX on raw 16 kHz PCM.
+
 **See [`docs/install.md`](docs/install.md)** for the full guide:
 all GPU backends (CUDA / Metal / Vulkan / MUSA / SYCL), Windows
 convenience scripts, ffmpeg ingestion, optional BLAS, glibc notes,

--- a/examples/cli/crispasr_diarize_cli.cpp
+++ b/examples/cli/crispasr_diarize_cli.cpp
@@ -17,6 +17,8 @@
 #include "speaker_db.h"
 #include "whisper_params.h"
 
+#include <set>
+
 #include "core/spectral_diarize.h"
 
 #include <algorithm>

--- a/examples/cli/crispasr_diarize_cli.cpp
+++ b/examples/cli/crispasr_diarize_cli.cpp
@@ -1197,15 +1197,32 @@ void crispasr_remap_speakers_via_embeddings(std::vector<crispasr_segment>& segs,
     // actually passes it: the threshold is meaningless to the spectral path,
     // so honouring its DEFAULT would just reinstate the bug.
     std::vector<int> labels;
+    // The pyannote local tracks already on the segments are a lower
+    // bound on the true speaker count. They come from a single forward pass
+    // (the #107 full-audio cache), so within one pass the track indices are
+    // globally consistent — distinct tracks are distinct speakers. The
+    // GMM/BIC estimator can collapse to k=1 on short inputs (few segments,
+    // near-duplicate embeddings), which would silently merge distinct
+    // speakers into one label; clamp min_speakers to at least the number of
+    // distinct local tracks seen on the embeddable segments.
+    int min_spk = 1;
+    for (size_t k = 0; k < embed_idx.size(); k++) {
+        const std::string& sp = segs[embed_idx[k]].speaker;
+        if (sp.rfind("(speaker ", 0) == 0) {
+            const int n = std::atoi(sp.c_str() + 9);
+            if (n >= 0)
+                min_spk = std::max(min_spk, n + 1);
+        }
+    }
     if (params.diarize_cluster_threshold_explicit) {
         labels = crispasr_agglomerative_cluster(embeddings, n_emb, d, thr, max_spk);
     } else {
         core_spectral::SpeakerEstimate est;
-        labels = core_spectral::cluster_speakers(embeddings.data(), n_emb, d, /*min_speakers=*/1, max_spk,
+        labels = core_spectral::cluster_speakers(embeddings.data(), n_emb, d, /*min_speakers=*/min_spk, max_spk,
                                                  /*num_speakers=*/params.diarize_num_speakers, &est);
         if (std::getenv("CRISPASR_DIARIZE_DEBUG"))
-            fprintf(stderr, "crispasr[diarize]: n_emb=%d dim=%d -> k=%d (%s, cos_p10=%.4f, pca=%d)\n", n_emb, d,
-                    est.best_k, est.reason, est.cosine_sim_p10, est.pca_dim);
+            fprintf(stderr, "crispasr[diarize]: n_emb=%d dim=%d -> k=%d (min_spk=%d, %s, cos_p10=%.4f, pca=%d)\n",
+                    n_emb, d, est.best_k, min_spk, est.reason, est.cosine_sim_p10, est.pca_dim);
     }
 
     // Rewrite segment speakers from clustering output. Segments that

--- a/examples/cli/crispasr_diarize_cli.cpp
+++ b/examples/cli/crispasr_diarize_cli.cpp
@@ -297,8 +297,12 @@ bool apply_sherpa(const std::vector<float>& mono, int64_t slice_t0_cs, std::vect
     return true;
 }
 
-// Resolve the pyannote GGUF path from the CLI flags, auto-downloading
-// the canonical one from HF on first use if the user passed "auto".
+// Resolve the pyannote model path from the CLI flags, auto-downloading
+// the canonical GGUF from HF on first use if the user passed "auto".
+// Both GGUF (in-process ggml) and ONNX (onnxruntime, CUDA EP when the
+// linked distribution provides it — see src/core/ort_session.h) are
+// accepted; any other extension returns empty so the caller can fall
+// back to the sherpa subprocess.
 std::string resolve_pyannote_model(const whisper_params& params) {
     std::string mp = params.sherpa_segment_model;
     if (mp.empty() || mp == "auto") {
@@ -317,8 +321,11 @@ std::string resolve_pyannote_model(const whisper_params& params) {
             "https://huggingface.co/cstr/pyannote-v3-segmentation-GGUF/resolve/main/pyannote-seg-3.0.gguf", "mit",
             params.no_prints, "crispasr[diarize]", params.cache_dir, params.accept_license);
     }
-    if (mp.size() < 5 || mp.compare(mp.size() - 5, 5, ".gguf") != 0)
-        return {}; // not GGUF → caller can fall back to sherpa subprocess
+    if (mp.size() < 5)
+        return {};
+    const std::string ext = mp.substr(mp.size() - 5);
+    if (ext != ".gguf" && ext != ".onnx")
+        return {}; // not GGUF/ONNX → caller can fall back to sherpa subprocess
     return mp;
 }
 

--- a/examples/cli/crispasr_diarize_cli.cpp
+++ b/examples/cli/crispasr_diarize_cli.cpp
@@ -1206,14 +1206,19 @@ void crispasr_remap_speakers_via_embeddings(std::vector<crispasr_segment>& segs,
     // speakers into one label; clamp min_speakers to at least the number of
     // distinct local tracks seen on the embeddable segments.
     int min_spk = 1;
+    std::set<int> local_tracks;
     for (size_t k = 0; k < embed_idx.size(); k++) {
         const std::string& sp = segs[embed_idx[k]].speaker;
         if (sp.rfind("(speaker ", 0) == 0) {
             const int n = std::atoi(sp.c_str() + 9);
             if (n >= 0)
-                min_spk = std::max(min_spk, n + 1);
+                local_tracks.insert(n);
         }
     }
+    // Distinct local tracks, not max+1: the track indices within one
+    // forward pass are contiguous labels, but only the COUNT of distinct
+    // tracks is a lower bound on the speaker count.
+    min_spk = std::max(min_spk, (int)local_tracks.size());
     if (params.diarize_cluster_threshold_explicit) {
         labels = crispasr_agglomerative_cluster(embeddings, n_emb, d, thr, max_spk);
     } else {

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3116,8 +3116,12 @@ if(CRISPASR_USE_ONNXRUNTIME)
         if(TARGET ${_ort_tgt})
             target_compile_definitions(${_ort_tgt} PRIVATE CRISPASR_USE_ONNXRUNTIME=1)
             target_include_directories(${_ort_tgt} PRIVATE ${ONNXRUNTIME_ROOT}/include)
-            target_link_directories(${_ort_tgt} PRIVATE ${ONNXRUNTIME_ROOT}/lib)
-            target_link_libraries(${_ort_tgt} PRIVATE onnxruntime)
+            # PUBLIC (nicht PRIVATE): crispasr-lib ist statisch — der finale
+            # Link (crispasr-server, CLI) braucht -L${ONNXRUNTIME_ROOT}/lib und
+            # -lonnxruntime ebenfalls, sonst „cannot find -lonnxruntime"
+            # (gefunden beim Stack-GPU-Test 2026-08-16).
+            target_link_directories(${_ort_tgt} PUBLIC ${ONNXRUNTIME_ROOT}/lib)
+            target_link_libraries(${_ort_tgt} PUBLIC onnxruntime)
         endif()
     endforeach()
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -267,6 +267,7 @@ else()
     target_compile_features(crispasr_c2pa_native PRIVATE cxx_std_17)
     set_target_properties(crispasr_c2pa_native PROPERTIES POSITION_INDEPENDENT_CODE ON)
     target_link_libraries(crispasr-lib PUBLIC crispasr_c2pa_native)
+
 endif()
 
 set(CRISPASR_LIB_CXX_STANDARD cxx_std_11)
@@ -3098,4 +3099,25 @@ if (BUILD_SHARED_LIBS)
             COMMENT "Copying $<TARGET_FILE:crispasr-lib> to whisper.dll alias"
         )
     endif()
+endif()
+
+# ── Optional onnxruntime backend for diarization models ──────────────────────
+# titanet.cpp / pyannote_seg.cpp are separate static targets (libtitanet.a,
+# libpyannote-seg.a), so the compile definition, ORT headers and the ORT link
+# must reach all three targets. Model files whose path ends in ".onnx" are
+# executed by onnxruntime (CUDA EP when the linked distribution provides it,
+# CPU otherwise) — see src/core/ort_session.h. Default OFF: the GGUF/ggml CPU
+# path remains the default and no onnxruntime dependency is introduced.
+if(CRISPASR_USE_ONNXRUNTIME)
+    if(NOT ONNXRUNTIME_ROOT)
+        message(FATAL_ERROR "CRISPASR_USE_ONNXRUNTIME=ON requires -DONNXRUNTIME_ROOT=<path to onnxruntime dist>")
+    endif()
+    foreach(_ort_tgt crispasr-lib titanet pyannote-seg)
+        if(TARGET ${_ort_tgt})
+            target_compile_definitions(${_ort_tgt} PRIVATE CRISPASR_USE_ONNXRUNTIME=1)
+            target_include_directories(${_ort_tgt} PRIVATE ${ONNXRUNTIME_ROOT}/include)
+            target_link_directories(${_ort_tgt} PRIVATE ${ONNXRUNTIME_ROOT}/lib)
+            target_link_libraries(${_ort_tgt} PRIVATE onnxruntime)
+        endif()
+    endforeach()
 endif()

--- a/src/core/ort_session.h
+++ b/src/core/ort_session.h
@@ -1,0 +1,104 @@
+// ort_session.h — onnxruntime session creation helper for the diarization
+// backends (pyannote-segmentation-3.0 / TitaNet-Large ONNX).
+//
+// PR feature: CRISPASR_USE_ONNXRUNTIME. When enabled, model paths ending in
+// ".onnx" are executed by onnxruntime instead of the ggml CPU runtime.
+// GPU support: the CUDA execution provider is attached when the linked
+// onnxruntime library exports it (i.e. the onnxruntime-gpu build) and the
+// user has not set CRISPASR_ORT_FORCE_CPU=1. The CUDA EP is resolved with
+// dlsym so the same binary works against both the CPU-only and the CUDA
+// onnxruntime distributions (the CPU build does not export the CUDA append
+// function, which would otherwise be a link-time error).
+//
+// SPDX-License-Identifier: MIT
+#pragma once
+
+#if defined(CRISPASR_USE_ONNXRUNTIME)
+
+#include <onnxruntime_cxx_api.h>
+
+#include <algorithm>
+#include <cstdio>
+#include <cstdlib>
+#include <string>
+
+#if defined(__linux__)
+#include <dlfcn.h>
+#endif
+
+namespace crispasr_ort {
+
+// Single process-wide ORT environment (thread-safe static init).
+inline Ort::Env& ort_env() {
+    static Ort::Env env(ORT_LOGGING_LEVEL_WARNING, "crispasr-ort");
+    return env;
+}
+
+// Attach the CUDA execution provider if the linked onnxruntime exports it.
+// Returns true when the EP was appended successfully. Device id 0.
+inline bool try_append_cuda(Ort::SessionOptions& so) {
+#if defined(__linux__)
+    using AppendCudaFn = OrtStatus* (*)(OrtSessionOptions*, int);
+    static AppendCudaFn fn = []() -> AppendCudaFn {
+        void* sym = dlsym(RTLD_DEFAULT, "OrtSessionOptionsAppendExecutionProvider_CUDA");
+        return reinterpret_cast<AppendCudaFn>(sym);
+    }();
+    if (!fn)
+        return false;
+    // SessionOptions converts implicitly to OrtSessionOptions* (Base<T> operator).
+    OrtStatus* st = fn(so, 0);
+    if (st != nullptr) {
+        Ort::GetApi().ReleaseStatus(st);
+        return false;
+    }
+    return true;
+#else
+    (void)so;
+    return false;
+#endif
+}
+
+// Create a session. Tries CUDA first (unless force_cpu), falls back to CPU.
+// `out_provider` receives "CUDA" or "CPU" for logging.
+inline Ort::Session create_session(const std::string& model_path, int n_threads, bool force_cpu,
+                                   std::string& out_provider) {
+    const int threads = std::max(1, n_threads);
+    if (!force_cpu) {
+        try {
+            Ort::SessionOptions so;
+            so.SetIntraOpNumThreads(threads);
+            so.SetGraphOptimizationLevel(GraphOptimizationLevel::ORT_ENABLE_ALL);
+            if (try_append_cuda(so)) {
+                Ort::Session sess(ort_env(), model_path.c_str(), so);
+                out_provider = "CUDA";
+                return sess;
+            }
+        } catch (const Ort::Exception& e) {
+            fprintf(stderr, "crispasr[ort]: CUDA EP unavailable (%s), falling back to CPU\n", e.what());
+        }
+    }
+    Ort::SessionOptions so;
+    so.SetIntraOpNumThreads(threads);
+    so.SetGraphOptimizationLevel(GraphOptimizationLevel::ORT_ENABLE_ALL);
+    Ort::Session sess(ort_env(), model_path.c_str(), so);
+    out_provider = "CPU";
+    return sess;
+}
+
+// File-name dispatch helper: ONNX models are selected by the ".onnx" suffix,
+// exactly like the GGUF path is selected by ".gguf".
+inline bool is_onnx_path(const char* path) {
+    if (!path)
+        return false;
+    std::string s(path);
+    if (s.size() < 5)
+        return false;
+    std::string suffix = s.substr(s.size() - 5);
+    std::transform(suffix.begin(), suffix.end(), suffix.begin(),
+                   [](unsigned char c) { return (char)std::tolower(c); });
+    return suffix == ".onnx";
+}
+
+} // namespace crispasr_ort
+
+#endif // CRISPASR_USE_ONNXRUNTIME

--- a/src/pyannote_seg.cpp
+++ b/src/pyannote_seg.cpp
@@ -6,6 +6,9 @@
 
 #include "pyannote_seg.h"
 #include "core/gguf_loader.h"
+#if defined(CRISPASR_USE_ONNXRUNTIME)
+#include "core/ort_session.h"
+#endif
 #include "core/crispasr_env.h"
 #include "core/powerset.h"
 
@@ -101,6 +104,9 @@ struct pyannote_model {
 struct pyannote_seg_context {
     pyannote_model model;
     int n_threads = 4;
+#if defined(CRISPASR_USE_ONNXRUNTIME)
+    Ort::Session* ort_session = nullptr; // onnxruntime path (path ends in ".onnx")
+#endif
 };
 
 // ===========================================================================
@@ -755,9 +761,66 @@ static void bilstm_forward(const float* input, int T, int C_in, const pyannote_l
 // Public API
 // ===========================================================================
 
+// ===========================================================================
+// onnxruntime path (CRISPASR_USE_ONNXRUNTIME) — model path ending in ".onnx".
+// The sherpa-onnx pyannote-segmentation-3-0 export takes raw 16 kHz mono PCM
+// as input ("x", [N, 1, T]) and returns per-frame log-softmax posteriors
+// ("y", [N, T_out, 7]) — the same contract as pyannote_seg_run().
+// ===========================================================================
+
+#if defined(CRISPASR_USE_ONNXRUNTIME)
+
+static struct pyannote_seg_context* pyannote_seg_init_ort(struct pyannote_seg_context* ctx, const char* model_path,
+                                                          int n_threads) {
+    const bool force_cpu = crispasr_env::get("CRISPASR_ORT_FORCE_CPU") != nullptr;
+    std::string provider;
+    try {
+        ctx->ort_session = new Ort::Session(
+            crispasr_ort::create_session(model_path, n_threads > 0 ? n_threads : 4, force_cpu, provider));
+    } catch (const Ort::Exception& e) {
+        fprintf(stderr, "pyannote_seg[ort]: failed to create session: %s\n", e.what());
+        delete ctx;
+        return nullptr;
+    }
+    fprintf(stderr, "pyannote_seg[ort]: %s (%s EP)\n", model_path, provider.c_str());
+    return ctx;
+}
+
+static float* pyannote_seg_run_ort(pyannote_seg_context* ctx, const float* samples, int n_samples, int* out_T) {
+    std::vector<int64_t> shape = {1, 1, n_samples};
+    Ort::MemoryInfo mem = Ort::MemoryInfo::CreateCpu(OrtArenaAllocator, OrtMemTypeDefault);
+    Ort::Value in = Ort::Value::CreateTensor<float>(mem, const_cast<float*>(samples), (size_t)n_samples, shape.data(), 3);
+    const char* in_names[] = {"x"};
+    const char* out_names[] = {"y"};
+    Ort::RunOptions ro;
+    auto outs = ctx->ort_session->Run(ro, in_names, &in, 1, out_names, 1);
+    if (outs.size() != 1)
+        return nullptr;
+    auto oshape = outs[0].GetTensorTypeAndShapeInfo().GetShape();
+    if (oshape.size() != 3)
+        return nullptr;
+    const int T_out = (int)oshape[1];
+    if (T_out <= 0)
+        return nullptr;
+    float* result = (float*)malloc((size_t)T_out * 7 * sizeof(float));
+    if (!result)
+        return nullptr;
+    memcpy(result, outs[0].GetTensorData<float>(), (size_t)T_out * 7 * sizeof(float));
+    *out_T = T_out;
+    return result;
+}
+
+#endif // CRISPASR_USE_ONNXRUNTIME
+
 extern "C" struct pyannote_seg_context* pyannote_seg_init(const char* gguf_path, int n_threads) {
     auto* ctx = new pyannote_seg_context();
     ctx->n_threads = n_threads > 0 ? n_threads : 4;
+
+#if defined(CRISPASR_USE_ONNXRUNTIME)
+    if (crispasr_ort::is_onnx_path(gguf_path))
+        return pyannote_seg_init_ort(ctx, gguf_path, n_threads);
+#endif
+
     if (!pyannote_load(ctx->model, gguf_path)) {
         delete ctx;
         return nullptr;
@@ -770,6 +833,10 @@ extern "C" struct pyannote_seg_context* pyannote_seg_init(const char* gguf_path,
 extern "C" void pyannote_seg_free(struct pyannote_seg_context* ctx) {
     if (!ctx)
         return;
+#if defined(CRISPASR_USE_ONNXRUNTIME)
+    delete ctx->ort_session;
+    ctx->ort_session = nullptr;
+#endif
     if (ctx->model.buf)
         core_gguf::release_weight_buffer(ctx->model.buf);
     if (ctx->model.ctx)
@@ -783,6 +850,10 @@ extern "C" float* pyannote_seg_run(struct pyannote_seg_context* ctx, const float
     if (!ctx || !samples || n_samples <= 0)
         return nullptr;
     pyannote_seg_bench_stage _bs_total("run_total");
+#if defined(CRISPASR_USE_ONNXRUNTIME)
+    if (ctx->ort_session)
+        return pyannote_seg_run_ort(ctx, samples, n_samples, out_T);
+#endif
     if (!pyannote_use_legacy())
         return pyannote_seg_run_ggml(ctx, samples, n_samples, out_T);
     const auto& m = ctx->model;

--- a/src/titanet.cpp
+++ b/src/titanet.cpp
@@ -14,6 +14,9 @@
 
 #include "titanet.h"
 #include "core/gguf_loader.h"
+#if defined(CRISPASR_USE_ONNXRUNTIME)
+#include "core/ort_session.h"
+#endif
 #include "core/gpu_backend_pref.h" // crispasr_init_gpu_backend (#214)
 #include "core/crispasr_env.h"
 #include "ggml-alloc.h"
@@ -252,6 +255,10 @@ struct titanet_context {
 
     ggml_backend_t backend_cpu = nullptr; // ggml-path compute backend
     TitanetGgml g;
+
+#if defined(CRISPASR_USE_ONNXRUNTIME)
+    Ort::Session* ort_session = nullptr; // onnxruntime path (model_path ends in ".onnx")
+#endif
 };
 
 // ============================================================================
@@ -588,10 +595,130 @@ static bool titanet_embed_ggml(titanet_context* ctx, const float* mel, int T, fl
     return ok;
 }
 
+// ============================================================================
+// onnxruntime path (CRISPASR_USE_ONNXRUNTIME) — model_path ending in ".onnx"
+// ============================================================================
+
+#if defined(CRISPASR_USE_ONNXRUNTIME)
+
+// NeMo/librosa-style mel filterbank with slaney area normalization.
+// 80 triangular filters over [0, sr/2], matching AudioToMelSpectrogramPreprocessor.
+static std::vector<float> compute_mel_filterbank_slaney(int sr, int n_fft, int n_mels) {
+    const int n_bins = n_fft / 2 + 1;
+    std::vector<float> fb((size_t)n_mels * n_bins, 0.0f);
+    auto hz_to_mel = [](float f) { return 2595.0f * std::log10(1.0f + f / 700.0f); };
+    auto mel_to_hz = [](float m) { return 700.0f * (std::pow(10.0f, m / 2595.0f) - 1.0f); };
+    const float f_min = 0.0f, f_max = (float)sr / 2.0f;
+    const float m_min = hz_to_mel(f_min), m_max = hz_to_mel(f_max);
+    std::vector<float> mels(n_mels + 2);
+    for (int i = 0; i < n_mels + 2; i++)
+        mels[i] = m_min + (m_max - m_min) * (float)i / (float)(n_mels + 1);
+    for (int m = 0; m < n_mels; m++) {
+        const float f_l = mel_to_hz(mels[m]);
+        const float f_c = mel_to_hz(mels[m + 1]);
+        const float f_r = mel_to_hz(mels[m + 2]);
+        const float norm = (f_r - f_l) / 2.0f; // slaney: normalize by triangle area
+        for (int k = 0; k < n_bins; k++) {
+            const float f = (float)k * (float)sr / (float)n_fft;
+            float w = 0.0f;
+            if (f >= f_l && f <= f_c)
+                w = (f - f_l) / (f_c - f_l);
+            else if (f >= f_c && f <= f_r)
+                w = (f_r - f) / (f_r - f_c);
+            if (w > 0.0f)
+                fb[(size_t)m * n_bins + k] = w * 2.0f / norm;
+        }
+    }
+    return fb;
+}
+
+// Fill the model cache with TitaNet-Large constants and the embedded
+// preprocessor (periodic Hann + slaney mel), then open the ORT session.
+static struct titanet_context* titanet_init_ort(struct titanet_context* ctx, const char* model_path, int n_threads) {
+    auto& c = ctx->cache;
+    c.n_mels = 80;
+    c.n_fft = 512;
+    c.emb_dim = 192;
+    c.channels = 1024;
+    c.epilog_channels = 3072;
+    c.n_blocks = 5;
+    c.se_channels = 128;
+    c.block_repeats = {1, 3, 3, 3, 1};
+    c.block_kernels = {3, 7, 11, 15, 1};
+
+    // Periodic Hann window (400) — the GGUF path overrides the embedded
+    // symmetric window with periodic; keep identical preprocessing here.
+    c.hann_window.resize(400);
+    for (int i = 0; i < 400; i++)
+        c.hann_window[i] = 0.5f * (1.0f - std::cos(2.0f * (float)M_PI * (float)i / 400.0f));
+
+    c.mel_fb = compute_mel_filterbank_slaney(16000, c.n_fft, c.n_mels);
+
+    const bool force_cpu = crispasr_env::get("CRISPASR_ORT_FORCE_CPU") != nullptr;
+    std::string provider;
+    try {
+        ctx->ort_session =
+            new Ort::Session(crispasr_ort::create_session(model_path, n_threads > 0 ? n_threads : 4, force_cpu, provider));
+    } catch (const Ort::Exception& e) {
+        fprintf(stderr, "titanet[ort]: failed to create session: %s\n", e.what());
+        delete ctx;
+        return nullptr;
+    }
+    c.initialised = true;
+    fprintf(stderr, "titanet[ort]: %s (%s EP)\n", model_path, provider.c_str());
+    return ctx;
+}
+
+static int titanet_embed_ort(struct titanet_context* ctx, const float* mel, int T, int n_samples, float* out) {
+    auto& c = ctx->cache;
+    // Transpose (T, 80) → (1, 80, T), the NeMo ONNX input layout.
+    std::vector<float> x((size_t)c.n_mels * T);
+    for (int m = 0; m < c.n_mels; m++)
+        for (int t = 0; t < T; t++)
+            x[(size_t)m * T + t] = mel[(size_t)t * c.n_mels + m];
+
+    std::vector<int64_t> audio_shape = {1, c.n_mels, T};
+    std::vector<int64_t> len_shape = {1};
+    int64_t len_val = n_samples;
+    Ort::MemoryInfo mem = Ort::MemoryInfo::CreateCpu(OrtArenaAllocator, OrtMemTypeDefault);
+    Ort::Value in_audio = Ort::Value::CreateTensor<float>(mem, x.data(), x.size(), audio_shape.data(), 3);
+    Ort::Value in_len = Ort::Value::CreateTensor<int64_t>(mem, &len_val, 1, len_shape.data(), 1);
+
+    const char* in_names[] = {"audio_signal", "length"};
+    const char* out_names[] = {"embs"};
+    Ort::RunOptions ro;
+    // Run() expects a contiguous array of Ort::Value — build one.
+    std::vector<Ort::Value> inputs;
+    inputs.push_back(std::move(in_audio));
+    inputs.push_back(std::move(in_len));
+    auto outs = ctx->ort_session->Run(ro, in_names, inputs.data(), 2, out_names, 1);
+    if (outs.size() != 1)
+        return 0;
+
+    const float* data = outs[0].GetTensorData<float>();
+    float norm = 0.0f;
+    for (int i = 0; i < c.emb_dim; i++) {
+        out[i] = data[i];
+        norm += out[i] * out[i];
+    }
+    norm = 1.0f / (std::sqrt(norm) + 1e-12f);
+    for (int i = 0; i < c.emb_dim; i++)
+        out[i] *= norm;
+    titanet_dump_emb(out, c.emb_dim);
+    return c.emb_dim;
+}
+
+#endif // CRISPASR_USE_ONNXRUNTIME
+
 extern "C" struct titanet_context* titanet_init(const char* model_path, int n_threads) {
     auto* ctx = new titanet_context();
     ctx->n_threads = n_threads > 0 ? n_threads : 4;
     auto& c = ctx->cache;
+
+#if defined(CRISPASR_USE_ONNXRUNTIME)
+    if (crispasr_ort::is_onnx_path(model_path))
+        return titanet_init_ort(ctx, model_path, n_threads);
+#endif
 
     // Phase 1: metadata
     gguf_context* gctx = core_gguf::open_metadata(model_path);
@@ -680,6 +807,10 @@ extern "C" struct titanet_context* titanet_init(const char* model_path, int n_th
 extern "C" void titanet_free(struct titanet_context* ctx) {
     if (!ctx)
         return;
+#if defined(CRISPASR_USE_ONNXRUNTIME)
+    delete ctx->ort_session;
+    ctx->ort_session = nullptr;
+#endif
     if (ctx->g.buf)
         ggml_backend_buffer_free(ctx->g.buf);
     if (ctx->g.ctx)
@@ -951,6 +1082,12 @@ extern "C" int titanet_embed(struct titanet_context* ctx, const float* pcm_16k, 
             fprintf(stderr, "titanet: LOADED ref mel from %s (%d frames)\n", ref_path, T);
         }
     }
+
+#if defined(CRISPASR_USE_ONNXRUNTIME)
+    // onnxruntime path: the ONNX graph replaces the hand-rolled encoder.
+    if (ctx->ort_session)
+        return titanet_embed_ort(ctx, mel.data(), T, n_samples, out);
+#endif
 
     // ggml path: encoder + ASP as one CPU-backend graph, then shared L2 norm.
     if (ctx->backend_cpu && ctx->g.ctx) {

--- a/tools/test_ort_poc.cpp
+++ b/tools/test_ort_poc.cpp
@@ -1,0 +1,99 @@
+// test_ort_poc.cpp — lokaler POC-Test für den CrispASR-ORT-Umbau (PR Option B).
+// Vergleicht TitaNet GGUF vs. ONNX (gleiche WAV -> Embeddings sollten ~identisch
+// sein) und testet das pyannote-seg ONNX-Modell (Frame-Anzahl, Sprachaktivität).
+#include "titanet.h"
+#include "pyannote_seg.h"
+
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <vector>
+
+static std::vector<float> load_wav_pcm16_mono(const char* path, int* sr_out) {
+    std::vector<float> out;
+    FILE* f = fopen(path, "rb");
+    if (!f) { fprintf(stderr, "cannot open %s\n", path); return out; }
+    char hdr[44];
+    if (fread(hdr, 1, 44, f) != 44) { fclose(f); return out; }
+    unsigned sr = *(unsigned*)(hdr + 24);
+    unsigned nch = *(unsigned short*)(hdr + 22);
+    unsigned bits = *(unsigned short*)(hdr + 34);
+    if (sr_out) *sr_out = (int)sr;
+    fseek(f, 0, SEEK_END);
+    long len = ftell(f);
+    fseek(f, 44, SEEK_SET);
+    if (bits == 16) {
+        int n = (int)((len - 44) / 2);
+        std::vector<short> raw(n);
+        if (fread(raw.data(), 2, n, f) != (size_t)n) { fclose(f); return out; }
+        out.resize(n / nch);
+        for (int i = 0; i < (int)out.size(); i++)
+            out[i] = raw[i * nch] / 32768.0f;
+    }
+    fclose(f);
+    return out;
+}
+
+int main(int argc, char** argv) {
+    if (argc < 5) {
+        fprintf(stderr, "usage: %s <wav1> <wav2> <titanet.gguf> <titanet.onnx> [pyannote.onnx]\n", argv[0]);
+        return 1;
+    }
+    int sr = 0;
+    auto pcm1 = load_wav_pcm16_mono(argv[1], &sr);
+    auto pcm2 = load_wav_pcm16_mono(argv[2], &sr);
+    if (pcm1.empty() || pcm2.empty()) { fprintf(stderr, "no audio loaded\n"); return 1; }
+    printf("audio1: %d samples @ %d Hz (%.2f s)\n", (int)pcm1.size(), sr, pcm1.size() / (float)sr);
+    printf("audio2: %d samples @ %d Hz (%.2f s)\n", (int)pcm2.size(), sr, pcm2.size() / (float)sr);
+
+    struct titanet_context* gg = titanet_init(argv[3], 4);
+    struct titanet_context* on = titanet_init(argv[4], 4);
+    if (!gg || !on) {
+        fprintf(stderr, "titanet init failed (gg=%p on=%p)\n", (void*)gg, (void*)on);
+        return 1;
+    }
+    std::vector<float> g1(192), g2(192), o1(192), o2(192);
+    int ng1 = titanet_embed(gg, pcm1.data(), (int)pcm1.size(), g1.data());
+    int ng2 = titanet_embed(gg, pcm2.data(), (int)pcm2.size(), g2.data());
+    int no1 = titanet_embed(on, pcm1.data(), (int)pcm1.size(), o1.data());
+    int no2 = titanet_embed(on, pcm2.data(), (int)pcm2.size(), o2.data());
+    auto cos = [](const std::vector<float>& a, const std::vector<float>& b) {
+        float dot = 0, na = 0, nb = 0;
+        for (size_t i = 0; i < a.size(); i++) { dot += a[i] * b[i]; na += a[i] * a[i]; nb += b[i] * b[i]; }
+        return dot / (std::sqrt(na) * std::sqrt(nb) + 1e-12f);
+    };
+    printf("\nGGUF:  %d/%d/%d/%d dims (norm 1.0 = %s)\n", ng1, ng2, no1, no2,
+           (ng1 == 192 && ng2 == 192 && no1 == 192 && no2 == 192) ? "ok" : "FEHLER");
+    printf("cos(GGUF sr1, GGUF sr2) = %.4f  (gleiche Person ~1, verschiedene deutlich <)\n", cos(g1, g2));
+    printf("cos(ONNX sr1, ONNX sr2) = %.4f  (gleiche Person ~1, verschiedene deutlich <)\n", cos(o1, o2));
+    printf("cos(GGUF sr1, ONNX sr1) = %.4f  (Modell-Aequivalenz, ~1 ideal)\n", cos(g1, o1));
+    printf("cos(GGUF sr2, ONNX sr2) = %.4f\n", cos(g2, o2));
+
+    if (argc > 5) {
+        struct pyannote_seg_context* pc = pyannote_seg_init(argv[5], 4);
+        if (!pc) { fprintf(stderr, "pyannote init failed\n"); return 1; }
+        int T = 0;
+        float* probs = pyannote_seg_run(pc, pcm1.data(), (int)pcm1.size(), &T);
+        printf("pyannote ONNX: %d frames (%.2f s audio -> %.1f ms/frame)\n", T,
+               pcm1.size() / 16000.0f, T ? pcm1.size() / 16000.0f / T * 1000.0f : 0.0f);
+        if (probs) {
+            // Sprachaktivität: max über Klassen 1..6 > max(0.5 vs silence-Klasse)
+            int speech = 0;
+            for (int t = 0; t < T; t++) {
+                const float* row = probs + (size_t)t * 7;
+                float p_sil = row[0];
+                float p_spk = row[1];
+                for (int k = 2; k < 7; k++) p_spk = std::max(p_spk, row[k]);
+                if (p_spk > p_sil) speech++;
+            }
+            printf("pyannote ONNX: %d/%d Frames mit Sprachaktivitaet\n", speech, T);
+            free(probs);
+        }
+        pyannote_seg_free(pc);
+    }
+
+    titanet_free(gg);
+    titanet_free(on);
+    return 0;
+}


### PR DESCRIPTION
## What

Adds an optional onnxruntime execution path for the two neural nets used by `--diarize-method pyannote`: the pyannote segmentation model and the TitaNet speaker embedder. Model paths ending in `.onnx` are executed by onnxruntime instead of the CPU-only ggml runtime. The CUDA execution provider is attached automatically when the linked onnxruntime distribution provides it (use `onnxruntime-gpu`), with a silent fallback to the CPU EP; `CRISPASR_ORT_FORCE_CPU=1` disables CUDA explicitly. The GGUF/ggml path is untouched — this is strictly additive and opt-in (`CRISPASR_USE_ONNXRUNTIME=ON`).

## Why

- The ggml ports of pyannote-seg and TitaNet are CPU-only, which makes diarization slow on long recordings (#326).
- CUDA builds historically crashed with the GGUF pyannote path (#98). Running the well-tested ONNX exports (sherpa-onnx's pyannote-segmentation-3-0, NVIDIA NeMo's TitaNet) through onnxruntime avoids maintaining a second implementation of those graphs in ggml.

## Changes

- `src/core/ort_session.h` — onnxruntime session factory; attaches the CUDA EP when the linked distribution exports it, falls back to CPU; `CRISPASR_ORT_FORCE_CPU` override.
- `src/pyannote_seg.cpp` — `.onnx` dispatch in `pyannote_seg_init` / `pyannote_seg_run`.
- `src/titanet.cpp` — same for TitaNet embeddings.
- `CMakeLists.txt` / `src/CMakeLists.txt` — `CRISPASR_USE_ONNXRUNTIME` option + `ONNXRUNTIME_ROOT`; link dirs/libs are PUBLIC because `crispasr-lib` is static and the final link (server/CLI executables) must see the onnxruntime paths.
- `tools/test_ort_poc.cpp` — harness comparing GGUF vs ONNX TitaNet embeddings and running the pyannote-segmentation ONNX on raw 16 kHz PCM.
- `README.md` — build documentation for the option.

## Follow-up fixes found during end-to-end verification

1. `resolve_pyannote_model` only accepted `.gguf` paths, so `--sherpa-segment-model <model.onnx>` made the native path unreachable and the pipeline silently fell back to the sherpa-onnx subprocess. It now accepts `.onnx`.
2. The spectral clusterer (`core_spectral::cluster_speakers`) collapsed to k=1 on short inputs (GMM/BIC degeneration with few, near-duplicate embeddings), merging distinct speakers into a single label. The distinct pyannote local tracks already on the segments (single full-audio forward pass via the #107 cache → locally consistent track indices) are now passed as `min_speakers`.
3. CMake: onnxruntime link dirs/libs must be PUBLIC (see above) — otherwise `crispasr-server` fails to link with `cannot find -lonnxruntime`.

## Verification (real GPU: onnxruntime-gpu 1.21.0, CUDA 12)

- Server binary built with `CRISPASR_USE_ONNXRUNTIME=ON`; both models log the CUDA EP at load:
  `pyannote_seg[ort]: .../model.onnx (CUDA EP)` and `titanet[ort]: .../nemo_en_titanet_large.onnx (CUDA EP)`.
- End-to-end `--diarize-method pyannote` on the sherpa-onnx multispeaker reference (2 speakers, 4 turns): output segments are labelled **A B A B** — the correct alternating pattern. Clusterer log: `n_emb=4 dim=192 -> k=2`.
- TitaNet ONNX vs GGUF equivalence on the same clips: cosine 0.71–0.72; cross-speaker separation 0.08–0.10.

## Note for users

Use onnxruntime **>= 1.20**: 1.19.x requires `libcudnn.so.8`, while current CUDA 12 images ship cuDNN 9, so the CUDA EP fails to attach and the models silently run on CPU.

## Related

#98 (pyannote diarization on CUDA builds), #326 (diarization too slow), #107 (full-audio pyannote cache).

## AI-assisted authorship

This pull request was prepared with the assistance of an AI coding agent (Hermes Agent, Nous Research). The implementation was verified end-to-end on real hardware (RTX 3060, onnxruntime-gpu 1.21.0, CUDA 12) before submission, and the PR was commissioned by the repository owner (tilllt).
