### PR TITLE
fix(diarize): clamp min speaker count to distinct pyannote local tracks

### DIFF
--- a/examples/cli/crispasr_diarize_cli.cpp
+++ b/examples/cli/crispasr_diarize_cli.cpp
@@ -1199,14 +1199,19 @@ void crispasr_remap_speakers_via_embeddings(std::vector<crispasr_segment>& segs,
     // speakers into one label; clamp min_speakers to at least the number of
     // distinct local tracks seen on the embeddable segments.
     int min_spk = 1;
+    std::set<int> local_tracks;
     for (size_t k = 0; k < embed_idx.size(); k++) {
         const std::string& sp = segs[embed_idx[k]].speaker;
         if (sp.rfind("(speaker ", 0) == 0) {
             const int n = std::atoi(sp.c_str() + 9);
             if (n >= 0)
-                min_spk = std::max(min_spk, n + 1);
+                local_tracks.insert(n);
         }
     }
+    // Distinct local tracks, not max+1: the track indices within one
+    // forward pass are contiguous labels, but only the COUNT of distinct
+    // tracks is a lower bound on the speaker count.
+    min_spk = std::max(min_spk, (int)local_tracks.size());
     if (params.diarize_cluster_threshold_explicit) {
         labels = crispasr_agglomerative_cluster(embeddings, n_emb, d, thr, max_spk);
     } else {

--- a/examples/cli/crispasr_diarize_cli.cpp
+++ b/examples/cli/crispasr_diarize_cli.cpp
@@ -17,6 +17,8 @@
 #include "speaker_db.h"
 #include "whisper_params.h"
 
+#include <set>
+
 #include "core/spectral_diarize.h"
 
 #include <algorithm>

--- a/examples/cli/crispasr_diarize_cli.cpp
+++ b/examples/cli/crispasr_diarize_cli.cpp
@@ -1190,15 +1190,32 @@ void crispasr_remap_speakers_via_embeddings(std::vector<crispasr_segment>& segs,
     // actually passes it: the threshold is meaningless to the spectral path,
     // so honouring its DEFAULT would just reinstate the bug.
     std::vector<int> labels;
+    // The pyannote local tracks already on the segments are a lower
+    // bound on the true speaker count. They come from a single forward pass
+    // (the #107 full-audio cache), so within one pass the track indices are
+    // globally consistent — distinct tracks are distinct speakers. The
+    // GMM/BIC estimator can collapse to k=1 on short inputs (few segments,
+    // near-duplicate embeddings), which would silently merge distinct
+    // speakers into one label; clamp min_speakers to at least the number of
+    // distinct local tracks seen on the embeddable segments.
+    int min_spk = 1;
+    for (size_t k = 0; k < embed_idx.size(); k++) {
+        const std::string& sp = segs[embed_idx[k]].speaker;
+        if (sp.rfind("(speaker ", 0) == 0) {
+            const int n = std::atoi(sp.c_str() + 9);
+            if (n >= 0)
+                min_spk = std::max(min_spk, n + 1);
+        }
+    }
     if (params.diarize_cluster_threshold_explicit) {
         labels = crispasr_agglomerative_cluster(embeddings, n_emb, d, thr, max_spk);
     } else {
         core_spectral::SpeakerEstimate est;
-        labels = core_spectral::cluster_speakers(embeddings.data(), n_emb, d, /*min_speakers=*/1, max_spk,
+        labels = core_spectral::cluster_speakers(embeddings.data(), n_emb, d, /*min_speakers=*/min_spk, max_spk,
                                                  /*num_speakers=*/params.diarize_num_speakers, &est);
         if (std::getenv("CRISPASR_DIARIZE_DEBUG"))
-            fprintf(stderr, "crispasr[diarize]: n_emb=%d dim=%d -> k=%d (%s, cos_p10=%.4f, pca=%d)\n", n_emb, d,
-                    est.best_k, est.reason, est.cosine_sim_p10, est.pca_dim);
+            fprintf(stderr, "crispasr[diarize]: n_emb=%d dim=%d -> k=%d (min_spk=%d, %s, cos_p10=%.4f, pca=%d)\n",
+                    n_emb, d, est.best_k, min_spk, est.reason, est.cosine_sim_p10, est.pca_dim);
     }
 
     // Rewrite segment speakers from clustering output. Segments that


### PR DESCRIPTION
Follow-up to the closed PR #364 — the standalone speaker-count fix you asked to be split out, on its own branch.

## What

In `--diarize-speakers` mode (pyannote segmentation + TitaNet embedder + `core_spectral` clustering), the GMM/BIC estimator can collapse to **k=1 on short inputs** (few segments, near-duplicate embeddings), silently merging distinct speakers into one label. The clustering now clamps `min_speakers` to at least the **number of distinct pyannote local tracks** seen on the embeddable segments — using the distinct-track count, not max+1, since sparse track indices (e.g. only tracks 1 and 2 active) would over-estimate.

The pyannote local tracks come from a single forward pass (the #107 full-audio cache), so within one pass track indices are globally consistent: distinct tracks are distinct speakers, and their count is a sound lower bound.

## Verification (CPU build, `samples/multispeaker.wav`, `CRISPASR_DIARIZE_DEBUG=1`)

```
crispasr[diarize]: n_emb=4 dim=192 -> k=2 (min_spk=2, gmm_bic, cos_p10=0.0778, pca=2)
```

Segments come out labelled 0/1/0/1 — two distinct speakers, correct. The same failure mode (few segments collapsing to k=1, `n_emb=5 -> k=1 (gmm_bic)`) was independently reproduced on this sample in the #364 discussion; with the clamp, `min_spk` appears in the debug line and forces k=2.

The debug line now also prints `min_spk` so the clamp is observable in `CRISPASR_DIARIZE_DEBUG` runs.

## Scope

- `examples/cli/crispasr_diarize_cli.cpp` only, +14/−2.
- No onnxruntime, no ggml changes, no new dependencies. Works for every embedder (`auto`/`titanet`, `indextts`, `ecapa`) since it only inspects the `(speaker N)` track labels already on the segments.

Note: AI-assisted authorship — this patch was developed and verified by an AI agent (Hermes Agent) on behalf of the PR author.