### PR TITLE
tts: apply per-request voice reference at synth time

### DIFF
--- a/examples/cli/crispasr_backend_f5_tts.cpp
+++ b/examples/cli/crispasr_backend_f5_tts.cpp
@@ -204,8 +204,8 @@ public:
             if (cache_enabled && crispasr_ref_cache::load(cache_path, p.tts_voice, "f5-reftext", shape, payload)) {
                 ref_text_str.assign((const char*)payload.data(), payload.size());
                 if (!p.no_prints) {
-                    fprintf(stderr, "crispasr[f5-tts]: using cached ref transcript '%s': '%s'\n",
-                            cache_path.c_str(), ref_text_str.c_str());
+                    fprintf(stderr, "crispasr[f5-tts]: using cached ref transcript '%s': '%s'\n", cache_path.c_str(),
+                            ref_text_str.c_str());
                 }
             } else {
                 // Resample ref to 16kHz for whisper

--- a/examples/cli/crispasr_backend_f5_tts.cpp
+++ b/examples/cli/crispasr_backend_f5_tts.cpp
@@ -142,96 +142,116 @@ public:
             return false;
         }
 
-        // Load reference audio for voice cloning.
-        //
-        // "default" / "auto" mean "use the built-in reference", the same sentinel
-        // cosyvoice3, tada and omnivoice already honour. f5-tts alone treated them
-        // as a filename and died with "failed to load reference audio 'default'",
-        // which is what broke `--voice default` in the TTS regression manifest.
+        // Voice cloning is intentionally NOT applied here (at startup): the
+        // HTTP server owns ONE backend instance and passes a per-request
+        // `voice=` in params.tts_voice, which only takes effect if re-applied
+        // at synth time (see prepare_voice below). Baking --voice at init alone
+        // made every /v1/audio/speech request serve the startup voice (or the
+        // built-in default when no --voice was given).
+
+        return true;
+    }
+
+    // Load + encode the reference WAV (voice cloning), re-loading only when the
+    // path changes so single-shot and server callers pay the encode once.
+    // Mirrors moss-tts prepare_voice: the server passes a per-request `voice=`
+    // into params.tts_voice which MUST be consumed at synth time. "default" /
+    // "auto" mean "use the built-in reference" (kept as-is); an empty voice
+    // also keeps the current reference.
+    void prepare_voice(const whisper_params& p) {
+        if (p.tts_voice == last_voice_)
+            return;
+        last_voice_ = p.tts_voice;
         const bool voice_is_sentinel = p.tts_voice == "default" || p.tts_voice == "auto";
-        if (!p.tts_voice.empty() && !voice_is_sentinel) {
-            int wav_sr = 0;
-            auto ref_pcm = read_wav_mono(p.tts_voice, &wav_sr);
-            if (ref_pcm.empty() || wav_sr <= 0) {
-                fprintf(stderr, "crispasr[f5-tts]: failed to load reference audio '%s'\n", p.tts_voice.c_str());
-                return false;
+        if (p.tts_voice.empty() || voice_is_sentinel)
+            return;
+
+        int wav_sr = 0;
+        auto ref_pcm = read_wav_mono(p.tts_voice, &wav_sr);
+        if (ref_pcm.empty() || wav_sr <= 0) {
+            fprintf(stderr, "crispasr[f5-tts]: failed to load reference audio '%s'\n", p.tts_voice.c_str());
+            last_voice_.clear();
+            return;
+        }
+
+        // Resample to 24kHz
+        auto ref_24k = resample_linear(ref_pcm, wav_sr, 24000);
+
+        // RMS normalize to 0.1 (matching Python reference)
+        float rms = 0.0f;
+        for (float s : ref_24k)
+            rms += s * s;
+        rms = sqrtf(rms / (float)ref_24k.size());
+        if (rms < 0.1f && rms > 1e-10f) {
+            float scale = 0.1f / rms;
+            for (float& s : ref_24k)
+                s *= scale;
+        }
+
+        // Auto-transcribe reference audio when --ref-text is missing.
+        // F5-TTS needs the ref transcript to estimate speech rate for
+        // duration calculation; without it, output length is wrong.
+        std::string ref_text_str = p.tts_ref_text;
+        if (ref_text_str.empty()) {
+            // The reference transcript is stable per voice clip, and
+            // auto-transcription loads + runs a whole ASR model. Cache it
+            // next to the voice as "<voice>.f5reftext" so later runs skip
+            // Whisper entirely. Disable with CRISPASR_TTS_REF_CACHE=0.
+            const std::string cache_path = crispasr_ref_cache::path_for(p.tts_voice, ".f5reftext");
+            const bool cache_enabled = !crispasr_ref_cache::disabled();
+            std::vector<uint32_t> shape;
+            std::vector<uint8_t> payload;
+            if (cache_enabled && crispasr_ref_cache::load(cache_path, p.tts_voice, "f5-reftext", shape, payload)) {
+                ref_text_str.assign((const char*)payload.data(), payload.size());
+                if (!p.no_prints) {
+                    fprintf(stderr, "crispasr[f5-tts]: using cached ref transcript '%s': '%s'\n",
+                            cache_path.c_str(), ref_text_str.c_str());
+                }
+            } else {
+                // Resample ref to 16kHz for whisper
+                auto ref_16k = resample_linear(ref_pcm, wav_sr, 16000);
+                std::string asr_name = p.tts_ref_asr.empty() ? "whisper" : p.tts_ref_asr;
+                if (!p.no_prints) {
+                    fprintf(stderr, "crispasr[f5-tts]: --ref-text not set, auto-transcribing via %s...\n",
+                            asr_name.c_str());
+                }
+                ref_text_str = crispasr_ref_text::transcribe(ref_16k, p, asr_name, "crispasr[f5-tts]");
+                if (cache_enabled && !ref_text_str.empty()) {
+                    crispasr_ref_cache::save(cache_path, "f5-reftext", {(uint32_t)ref_text_str.size()},
+                                             ref_text_str.data(), ref_text_str.size());
+                }
             }
-
-            // Resample to 24kHz
-            auto ref_24k = resample_linear(ref_pcm, wav_sr, 24000);
-
-            // RMS normalize to 0.1 (matching Python reference)
-            float rms = 0.0f;
-            for (float s : ref_24k)
-                rms += s * s;
-            rms = sqrtf(rms / (float)ref_24k.size());
-            if (rms < 0.1f && rms > 1e-10f) {
-                float scale = 0.1f / rms;
-                for (float& s : ref_24k)
-                    s *= scale;
-            }
-
-            // Auto-transcribe reference audio when --ref-text is missing.
-            // F5-TTS needs the ref transcript to estimate speech rate for
-            // duration calculation; without it, output length is wrong.
-            std::string ref_text_str = p.tts_ref_text;
             if (ref_text_str.empty()) {
-                // The reference transcript is stable per voice clip, and
-                // auto-transcription loads + runs a whole ASR model. Cache it
-                // next to the voice as "<voice>.f5reftext" so later runs skip
-                // Whisper entirely. Disable with CRISPASR_TTS_REF_CACHE=0.
-                const std::string cache_path = crispasr_ref_cache::path_for(p.tts_voice, ".f5reftext");
-                const bool cache_enabled = !crispasr_ref_cache::disabled();
-                std::vector<uint32_t> shape;
-                std::vector<uint8_t> payload;
-                if (cache_enabled && crispasr_ref_cache::load(cache_path, p.tts_voice, "f5-reftext", shape, payload)) {
-                    ref_text_str.assign((const char*)payload.data(), payload.size());
-                    if (!p.no_prints) {
-                        fprintf(stderr, "crispasr[f5-tts]: using cached ref transcript '%s': '%s'\n",
-                                cache_path.c_str(), ref_text_str.c_str());
-                    }
-                } else {
-                    // Resample ref to 16kHz for whisper
-                    auto ref_16k = resample_linear(ref_pcm, wav_sr, 16000);
-                    std::string asr_name = p.tts_ref_asr.empty() ? "whisper" : p.tts_ref_asr;
-                    if (!p.no_prints) {
-                        fprintf(stderr, "crispasr[f5-tts]: --ref-text not set, auto-transcribing via %s...\n",
-                                asr_name.c_str());
-                    }
-                    ref_text_str = crispasr_ref_text::transcribe(ref_16k, p, asr_name, "crispasr[f5-tts]");
-                    if (cache_enabled && !ref_text_str.empty()) {
-                        crispasr_ref_cache::save(cache_path, "f5-reftext", {(uint32_t)ref_text_str.size()},
-                                                 ref_text_str.data(), ref_text_str.size());
-                    }
+                if (!p.no_prints) {
+                    fprintf(stderr, "crispasr[f5-tts]: auto-transcription returned empty; "
+                                    "duration estimate may be inaccurate\n");
                 }
-                if (ref_text_str.empty()) {
-                    if (!p.no_prints) {
-                        fprintf(stderr, "crispasr[f5-tts]: auto-transcription returned empty; "
-                                        "duration estimate may be inaccurate\n");
-                    }
-                } else if (!p.no_prints) {
-                    fprintf(stderr, "crispasr[f5-tts]: auto-transcribed ref: '%s'\n", ref_text_str.c_str());
-                }
-            }
-
-            const char* ref_text = ref_text_str.empty() ? "" : ref_text_str.c_str();
-            if (f5_tts_set_reference(ctx_, ref_24k.data(), (int)ref_24k.size(), ref_text) != 0) {
-                fprintf(stderr, "crispasr[f5-tts]: failed to set reference audio\n");
-                return false;
-            }
-
-            if (!p.no_prints) {
-                fprintf(stderr, "crispasr[f5-tts]: loaded ref audio '%s' (%d@%dHz → %d@24kHz) ref_text='%s'\n",
-                        p.tts_voice.c_str(), (int)ref_pcm.size(), wav_sr, (int)ref_24k.size(), ref_text);
+            } else if (!p.no_prints) {
+                fprintf(stderr, "crispasr[f5-tts]: auto-transcribed ref: '%s'\n", ref_text_str.c_str());
             }
         }
 
-        return true;
+        const char* ref_text = ref_text_str.empty() ? "" : ref_text_str.c_str();
+        if (f5_tts_set_reference(ctx_, ref_24k.data(), (int)ref_24k.size(), ref_text) != 0) {
+            fprintf(stderr, "crispasr[f5-tts]: failed to set reference audio\n");
+            last_voice_.clear();
+            return;
+        }
+
+        if (!p.no_prints) {
+            fprintf(stderr, "crispasr[f5-tts]: loaded ref audio '%s' (%d@%dHz → %d@24kHz) ref_text='%s'\n",
+                    p.tts_voice.c_str(), (int)ref_pcm.size(), wav_sr, (int)ref_24k.size(), ref_text);
+        }
     }
 
     std::vector<float> synthesize(const std::string& text, const whisper_params& p) override {
         if (!ctx_)
             return {};
+
+        // Per-request voice cloning: the server copies the request's `voice`
+        // into params.tts_voice, so (re)apply the reference here whenever it
+        // changes. Sentinels/empty keep the built-in reference.
+        prepare_voice(p);
 
         // Update runtime params
         if (p.seed > 0)
@@ -266,6 +286,7 @@ public:
 
 private:
     f5_tts_context* ctx_ = nullptr;
+    std::string last_voice_; // cache key for the loaded reference voice
 };
 
 } // namespace

--- a/examples/cli/crispasr_backend_omnivoice.cpp
+++ b/examples/cli/crispasr_backend_omnivoice.cpp
@@ -106,13 +106,13 @@ public:
             omnivoice_set_language(ctx_, p.language.c_str());
         }
 
-        // Voice cloning
-        if (!p.tts_voice.empty()) {
-            std::string ref_text = p.tts_ref_text;
-            if (omnivoice_set_voice_prompt(ctx_, p.tts_voice.c_str(), ref_text.c_str()) != 0) {
-                fprintf(stderr, "crispasr[omnivoice]: failed to set voice prompt '%s'\n", p.tts_voice.c_str());
-            }
-        }
+        // Voice cloning is intentionally NOT applied here (at startup): the
+        // HTTP server owns ONE backend instance and passes a per-request
+        // `voice=` in params.tts_voice, which only takes effect if re-applied
+        // at synth time (see prepare_voice below) — the same shape as the
+        // per-request language/seed/instruct handling in synthesize(). Baking
+        // --voice at init alone made every /v1/audio/speech request serve the
+        // startup voice (or the built-in default when no --voice was given).
 
         // Style instruct. Upstream rejects an unsupported item rather than
         // ignoring it, so a bad --tts-instruct must fail the run — silently
@@ -144,6 +144,12 @@ public:
     std::vector<float> synthesize(const std::string& text, const whisper_params& params) override {
         if (!ctx_ || text.empty())
             return {};
+
+        // Per-request voice cloning, same reasoning as the per-request knobs
+        // below: the server copies the request's `voice` into
+        // params.tts_voice, so re-apply the reference prompt here whenever it
+        // changes (an empty value clears the prompt -> plain TTS).
+        prepare_voice(params);
 
         // Apply the diffusion step count PER CALL, not just at init: the server
         // reuses one backend instance and passes tts_num_steps per request, so a
@@ -209,7 +215,27 @@ public:
     }
 
 private:
+    // Re-apply the reference voice per request (mirror of moss-tts
+    // prepare_voice, and of the per-request language/seed/instruct handling in
+    // synthesize()). omnivoice_set_voice_prompt with an empty path clears the
+    // reference (plain TTS); with a path it encodes the WAV through the audio
+    // tokenizer into ref_audio_codes + ref_T. The encode is content-addressed
+    // disk-cached inside omnivoice.cpp, so re-calling it for the same ref is
+    // cheap. last_voice_ dedupes identical consecutive voices so a repeated
+    // request never pays the encode again.
+    void prepare_voice(const whisper_params& params) {
+        if (params.tts_voice == last_voice_)
+            return;
+        last_voice_ = params.tts_voice;
+        std::string ref_text = params.tts_ref_text;
+        if (omnivoice_set_voice_prompt(ctx_, params.tts_voice.c_str(), ref_text.c_str()) != 0) {
+            fprintf(stderr, "crispasr[omnivoice]: failed to set voice prompt '%s'\n", params.tts_voice.c_str());
+            last_voice_.clear();
+        }
+    }
+
     omnivoice_context* ctx_ = nullptr;
+    std::string last_voice_; // cache key for the loaded reference voice
 };
 
 } // namespace


### PR DESCRIPTION
## What
The HTTP TTS server reuses one backend instance for the whole session and passes each request's `voice` field into `params.tts_voice`. The `omnivoice` and `f5-tts` backends only consumed `tts_voice` at `init()` (from the `--voice` flag), so `/v1/audio/speech` always served the startup voice — or the built-in default when no `--voice` was given — regardless of the uploaded reference.

## Change
- Add `prepare_voice(params)` to both backends (mirroring `moss-tts`), called from `synthesize()`:
  - re-applies the reference whenever `tts_voice` changes, deduped via `last_voice_` so identical consecutive voices don't re-encode
  - empty voice clears the omnivoice prompt (plain TTS); f5 keeps the built-in reference for empty / `"default"` / `"auto"`
- Follows the existing per-request language/seed/instruct pattern already present in the omnivoice `synthesize()`.

## Verification
- Windows x64 + CUDA Release build of `crispasr-cli` succeeds
- TTS-related unit tests pass (omnivoice prompt/lang/instruct/seed/duration, voice-clone-policy, tts-ref-cache, tts-lang, tts-phonemes-policy, params, speaker-identity, marking-policy)
