### PR TITLE
f5-tts: count UTF-8 characters in duration estimate

### DIFF
--- a/src/f5_tts.cpp
+++ b/src/f5_tts.cpp
@@ -132,6 +132,20 @@ struct f5_bench_stage {
 
 // ── Hyperparameters ──────────────────────────────────────────────
 
+// UTF-8 codepoint count (not byte count). The duration estimate derives a
+// speech rate from the reference transcript and applies it to the target text;
+// strlen() counts bytes, so non-ASCII scripts (Devanagari, CJK: 3 bytes/char)
+// inflate the estimated duration ~3x, which makes the ODE solve quadratically
+// longer and minutes long.
+static size_t utf8_len(const char* s) {
+    size_t n = 0;
+    for (; *s; ++s) {
+        if (((unsigned char)*s & 0xC0) != 0x80)
+            ++n;
+    }
+    return n;
+}
+
 struct f5_hparams {
     int dim = 1024;
     int depth = 22;
@@ -2385,9 +2399,9 @@ int f5_tts_synthesize(struct f5_tts_context* ctx, const char* text, float** pcm_
         float ref_secs = (float)ref_T / mel_fps;
         ref_text_len = std::max(1, (int)(ref_secs * 13.0f));
     } else {
-        ref_text_len = (int)ref_text.size();
+        ref_text_len = (int)utf8_len(ref_text.c_str());
     }
-    int gen_text_len = (int)strlen(text);
+    int gen_text_len = (int)utf8_len(text);
     // Per-char speech rate derived from the reference (mel frames per char).
     // #294: the guard here must be ASYMMETRIC. Under-estimating the rate makes
     // `duration` too short and TRUNCATES the generated speech (drops the tail of


### PR DESCRIPTION
## What
The f5-tts duration estimate derives a speech rate from the reference transcript (`ref_T / ref_text_len`) and applies it to the target text, but both lengths used byte counts (`strlen()` / `ref_text.size()`). For non-ASCII scripts — Devanagari, CJK, etc., 3 bytes per character — the target length is inflated ~3x, so a short line was estimated at ~3x its real duration. Since the ODE solve cost scales quadratically with the mel sequence length, that turned a ~2-second line into minutes of synthesis (a 1025-frame target instead of ~350).

## Change
- Add `utf8_len()` (codepoint count) and use it for both `ref_text_len` and `gen_text_len` in the duration estimate
- ASCII text is byte-for-byte unaffected (1 byte per codepoint)

## Verification
- Windows x64 + CUDA Release build of `crispasr-cli` succeeds
- Hindi line: estimated duration drops from ~1025 mel frames to ~530, synthesis completes in seconds instead of minutes
