### PR TITLE
fix(canary): prevent repeated streamed overlap in #375

### DIFF
--- a/src/canary.cpp
+++ b/src/canary.cpp
@@ -1684,6 +1684,25 @@ extern "C" struct canary_result* canary_transcribe_streamed(struct canary_contex
             }
         }
 
+        // #375: after the encoder-graph lifetime fix (73bb9b2f), the AED can
+        // choose different wording for the overlap on adjacent chunks.  The
+        // token-id LCS above then finds no match and the re-transcribed prefix
+        // is appended verbatim, producing repeated phrases (and timestamps
+        // that move backwards).  Apply the conservative time signal here:
+        // only trim a prefix of at least two complete tokens whose end is
+        // already at or before the last accepted token.  A one-token prefix is
+        // intentionally retained; boundary timing can put a genuine first
+        // word slightly early, and this avoids the false-positive seen in
+        // #365 ("Many").  The fuzzy word matcher remains opt-in for cases
+        // where timing alone is insufficient.
+        if (chunks_processed > 0 && !all_tokens.empty() && part->n_tokens > n_skip) {
+            const int64_t accepted_end_cs = all_tokens.back().t1;
+            const int covered = core_overlap_trim::leading_covered_multi(
+                part->n_tokens, accepted_end_cs, [&](int i) { return part->tokens[i].t1; });
+            if (covered > 0)
+                n_skip = std::max(n_skip, covered);
+        }
+
         // #365: fuzzy seam dedup, UNDER the LCS result.
         //
         // The LCS above compares token ids, so it only fires when the decoder

--- a/src/core/asr_overlap_trim.h
+++ b/src/core/asr_overlap_trim.h
@@ -63,6 +63,14 @@ template <typename F> inline int leading_covered(int n, int64_t accepted_end_cs,
     return skip;
 }
 
+// Conservative streamed-seam variant. A single early token can be a genuine
+// first word whose decoder timestamp straddles the seam; require at least two
+// covered tokens before treating the prefix as re-transcribed overlap.
+template <typename F> inline int leading_covered_multi(int n, int64_t accepted_end_cs, F t1_of) {
+    const int skip = leading_covered(n, accepted_end_cs, t1_of);
+    return skip >= 2 && skip < n ? skip : 0;
+}
+
 
 // ---------------------------------------------------------------------------
 // Fuzzy seam dedup

--- a/tests/test-asr-overlap-trim.cpp
+++ b/tests/test-asr-overlap-trim.cpp
@@ -80,6 +80,16 @@ TEST_CASE("overlap trim: an entirely covered chunk reports every token", "[unit]
     REQUIRE(trim(next_chunk, 99999) == 2);
 }
 
+TEST_CASE("overlap trim: conservative seam rule requires two covered tokens", "[unit][overlap][issue-375]") {
+    const std::vector<Tok> one_early = {{" Many", 100, 200}, {" people", 200, 400}};
+    REQUIRE(core_overlap_trim::leading_covered_multi(
+                (int)one_early.size(), 250, [&](int i) { return one_early[(size_t)i].t1; }) == 0);
+
+    const std::vector<Tok> repeated = {{" rendu", 100, 200}, {" compte", 200, 250}, {" real", 250, 400}};
+    REQUIRE(core_overlap_trim::leading_covered_multi(
+                (int)repeated.size(), 250, [&](int i) { return repeated[(size_t)i].t1; }) == 2);
+}
+
 TEST_CASE("overlap trim: scanning stops at the first uncovered token", "[unit][overlap][issue-365]") {
     // A decoder can emit a stray token whose timing sits behind its neighbours.
     // Scanning the whole chunk and counting every covered token would drop real


### PR DESCRIPTION
## What changed

Canary streamed decoding now removes a conservative multi-token prefix when its token end times are already covered by the previous chunk. This catches reworded overlap that token-ID LCS cannot match, without enabling the broader fuzzy seam dedup or reverting the 73bb9b2f scheduler UAF fix. Single early tokens remain untouched.

## Validation

- `cmake --build /tmp/crispasr-build-375b --target test-asr-overlap-trim canary -j2`
- `test-asr-overlap-trim` (19 assertions, 8 cases)

The reporter did not attach audio/model details, so live reproduction on the HP Z800 input is still needed.