### PR TITLE
fix(#385): fire session progress callback on unified long-form dispatch

### DIFF
--- a/include/crispasr_session.h
+++ b/include/crispasr_session.h
@@ -71,6 +71,12 @@ CRISPASR_SESSION_API void crispasr_reset_progress(void);
 // Single-pass and non-Parakeet backends do not fire it. The module-level
 // atomic (crispasr_get_progress) is updated in lockstep, so pure pollers
 // (e.g. Dart FFI) get chunked progress without registering a callback.
+//
+// Issue #385: between the unified-dispatch switch (0.8.24) and 0.8.29 the
+// default non-JA Parakeet path ran through a shared orchestrator with no
+// progress hook, so neither the callback nor the atomic moved until the
+// call returned. The hook now lives in the orchestrator itself (one fire
+// per long-form window), so the contract holds on every dispatch path.
 typedef void (*crispasr_progress_callback)(int processed, int total, void* user_data);
 
 // Register (or clear, with cb == NULL) the session progress callback.

--- a/src/crispasr_c_api.cpp
+++ b/src/crispasr_c_api.cpp
@@ -5556,8 +5556,12 @@ static crispasr_session_result* transcribe_single(crispasr_session* s, const flo
                 }
                 for (auto& w : sw)
                     words.push_back(std::move(w));
-                if (s->progress_cb)
-                    s->progress_cb((int)si + 1, (int)slices.size(), s->progress_ud);
+                // Issue #385: report through the shared helper so the pollable
+                // g_progress atomic moves in lockstep with the callback — this
+                // path used to fire the callback alone, leaving Dart-style
+                // pollers at 0 % for the whole JA run. Units are slices, not
+                // samples (pre-existing on this path).
+                session_report_progress(s, (int)si + 1, (int)slices.size());
             }
             std::sort(
                 words.begin(), words.end(),

--- a/src/crispasr_c_api.cpp
+++ b/src/crispasr_c_api.cpp
@@ -4944,6 +4944,23 @@ CA_EXPORT crispasr_session_result* crispasr_session_transcribe_lang(crispasr_ses
 // session path bounds the FastConformer encode on long audio instead of
 // building one O(T^2) full-length graph.
 
+// The one definition of the #208 progress contract: mirror the pollable
+// g_progress atomic, then the per-session callback, in lockstep — every
+// long-form path reports through here so the two cannot drift apart (#385
+// was exactly that drift: a path that updated neither).
+static void session_report_progress(crispasr_session* s, int processed, int total) {
+    g_progress.store(total > 0 ? (int)((int64_t)processed * 100 / total) : 0, std::memory_order_relaxed);
+    if (s && s->progress_cb)
+        s->progress_cb(processed, total, s->progress_ud);
+}
+
+// Issue #208: started(0) / idle(-1) bracket around a long-form run, RAII so
+// no exit — early return or failure — can leak a stale percentage to pollers.
+struct scoped_session_progress {
+    scoped_session_progress() { g_progress.store(0, std::memory_order_relaxed); }
+    ~scoped_session_progress() { g_progress.store(-1, std::memory_order_relaxed); }
+};
+
 // Normalize a word for boundary-dedup comparison: lowercase + drop ASCII
 // punctuation. Non-ASCII bytes (JA / accented text) are kept verbatim.
 static std::string parakeet_norm_word(const char* s) {
@@ -4984,7 +5001,7 @@ static std::string parakeet_norm_word(const char* s) {
 static void parakeet_session_chunked_merge(parakeet_context* ctx, const float* samples, int n_samples,
                                            int chunk_samples, int overlap_samples,
                                            std::vector<crispasr_session_seg>& out,
-                                           crispasr_progress_callback prog_cb = nullptr, void* prog_ud = nullptr) {
+                                           crispasr_session* sess = nullptr) {
     const int SR = 16000;
     if (chunk_samples < SR)
         chunk_samples = SR; // 1 s floor
@@ -5035,11 +5052,8 @@ static void parakeet_session_chunked_merge(parakeet_context* ctx, const float* s
         }
         // Issue #208: report progress after each finished window. `end` is the
         // last input sample this window covered, so it is monotonically
-        // non-decreasing and reaches n_samples on the final window. Mirror it
-        // into the module-level atomic so pollers (Dart FFI) also see it.
-        g_progress.store((int)((int64_t)end * 100 / n_samples), std::memory_order_relaxed);
-        if (prog_cb)
-            prog_cb(end, n_samples, prog_ud);
+        // non-decreasing and reaches n_samples on the final window.
+        session_report_progress(sess, end, n_samples);
         if (end >= n_samples)
             break;
     }
@@ -5421,25 +5435,11 @@ static crispasr_session_result* transcribe_single(crispasr_session* s, const flo
             // Issue #385: the unified dispatch dropped the #208 progress
             // contract — neither s->progress_cb nor the pollable g_progress
             // atomic was touched, so chunked long-form callers saw 0 % until
-            // return. Route the orchestrator's per-window progress through
-            // both, in lockstep as the session header documents. `pc` lives on
-            // this frame; the orchestrator only fires the callback on the
-            // calling thread, inside this call.
-            struct prog_ctx {
-                crispasr_progress_callback cb;
-                void* ud;
-            } pc{s->progress_cb, s->progress_ud};
-            oo.progress_cb = [](int done, int total, void* ud) {
-                g_progress.store(total > 0 ? (int)((int64_t)done * 100 / total) : 0, std::memory_order_relaxed);
-                const auto* p = static_cast<const prog_ctx*>(ud);
-                if (p->cb)
-                    p->cb(done, total, p->ud);
-            };
-            oo.progress_ud = &pc;
-            g_progress.store(0, std::memory_order_relaxed); // issue #208: pollers see "started"
-            auto segs = parakeet_transcribe_segments(s->parakeet_ctx, pcm, n_samples, 0, is_ja, oo);
-            g_progress.store(-1, std::memory_order_relaxed); // back to idle
-            for (auto& ps : segs) {
+            // return. The orchestrator invokes on_progress on the calling
+            // thread, inside this call, so capturing `s` is safe.
+            oo.on_progress = [s](int done, int total) { session_report_progress(s, done, total); };
+            scoped_session_progress prog;
+            for (auto& ps : parakeet_transcribe_segments(s->parakeet_ctx, pcm, n_samples, 0, is_ja, oo)) {
                 crispasr_session_seg seg;
                 seg.text = std::move(ps.text);
                 seg.t0 = ps.t0;
@@ -5666,9 +5666,8 @@ static crispasr_session_result* transcribe_single(crispasr_session* s, const flo
             if (const char* e = getenv("CRISPASR_PARAKEET_STREAM_CHUNK"))
                 enc_window = std::max(2, atoi(e));
             const int ov = s->parakeet_force_overlap_seconds >= 0 ? s->parakeet_force_overlap_seconds : 2;
-            g_progress.store(0, std::memory_order_relaxed);
+            scoped_session_progress prog;
             parakeet_result* pr = parakeet_transcribe_streamed(s->parakeet_ctx, pcm, n_samples, 0, enc_window, ov);
-            g_progress.store(-1, std::memory_order_relaxed);
             if (!pr) {
                 delete r;
                 return nullptr;
@@ -5682,10 +5681,9 @@ static crispasr_session_result* transcribe_single(crispasr_session* s, const flo
         // merge (no dropped sections, no boundary duplicates). Emits one merged
         // segment (the #208 batch-caller contract).
         if (!use_single_pass && !is_ja) {
-            g_progress.store(0, std::memory_order_relaxed); // issue #208: pollers see "started"
+            scoped_session_progress prog; // issue #208: pollers see "started"; idle again on return
             parakeet_session_chunked_merge(s->parakeet_ctx, pcm, n_samples, chunk_s * SR, overlap_s * SR, r->segments,
-                                           s->progress_cb, s->progress_ud);
-            g_progress.store(-1, std::memory_order_relaxed); // back to idle
+                                           s);
             return r;
         }
 
@@ -5697,9 +5695,8 @@ static crispasr_session_result* transcribe_single(crispasr_session* s, const flo
         if (const char* e = getenv("CRISPASR_PARAKEET_VAD_SLICE_CAP"))
             ja_cap_s = std::max(0, atoi(e));
         if (!use_single_pass && is_ja && ja_cap_s > 0 && !force_chunked) {
-            g_progress.store(0, std::memory_order_relaxed);
+            scoped_session_progress prog;
             r->segments.push_back(transcribe_ja_sliced(pcm, n_samples, SR, ja_cap_s));
-            g_progress.store(-1, std::memory_order_relaxed);
             return r;
         }
 

--- a/src/crispasr_c_api.cpp
+++ b/src/crispasr_c_api.cpp
@@ -5418,7 +5418,28 @@ static crispasr_session_result* transcribe_single(crispasr_session* s, const flo
             oo.chunk_overlap_seconds =
                 s->parakeet_force_overlap_seconds >= 0 ? (float)s->parakeet_force_overlap_seconds : 2.0f;
             oo.no_prints = false;
-            for (auto& ps : parakeet_transcribe_segments(s->parakeet_ctx, pcm, n_samples, 0, is_ja, oo)) {
+            // Issue #385: the unified dispatch dropped the #208 progress
+            // contract — neither s->progress_cb nor the pollable g_progress
+            // atomic was touched, so chunked long-form callers saw 0 % until
+            // return. Route the orchestrator's per-window progress through
+            // both, in lockstep as the session header documents. `pc` lives on
+            // this frame; the orchestrator only fires the callback on the
+            // calling thread, inside this call.
+            struct prog_ctx {
+                crispasr_progress_callback cb;
+                void* ud;
+            } pc{s->progress_cb, s->progress_ud};
+            oo.progress_cb = [](int done, int total, void* ud) {
+                g_progress.store(total > 0 ? (int)((int64_t)done * 100 / total) : 0, std::memory_order_relaxed);
+                const auto* p = static_cast<const prog_ctx*>(ud);
+                if (p->cb)
+                    p->cb(done, total, p->ud);
+            };
+            oo.progress_ud = &pc;
+            g_progress.store(0, std::memory_order_relaxed); // issue #208: pollers see "started"
+            auto segs = parakeet_transcribe_segments(s->parakeet_ctx, pcm, n_samples, 0, is_ja, oo);
+            g_progress.store(-1, std::memory_order_relaxed); // back to idle
+            for (auto& ps : segs) {
                 crispasr_session_seg seg;
                 seg.text = std::move(ps.text);
                 seg.t0 = ps.t0;

--- a/src/crispasr_c_api.cpp
+++ b/src/crispasr_c_api.cpp
@@ -5000,8 +5000,7 @@ static std::string parakeet_norm_word(const char* s) {
 // (nothing dropped) with no boundary duplication.
 static void parakeet_session_chunked_merge(parakeet_context* ctx, const float* samples, int n_samples,
                                            int chunk_samples, int overlap_samples,
-                                           std::vector<crispasr_session_seg>& out,
-                                           crispasr_session* sess = nullptr) {
+                                           std::vector<crispasr_session_seg>& out, crispasr_session* sess = nullptr) {
     const int SR = 16000;
     if (chunk_samples < SR)
         chunk_samples = SR; // 1 s floor

--- a/src/crispasr_c_api.cpp
+++ b/src/crispasr_c_api.cpp
@@ -427,6 +427,14 @@ CA_EXPORT void crispasr_reset_progress(void) {
     g_progress.store(-1, std::memory_order_relaxed);
 }
 
+// Internal counterpart: mark a long-form run as started (0 %) so pollers see
+// progress before the first window finishes. Paired with
+// crispasr_reset_progress() when the run returns. Not exported — pollers only
+// ever read; the transcribe paths own the writes.
+static void crispasr_start_progress(void) {
+    g_progress.store(0, std::memory_order_relaxed);
+}
+
 // =========================================================================
 // whisper_full_params setters
 // =========================================================================
@@ -5430,9 +5438,9 @@ static crispasr_session_result* transcribe_single(crispasr_session* s, const flo
             // return. The orchestrator invokes on_progress on the calling
             // thread, inside this call, so capturing `s` is safe.
             oo.on_progress = [s](int done, int total) { session_report_progress(s, done, total); };
-            g_progress.store(0, std::memory_order_relaxed); // issue #208: pollers see "started"
+            crispasr_start_progress(); // issue #208: pollers see "started"
             auto segs = parakeet_transcribe_segments(s->parakeet_ctx, pcm, n_samples, 0, is_ja, oo);
-            g_progress.store(-1, std::memory_order_relaxed); // back to idle
+            crispasr_reset_progress(); // back to idle
             for (auto& ps : segs) {
                 crispasr_session_seg seg;
                 seg.text = std::move(ps.text);
@@ -5664,9 +5672,9 @@ static crispasr_session_result* transcribe_single(crispasr_session* s, const flo
             if (const char* e = getenv("CRISPASR_PARAKEET_STREAM_CHUNK"))
                 enc_window = std::max(2, atoi(e));
             const int ov = s->parakeet_force_overlap_seconds >= 0 ? s->parakeet_force_overlap_seconds : 2;
-            g_progress.store(0, std::memory_order_relaxed);
+            crispasr_start_progress();
             parakeet_result* pr = parakeet_transcribe_streamed(s->parakeet_ctx, pcm, n_samples, 0, enc_window, ov);
-            g_progress.store(-1, std::memory_order_relaxed);
+            crispasr_reset_progress();
             if (!pr) {
                 delete r;
                 return nullptr;
@@ -5680,10 +5688,10 @@ static crispasr_session_result* transcribe_single(crispasr_session* s, const flo
         // merge (no dropped sections, no boundary duplicates). Emits one merged
         // segment (the #208 batch-caller contract).
         if (!use_single_pass && !is_ja) {
-            g_progress.store(0, std::memory_order_relaxed); // issue #208: pollers see "started"
+            crispasr_start_progress(); // issue #208: pollers see "started"
             parakeet_session_chunked_merge(s->parakeet_ctx, pcm, n_samples, chunk_s * SR, overlap_s * SR, r->segments,
                                            s);
-            g_progress.store(-1, std::memory_order_relaxed); // back to idle
+            crispasr_reset_progress(); // back to idle
             return r;
         }
 
@@ -5695,9 +5703,9 @@ static crispasr_session_result* transcribe_single(crispasr_session* s, const flo
         if (const char* e = getenv("CRISPASR_PARAKEET_VAD_SLICE_CAP"))
             ja_cap_s = std::max(0, atoi(e));
         if (!use_single_pass && is_ja && ja_cap_s > 0 && !force_chunked) {
-            g_progress.store(0, std::memory_order_relaxed);
+            crispasr_start_progress();
             r->segments.push_back(transcribe_ja_sliced(pcm, n_samples, SR, ja_cap_s));
-            g_progress.store(-1, std::memory_order_relaxed);
+            crispasr_reset_progress();
             return r;
         }
 

--- a/src/crispasr_c_api.cpp
+++ b/src/crispasr_c_api.cpp
@@ -4954,13 +4954,6 @@ static void session_report_progress(crispasr_session* s, int processed, int tota
         s->progress_cb(processed, total, s->progress_ud);
 }
 
-// Issue #208: started(0) / idle(-1) bracket around a long-form run, RAII so
-// no exit — early return or failure — can leak a stale percentage to pollers.
-struct scoped_session_progress {
-    scoped_session_progress() { g_progress.store(0, std::memory_order_relaxed); }
-    ~scoped_session_progress() { g_progress.store(-1, std::memory_order_relaxed); }
-};
-
 // Normalize a word for boundary-dedup comparison: lowercase + drop ASCII
 // punctuation. Non-ASCII bytes (JA / accented text) are kept verbatim.
 static std::string parakeet_norm_word(const char* s) {
@@ -5437,8 +5430,10 @@ static crispasr_session_result* transcribe_single(crispasr_session* s, const flo
             // return. The orchestrator invokes on_progress on the calling
             // thread, inside this call, so capturing `s` is safe.
             oo.on_progress = [s](int done, int total) { session_report_progress(s, done, total); };
-            scoped_session_progress prog;
-            for (auto& ps : parakeet_transcribe_segments(s->parakeet_ctx, pcm, n_samples, 0, is_ja, oo)) {
+            g_progress.store(0, std::memory_order_relaxed); // issue #208: pollers see "started"
+            auto segs = parakeet_transcribe_segments(s->parakeet_ctx, pcm, n_samples, 0, is_ja, oo);
+            g_progress.store(-1, std::memory_order_relaxed); // back to idle
+            for (auto& ps : segs) {
                 crispasr_session_seg seg;
                 seg.text = std::move(ps.text);
                 seg.t0 = ps.t0;
@@ -5669,8 +5664,9 @@ static crispasr_session_result* transcribe_single(crispasr_session* s, const flo
             if (const char* e = getenv("CRISPASR_PARAKEET_STREAM_CHUNK"))
                 enc_window = std::max(2, atoi(e));
             const int ov = s->parakeet_force_overlap_seconds >= 0 ? s->parakeet_force_overlap_seconds : 2;
-            scoped_session_progress prog;
+            g_progress.store(0, std::memory_order_relaxed);
             parakeet_result* pr = parakeet_transcribe_streamed(s->parakeet_ctx, pcm, n_samples, 0, enc_window, ov);
+            g_progress.store(-1, std::memory_order_relaxed);
             if (!pr) {
                 delete r;
                 return nullptr;
@@ -5684,9 +5680,10 @@ static crispasr_session_result* transcribe_single(crispasr_session* s, const flo
         // merge (no dropped sections, no boundary duplicates). Emits one merged
         // segment (the #208 batch-caller contract).
         if (!use_single_pass && !is_ja) {
-            scoped_session_progress prog; // issue #208: pollers see "started"; idle again on return
+            g_progress.store(0, std::memory_order_relaxed); // issue #208: pollers see "started"
             parakeet_session_chunked_merge(s->parakeet_ctx, pcm, n_samples, chunk_s * SR, overlap_s * SR, r->segments,
                                            s);
+            g_progress.store(-1, std::memory_order_relaxed); // back to idle
             return r;
         }
 
@@ -5698,8 +5695,9 @@ static crispasr_session_result* transcribe_single(crispasr_session* s, const flo
         if (const char* e = getenv("CRISPASR_PARAKEET_VAD_SLICE_CAP"))
             ja_cap_s = std::max(0, atoi(e));
         if (!use_single_pass && is_ja && ja_cap_s > 0 && !force_chunked) {
-            scoped_session_progress prog;
+            g_progress.store(0, std::memory_order_relaxed);
             r->segments.push_back(transcribe_ja_sliced(pcm, n_samples, SR, ja_cap_s));
+            g_progress.store(-1, std::memory_order_relaxed);
             return r;
         }
 

--- a/src/parakeet_orchestrate.cpp
+++ b/src/parakeet_orchestrate.cpp
@@ -157,6 +157,7 @@ int find_silence_cut(const float* s, int n, int target, int window, int sr) {
 // ahead of the decoder (see transcribe_longform).
 struct lf_window {
     int ext_s, ext_e;          // encoder input range (window ± 2 s context)
+    int end;                   // logical end sample (pre-extension) — what progress reports as processed (#385)
     int64_t ext_t0;            // absolute start of ext_s, centiseconds
     int64_t left_cs, right_cs; // keep words with left_cs <= t0 < right_cs
 };
@@ -181,6 +182,7 @@ std::vector<lf_window> plan_longform_windows(const float* samples, int n_samples
         lf_window w;
         w.ext_s = std::max(0, pos - ctxs);
         w.ext_e = std::min(n_samples, end + ctxs);
+        w.end = end;
         w.ext_t0 = t_offset_cs + (int64_t)((double)w.ext_s / SR * 100.0);
         w.left_cs = (pos == 0) ? INT64_MIN : t_offset_cs + (int64_t)((double)pos / SR * 100.0);
         w.right_cs = (end == n_samples) ? INT64_MAX : t_offset_cs + (int64_t)((double)end / SR * 100.0);
@@ -447,19 +449,29 @@ void append_window_seg(parakeet_result* r, const lf_window& w, std::vector<parak
 // parakeet_decode_uses_backend() says so. CRISPASR_PARAKEET_PIPELINE=0/1
 // forces it off/on.
 std::vector<parakeet_seg> transcribe_longform(parakeet_context* ctx, const float* samples, int n_samples,
-                                              int64_t t_offset_cs, int cap_samples) {
+                                              int64_t t_offset_cs, int cap_samples,
+                                              const parakeet_orchestrate_opts& opts) {
     std::vector<parakeet_seg> out;
     const std::vector<lf_window> plan = plan_longform_windows(samples, n_samples, t_offset_cs, cap_samples);
     if (plan.empty())
         return out;
+
+    // Issue #385: report each finished window. `w.end` is the window's logical
+    // end sample, so the sequence is monotonic and the last fires (n, n).
+    auto report = [&](const lf_window& w) {
+        if (opts.progress_cb)
+            opts.progress_cb(w.end, n_samples, opts.progress_ud);
+    };
 
     bool pipeline = plan.size() > 1 && parakeet_decode_uses_backend(ctx) == 0;
     if (const char* e = getenv("CRISPASR_PARAKEET_PIPELINE"))
         pipeline = atoi(e) != 0 && plan.size() > 1;
 
     if (!pipeline) {
-        for (const auto& w : plan)
+        for (const auto& w : plan) {
             append_window_seg(parakeet_transcribe_ex(ctx, samples + w.ext_s, w.ext_e - w.ext_s, w.ext_t0), w, out);
+            report(w);
+        }
         return out;
     }
 
@@ -496,10 +508,11 @@ std::vector<parakeet_seg> transcribe_longform(parakeet_context* ctx, const float
             q.pop_front();
             cv_full.notify_one();
         }
-        if (!it.buf)
-            continue; // encode failed for this window; keep going, order intact
-        append_window_seg(parakeet_decode_frames(ctx, it.buf, it.T_enc, it.d_model, plan[i].ext_t0), plan[i], out);
-        free(it.buf);
+        if (it.buf) {
+            append_window_seg(parakeet_decode_frames(ctx, it.buf, it.T_enc, it.d_model, plan[i].ext_t0), plan[i], out);
+            free(it.buf);
+        } // else: encode failed for this window; keep going, order intact
+        report(plan[i]);
     }
 
     producer.join();
@@ -680,7 +693,7 @@ std::vector<parakeet_seg> parakeet_transcribe_segments(parakeet_context* ctx, co
     // are independent: the window is a throughput knob, gap_fill_segments is
     // what makes coverage robust.
     if (strat == parakeet_strategy::LONGFORM) {
-        out = transcribe_longform(ctx, samples, n_samples, t_offset_cs, rs.longform_window_s * SR);
+        out = transcribe_longform(ctx, samples, n_samples, t_offset_cs, rs.longform_window_s * SR, opts);
         if (repair)
             gap_fill_segments(ctx, samples, n_samples, t_offset_cs, out, kParakeetBoundedWindowS, kParakeetGapFillMinCs,
                               opts.no_prints);

--- a/src/parakeet_orchestrate.cpp
+++ b/src/parakeet_orchestrate.cpp
@@ -459,8 +459,8 @@ std::vector<parakeet_seg> transcribe_longform(parakeet_context* ctx, const float
     // Issue #385: report each finished window. `w.end` is the window's logical
     // end sample, so the sequence is monotonic and the last fires (n, n).
     auto report = [&](const lf_window& w) {
-        if (opts.progress_cb)
-            opts.progress_cb(w.end, n_samples, opts.progress_ud);
+        if (opts.on_progress)
+            opts.on_progress(w.end, n_samples);
     };
 
     bool pipeline = plan.size() > 1 && parakeet_decode_uses_backend(ctx) == 0;

--- a/src/parakeet_orchestrate.h
+++ b/src/parakeet_orchestrate.h
@@ -58,6 +58,18 @@ struct parakeet_orchestrate_opts {
     // never collapse to one unbounded full-length pass — see
     // parakeet_effective_single_pass_cap_s.
     bool chunked_requested = false;
+    // Issue #385: per-window progress on the LONGFORM route — the #208 session
+    // contract, which the #350 hoist left behind on the legacy inline path.
+    // Fired on the calling thread after each finished window with (input
+    // samples processed so far, total samples); `processed` is monotonically
+    // non-decreasing and reaches `total` on the last window, including a
+    // window whose encode failed, so a caller's progress bar cannot stall
+    // short of 100 %. The single-decode routes (SINGLE_PASS / STREAMED /
+    // CHUNK_SEGMENTED) have no observable windows and do not fire it, per the
+    // session header's documented contract; the #350 gap-fill repair runs
+    // after the last window and stays silent too.
+    void (*progress_cb)(int processed, int total, void* user_data) = nullptr;
+    void* progress_ud = nullptr;
 };
 
 // The decoder's reliable single-pass window, in seconds. Past roughly this much

--- a/src/parakeet_orchestrate.h
+++ b/src/parakeet_orchestrate.h
@@ -19,6 +19,7 @@
 
 #include <algorithm>
 #include <cstdint>
+#include <functional>
 #include <string>
 #include <utility>
 #include <vector>
@@ -60,16 +61,15 @@ struct parakeet_orchestrate_opts {
     bool chunked_requested = false;
     // Issue #385: per-window progress on the LONGFORM route — the #208 session
     // contract, which the #350 hoist left behind on the legacy inline path.
-    // Fired on the calling thread after each finished window with (input
+    // Invoked on the calling thread after each finished window with (input
     // samples processed so far, total samples); `processed` is monotonically
     // non-decreasing and reaches `total` on the last window, including a
     // window whose encode failed, so a caller's progress bar cannot stall
     // short of 100 %. The single-decode routes (SINGLE_PASS / STREAMED /
-    // CHUNK_SEGMENTED) have no observable windows and do not fire it, per the
-    // session header's documented contract; the #350 gap-fill repair runs
+    // CHUNK_SEGMENTED) have no observable windows and do not invoke it, per
+    // the session header's documented contract; the #350 gap-fill repair runs
     // after the last window and stays silent too.
-    void (*progress_cb)(int processed, int total, void* user_data) = nullptr;
-    void* progress_ud = nullptr;
+    std::function<void(int processed, int total)> on_progress;
 };
 
 // The decoder's reliable single-pass window, in seconds. Past roughly this much

--- a/tests/test_parakeet_longform_live.cpp
+++ b/tests/test_parakeet_longform_live.cpp
@@ -91,7 +91,9 @@ std::vector<float> repeated_fixture(int reps) {
 }
 
 // 231 s — squarely in the 30-300 s dead zone the #350 cases need.
-std::vector<float> long_fixture() { return repeated_fixture(21); }
+std::vector<float> long_fixture() {
+    return repeated_fixture(21);
+}
 
 std::string transcript_of(crispasr_session_result* r) {
     std::string text;
@@ -196,8 +198,7 @@ TEST_CASE("parakeet long-form: dropped spans are repaired (issue #350)", "[integ
 // but the orchestrator carried no progress hook, so
 // crispasr_session_set_progress_callback + transcribe_chunked reported nothing
 // (callback silent, g_progress atomic stuck at idle) until the call returned.
-TEST_CASE("parakeet long-form: chunked entry point reports progress (issue #385)",
-          "[integration][parakeet-longform]") {
+TEST_CASE("parakeet long-form: chunked entry point reports progress (issue #385)", "[integration][parakeet-longform]") {
     const char* model_path = parakeet_model();
     if (!model_path)
         SKIP("CRISPASR_MODEL_PARAKEET not set or not readable");

--- a/tests/test_parakeet_longform_live.cpp
+++ b/tests/test_parakeet_longform_live.cpp
@@ -33,6 +33,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace {
@@ -77,17 +78,20 @@ int count_occurrences(std::string hay, std::string needle) {
     return n;
 }
 
-// jfk.wav × 21 = 231 s of known content, or empty if the sample is missing.
-std::vector<float> long_fixture() {
+// jfk.wav × reps of known content, or empty if the sample is missing.
+std::vector<float> repeated_fixture(int reps) {
     const auto one = load_wav_16k("samples/jfk.wav");
     if (one.size() < 16000 * 10)
         return {};
     std::vector<float> pcm;
-    pcm.reserve(one.size() * 21);
-    for (int i = 0; i < 21; i++)
+    pcm.reserve(one.size() * reps);
+    for (int i = 0; i < reps; i++)
         pcm.insert(pcm.end(), one.begin(), one.end());
     return pcm;
 }
+
+// 231 s — squarely in the 30-300 s dead zone the #350 cases need.
+std::vector<float> long_fixture() { return repeated_fixture(21); }
 
 std::string transcript_of(crispasr_session_result* r) {
     std::string text;
@@ -185,4 +189,56 @@ TEST_CASE("parakeet long-form: dropped spans are repaired (issue #350)", "[integ
     CHECK(count_occurrences(text, "country") >= 40);
     // ...and the sentence survives intact, not just the keyword.
     CHECK(count_occurrences(text, "ask what you can do for your country") >= 18);
+}
+
+// Issue #385 regression guard — the #208 progress contract on the unified
+// dispatch. #350's fix restored the CHUNKING through the shared orchestrator
+// but the orchestrator carried no progress hook, so
+// crispasr_session_set_progress_callback + transcribe_chunked reported nothing
+// (callback silent, g_progress atomic stuck at idle) until the call returned.
+TEST_CASE("parakeet long-form: chunked entry point reports progress (issue #385)",
+          "[integration][parakeet-longform]") {
+    const char* model_path = parakeet_model();
+    if (!model_path)
+        SKIP("CRISPASR_MODEL_PARAKEET not set or not readable");
+    // 66 s — past the chunked entry point's ~30 s bounded cap, so the run
+    // takes the multi-window LONGFORM route with at least two windows.
+    const auto pcm = repeated_fixture(6);
+    if (pcm.empty())
+        SKIP("samples/jfk.wav not found — run from the repo root");
+
+    struct prog_log {
+        std::vector<std::pair<int, int>> fires; // (processed, total)
+        int polled_max = -1;                    // g_progress seen from inside the callback
+    } log;
+    crispasr_reset_progress();
+
+    crispasr_session* s = crispasr_session_open(model_path, 4);
+    REQUIRE(s != nullptr);
+    crispasr_session_set_progress_callback(
+        s,
+        [](int processed, int total, void* ud) {
+            auto* l = static_cast<prog_log*>(ud);
+            l->fires.push_back({processed, total});
+            l->polled_max = std::max(l->polled_max, crispasr_get_progress());
+        },
+        &log);
+    crispasr_session_result* r = crispasr_session_transcribe_chunked(s, pcm.data(), (int)pcm.size(), 0, -1);
+    REQUIRE(r != nullptr);
+    crispasr_session_result_free(r);
+    crispasr_session_close(s);
+
+    // Once per finished window: a 66 s run over ~30 s windows has >= 2.
+    REQUIRE(log.fires.size() >= 2);
+    // Monotonically non-decreasing, ending at (total, total) with the real
+    // sample count — the documented crispasr_progress_callback contract.
+    for (size_t i = 1; i < log.fires.size(); i++)
+        CHECK(log.fires[i].first >= log.fires[i - 1].first);
+    for (const auto& f : log.fires)
+        CHECK(f.second == (int)pcm.size());
+    CHECK(log.fires.back().first == (int)pcm.size());
+    // The pollable atomic moves in lockstep with the callback, and returns to
+    // idle when the call is done.
+    CHECK(log.polled_max > 0);
+    CHECK(crispasr_get_progress() == -1);
 }


### PR DESCRIPTION
Fixes #385.

## Problem

The #350 unified-dispatch fix (v0.8.29) restored the *chunking* through the shared orchestrator, but the *reporting* stayed broken: `parakeet_transcribe_segments` carried no progress hook, so a caller of `crispasr_session_set_progress_callback` + `crispasr_session_transcribe_chunked[_lang]` saw 0 % until the call returned, and the pollable `g_progress` atomic (Dart FFI) stayed at idle too.

## Fix

Hoist the #208 progress contract into the orchestrator:

- `parakeet_orchestrate_opts` gains `progress_cb`/`progress_ud`, fired once per finished LONGFORM window with `(samples processed so far, total samples)` — monotonically non-decreasing, reaching `total` on the last window. Both the serial and pipelined loops fire it, **including a window whose encode failed**, so a progress bar cannot stall short of 100 %.
- The single-decode routes (SINGLE_PASS / STREAMED / CHUNK_SEGMENTED) have no observable windows and stay silent, per the session header's documented contract; the #350 gap-fill repair runs after 100 % and stays silent too.
- The session's unified branch wraps `s->progress_cb` and the `g_progress` mirror into that hook, in lockstep as documented, bracketed by the same started(0)/idle(-1) stores the legacy inline path used.
- Header doc: noted the 0.8.24–0.8.29 gap on `crispasr_progress_callback`, mirroring the existing #350 note.

## Verification

Live on `parakeet-tdt-0.6b-v3-q4_k` (M1 Pro, Metal):

- 66 s chunked run through the session ABI: 3 windows fire (`400800 → 880800 → 1056000/1056000`), poller sees 37/83/100 %, atomic resets to −1 after — previously zero fires.
- Legacy A/B path (`CRISPASR_SESSION_UNIFIED_DISPATCH=0`) unchanged: 5 fires, same contract.
- New regression case in `test_parakeet_longform_live.cpp` (`[parakeet-longform]`, model-gated, SKIPs cleanly): ≥ 2 fires on a 66 s chunked run, monotonic, ends at `(total, total)`, atomic advances during the run and returns to idle after. All 3 cases in that binary pass, as do `test-parakeet-strategy` (56 assertions) and `test-issue-356-gap-fill-overlap` (90 assertions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)