### PR TITLE
perf(spectral-diarize): compute the affinity once, parallelise the k-sweeps (#324)

### DIFF
--- a/docs/foxnose-diarize/PLAN.md
+++ b/docs/foxnose-diarize/PLAN.md
@@ -286,9 +286,52 @@ Where the time goes on a 215 s file (~45 s wall, ~4.8x realtime):
 | stage | share |
 |---|---|
 | WeSpeaker ResNet34 forward | ~70% (94% of the embedder) |
-| speaker-count estimation (GMM/BIC + silhouette) | ~12% (58 s -> 51 s when `--diarize-num-speakers` pins it) |
+| speaker-count estimation (GMM/BIC + silhouette) | ~12% (58 s -> 51 s when `--diarize-num-speakers` pins it), before the parallel sweep below |
 | Kaldi fbank | ~4% |
 | VAD, clustering, smoothing, I/O | remainder |
+
+**Speaker counting was single-threaded and recomputed its inputs (2026-08).**
+`cluster_speakers` rebuilt the same O(n^2 d) cosine affinity up to ~10 times
+per call — once inside the `run(k)` lambda and at three more sites — and then
+ran both k-sweeps serially: the GMM/BIC sweep (`n_init=5`, `max_iter=300` per
+k) and the spectral+silhouette sweep (a dense Laplacian, a subspace iteration
+and `10x300` k-means per k, for every k in `[2, max_speakers]`). Every k is
+independent — `gmm_bic` seeds its own RNG per init, and the spectral runs take
+the same `seed` per candidate — so the sweeps parallelise with the reductions
+left serial in ascending k, which is what keeps the tie-breaks (and therefore
+the chosen count) bit-identical.
+
+The fan-out is a file-local `parallel_tasks` in `spectral_diarize.cpp`, kept
+local to match every other parallelism helper in the tree
+(`firered_parallel_for`, `marblenet_parallel_for`, `ov_parallel_for`, and the
+inline loops in `core/mel.cpp` and `core/foxnose_pipeline.cpp` — none of them
+sit in a shared header). It differs from those four in handing out task
+INDICES from an atomic counter rather than splitting [0, n) into contiguous
+per-thread chunks: they parallelise uniform-cost items like audio frames,
+whereas a k=8 spectral run costs many times a k=2 one, so a static split
+leaves the thread holding the cheap candidates idle. Unifying all five behind
+one helper is a reasonable cleanup, but it has its own testing surface (two
+VAD models plus omnivoice) and does not belong in a diarization perf change.
+
+⚠ Note for anyone extending this: neither of the "just use the standard/
+platform" routes works here, and both were tested rather than assumed.
+`std::execution::par` is in-standard for core (C++17) but does not build on
+the Apple toolchain — libc++ gates `<execution>` behind
+`_LIBCPP_HAS_EXPERIMENTAL_PSTL`, and force-enabling it fails to LINK
+(`__pstl::__libdispatch::__dispatch_apply` is not in the shipped dylib);
+libstdc++ implements it over Intel TBB, which is nowhere in this tree. OpenMP
+is used heavily elsewhere (~28 pragma sites, including `schedule(dynamic)` at
+`mel_band_roformer.cpp:666`), but every site is `#ifdef _OPENMP`-guarded and
+OpenMP is NOT found on the stock macOS toolchain, so a pragma-based sweep
+would have delivered 0% of the speedup below on the machine it was measured
+on — the same trap the firered-asr note in `src/CMakeLists.txt` records.
+
+Measured on an M-series box, `-t 8`, esrit.wav (215 s), warm runs, arms
+interleaved base/PR: ASR-only 2.39 s; foxnose end-to-end **10.82 s -> 9.63 s**,
+i.e. **diarization delta 8.43 s -> 7.24 s (1.16x)**. Labels are bit-identical
+(259 spectral assertions unchanged, shard DER identical per file at 7.32%).
+The remaining estimation cost is real work, not redundancy: pinning the count
+with `--diarize-num-speakers` still saves ~1 s on top of this.
 
 ### Levers that were tried and LOST — do not re-litigate without new evidence
 

--- a/src/core/spectral_diarize.cpp
+++ b/src/core/spectral_diarize.cpp
@@ -10,14 +10,61 @@
 #include <numeric>
 #include <cstdlib>
 #include <functional>
+#include <atomic>
 #include <random>
 #include <string>
+#include <thread>
 
 namespace core_spectral {
 
 namespace {
 
 constexpr double kTiny = 1e-12;
+
+// Run fn(0..n_tasks-1) across the machine's cores, handing out task INDICES
+// from an atomic counter rather than splitting the range into contiguous
+// per-thread chunks the way firered_parallel_for / marblenet_parallel_for /
+// ov_parallel_for / core/mel.cpp do. Those are right for uniform-cost items
+// like audio frames; here a k=8 spectral run costs many times a k=2 one, so a
+// static split would leave the thread holding the cheap candidates idle.
+// Same shape as the inline loop in core/foxnose_pipeline.cpp.
+//
+// Not std::execution::par (libc++ gates it behind _LIBCPP_HAS_EXPERIMENTAL_PSTL
+// and does not ship the backend to link against) and not OpenMP (optional, and
+// absent on the stock macOS toolchain this was measured on, so the pragma would
+// compile to a serial loop). See the PR for the tested details.
+//
+// DETERMINISM: fn must write only to its own task index, and callers reduce
+// SERIALLY afterwards in ascending order, so tie-breaks land where the old
+// sequential loop put them.
+template <typename F> void parallel_tasks(int n_tasks, F&& fn) {
+    if (n_tasks <= 0)
+        return;
+    const unsigned hw = std::thread::hardware_concurrency();
+    const int n_threads = std::max(1, std::min(n_tasks, (int)(hw == 0 ? 1u : hw)));
+    if (n_threads == 1) {
+        for (int i = 0; i < n_tasks; i++)
+            fn(i);
+        return;
+    }
+    std::atomic<int> next{0};
+    auto run = [&]() {
+        for (;;) {
+            const int i = next.fetch_add(1);
+            if (i >= n_tasks)
+                return;
+            fn(i);
+        }
+    };
+    std::vector<std::thread> pool;
+    pool.reserve((size_t)n_threads - 1);
+    for (int t = 1; t < n_threads; t++)
+        pool.emplace_back(run);
+    run(); // the calling thread pulls tasks too
+    for (auto& t : pool)
+        t.join();
+}
+
 
 // ── Portable RNG draws ────────────────────────────────────────────────────
 //
@@ -807,8 +854,9 @@ float silhouette_precomputed(const float* distance, int n, const std::vector<int
         count[(size_t)v]++;
 
     double total = 0.0;
+    std::vector<double> sum((size_t)k);
     for (int i = 0; i < n; i++) {
-        std::vector<double> sum((size_t)k, 0.0);
+        std::fill(sum.begin(), sum.end(), 0.0);
         for (int j = 0; j < n; j++) {
             if (j == i)
                 continue;
@@ -910,7 +958,8 @@ std::vector<int> refine_spherical(const float* x, int n, int d, const std::vecto
     return cur;
 }
 
-SpeakerEstimate estimate_speakers(const float* x, int n, int d, int min_k, int max_k, unsigned seed) {
+static SpeakerEstimate estimate_speakers_impl(const float* x, int n, int d, int min_k, int max_k, unsigned seed,
+                                              const float* sim_precomputed) {
     SpeakerEstimate est;
     est.min_k_used = std::max(1, min_k);
     est.best_k = std::max(1, min_k);
@@ -927,7 +976,12 @@ SpeakerEstimate estimate_speakers(const float* x, int n, int d, int min_k, int m
     // Single-speaker veto: if even the 10th percentile of off-diagonal cosine
     // similarity is high, everything is one voice and BIC would over-split it.
     {
-        std::vector<float> sim = cosine_similarity(x, n, d);
+        std::vector<float> sim_local;
+        if (!sim_precomputed) {
+            sim_local = cosine_similarity(x, n, d);
+            sim_precomputed = sim_local.data();
+        }
+        const float* sim = sim_precomputed;
         std::vector<float> off;
         off.reserve((size_t)n * (n - 1));
         for (int i = 0; i < n; i++)
@@ -984,17 +1038,31 @@ SpeakerEstimate estimate_speakers(const float* x, int n, int d, int min_k, int m
     // against PCA noise-component variances of ~0.03.
     const int k_occupancy = std::max(1, n / (pca_dim + 1));
     const int k_upper = std::max(min_k + 1, std::min({max_k + 1, n / 2 + 1, k_occupancy + 1}));
+    // Every k's GMM is seeded independently (seed + init*7919 inside gmm_bic)
+    // and touches only its own slot, so the sweep parallelises without
+    // changing a single BIC; the argmin below runs serially in ascending k,
+    // preserving the old first-wins tie-break.
+    const int k_lo = std::max(1, min_k);
+    const int k_cnt = std::max(0, k_upper - k_lo);
+    std::vector<float> bics((size_t)k_cnt, 0.0f);
+    std::vector<char> bic_ok((size_t)k_cnt, 0);
+    parallel_tasks(k_cnt, [&](int i) {
+        float bic = 0.0f;
+        if (gmm_bic(proj.data(), n, pca_dim, k_lo + i, kGmmNInit, kGmmMaxIter, seed, &bic)) {
+            bics[(size_t)i] = bic;
+            bic_ok[(size_t)i] = 1;
+        }
+    });
     float best_bic = std::numeric_limits<float>::infinity();
     int best_k = min_k;
     bool any = false;
-    for (int k = std::max(1, min_k); k < k_upper; k++) {
-        float bic = 0.0f;
-        if (!gmm_bic(proj.data(), n, pca_dim, k, kGmmNInit, kGmmMaxIter, seed, &bic))
+    for (int i = 0; i < k_cnt; i++) {
+        if (!bic_ok[(size_t)i])
             continue;
-        est.k_bics.push_back(bic);
-        if (bic < best_bic) {
-            best_bic = bic;
-            best_k = k;
+        est.k_bics.push_back(bics[(size_t)i]);
+        if (bics[(size_t)i] < best_bic) {
+            best_bic = bics[(size_t)i];
+            best_k = k_lo + i;
         }
         any = true;
     }
@@ -1007,6 +1075,10 @@ SpeakerEstimate estimate_speakers(const float* x, int n, int d, int min_k, int m
     return est;
 }
 
+SpeakerEstimate estimate_speakers(const float* x, int n, int d, int min_k, int max_k, unsigned seed) {
+    return estimate_speakers_impl(x, n, d, min_k, max_k, seed, nullptr);
+}
+
 std::vector<int> cluster_speakers(const float* x, int n, int d, int min_speakers, int max_speakers, int num_speakers,
                                   SpeakerEstimate* out_estimate, unsigned seed) {
     if (n <= 0)
@@ -1014,8 +1086,21 @@ std::vector<int> cluster_speakers(const float* x, int n, int d, int min_speakers
     if (n < 2)
         return std::vector<int>((size_t)n, 0);
 
+    // ONE O(n^2 d) similarity pass for the whole function. Everything below —
+    // the affinity every spectral run clusters on, the p10 single-speaker veto
+    // inside the estimator, and the silhouette's distance matrix — is a cheap
+    // transform of this one matrix; it used to be recomputed per spectral run.
+    std::vector<float> sim = cosine_similarity(x, n, d);
+    std::vector<float> aff = sim;
+    for (int i = 0; i < n; i++)
+        for (int j = 0; j < n; j++) {
+            float v = (aff[(size_t)i * n + j] + 1.0f) * 0.5f;
+            aff[(size_t)i * n + j] = std::max(v, 0.0f);
+        }
+    for (int i = 0; i < n; i++)
+        aff[(size_t)i * n + i] = 1.0f;
+
     auto run = [&](int k) {
-        std::vector<float> aff = cosine_affinity(x, n, d);
         std::vector<int> lab = spectral_labels(aff.data(), n, k, seed);
         return refine_spherical(x, n, d, lab);
     };
@@ -1030,9 +1115,8 @@ std::vector<int> cluster_speakers(const float* x, int n, int d, int min_speakers
 
     SpeakerEstimate est;
     if (count_method_from_env() == CountMethod::NmeSc) {
-        std::vector<float> aff0 = cosine_affinity(x, n, d);
         NmeScDiag diag;
-        est.best_k = estimate_speakers_nme_sc(aff0.data(), n, min_speakers, max_speakers, seed, &diag);
+        est.best_k = estimate_speakers_nme_sc(aff.data(), n, min_speakers, max_speakers, seed, &diag);
         est.reason = "nme-sc";
         if (out_estimate)
             *out_estimate = est;
@@ -1047,8 +1131,7 @@ std::vector<int> cluster_speakers(const float* x, int n, int d, int min_speakers
         return run(est.best_k);
     }
     if (count_method_from_env() == CountMethod::Eigengap) {
-        std::vector<float> aff0 = cosine_affinity(x, n, d);
-        est.best_k = estimate_speakers_eigengap(aff0.data(), n, min_speakers, max_speakers, seed);
+        est.best_k = estimate_speakers_eigengap(aff.data(), n, min_speakers, max_speakers, seed);
         est.reason = "eigengap";
         if (out_estimate)
             *out_estimate = est;
@@ -1056,7 +1139,7 @@ std::vector<int> cluster_speakers(const float* x, int n, int d, int min_speakers
         // the silhouette pass — which is what saturates — is skipped.
         return run(est.best_k);
     }
-    est = estimate_speakers(x, n, d, min_speakers, max_speakers, seed);
+    est = estimate_speakers_impl(x, n, d, min_speakers, max_speakers, seed, sim.data());
     if (out_estimate)
         *out_estimate = est;
     const int k = est.best_k;
@@ -1102,17 +1185,29 @@ std::vector<int> cluster_speakers(const float* x, int n, int d, int min_speakers
     if (upper <= lower)
         return run(k);
 
-    std::vector<float> aff = cosine_affinity(x, n, d);
     std::vector<float> dist((size_t)n * n);
     for (size_t i = 0; i < dist.size(); i++)
         dist[i] = std::max(1.0f - aff[i], 0.0f);
 
+    // Every k's spectral run + silhouette is independent (read-only inputs,
+    // per-call RNG seeded from the same `seed`), so the sweep parallelises
+    // without moving a single score; the argmax below stays serial in
+    // ascending k, preserving the old strictly-greater tie-break.
+    const int n_cand = upper - lower + 1;
+    std::vector<std::vector<int>> cand_labels((size_t)n_cand);
+    std::vector<float> cand_sil((size_t)n_cand, 0.0f);
+    parallel_tasks(n_cand, [&](int i) {
+        const int c = lower + i;
+        cand_labels[(size_t)i] = refine_spherical(x, n, d, spectral_labels(aff.data(), n, c, seed));
+        cand_sil[(size_t)i] = silhouette_precomputed(dist.data(), n, cand_labels[(size_t)i]);
+    });
+
     int best_k = k;
     std::vector<int> best_labels;
     float best_score = -std::numeric_limits<float>::infinity();
-    for (int c = lower; c <= upper; c++) {
-        std::vector<int> lab = refine_spherical(x, n, d, spectral_labels(aff.data(), n, c, seed));
-        const float sil = silhouette_precomputed(dist.data(), n, lab);
+    for (int i = 0; i < n_cand; i++) {
+        const int c = lower + i;
+        const float sil = cand_sil[(size_t)i];
         const float score = sil + kSilhouetteKBonus * (float)std::log((double)std::max(c, 1));
         if (std::getenv("CRISPASR_DIARIZE_DEBUG"))
             fprintf(stderr, "  spectral: k=%d silhouette=%.4f score=%.4f%s\n", c, sil, score,
@@ -1120,7 +1215,7 @@ std::vector<int> cluster_speakers(const float* x, int n, int d, int min_speakers
         if (score > best_score) {
             best_score = score;
             best_k = c;
-            best_labels = std::move(lab);
+            best_labels = std::move(cand_labels[(size_t)i]);
         }
     }
     if (out_estimate && best_k != k) {


### PR DESCRIPTION
## Why

Speaker counting is the second cost in foxnose diarization after the embedder (`PLAN.md`: ~12%), and all of it ran on one core while recomputing its own inputs.

`cluster_speakers` rebuilt the same O(n²·d) cosine affinity **up to ~10 times per call** — once inside the `run(k)` lambda and at three more sites — on an n≈350, d=256 matrix. Then it ran both k-sweeps serially:

- the GMM/BIC sweep (`n_init=5`, `max_iter=300` per k), and
- the spectral + silhouette sweep — a dense Laplacian, a subspace iteration and `10x300` k-means **per k**, for every k in `[2, max_speakers]`.

## What

- **Compute the similarity once** at the top of `cluster_speakers` and derive everything from it: the affinity each spectral run clusters on, the estimator's p10 single-speaker veto (via a new `estimate_speakers_impl` taking a precomputed matrix), and the silhouette distance matrix. Public `estimate_speakers` keeps its signature.
- **Parallelise both k-sweeps.** Every k is independent — `gmm_bic` seeds its own RNG per init (`seed + init*7919`), `spectral_labels`/`refine_spherical` take the same `seed` per candidate — and each task writes only its own slot.
- **The reductions stay serial in ascending k.** This is the part that matters: the argmin's first-wins and the argmax's strictly-greater tie-breaks cannot move, so the chosen speaker count is bit-identical rather than merely usually-identical. The `CRISPASR_DIARIZE_DEBUG` per-k curve still prints in order.
- `silhouette_precomputed` allocated a k-vector per row inside a loop over all n points; hoisted.

## On the fan-out helper

`parallel_tasks` is file-local in `spectral_diarize.cpp`, matching every other parallelism helper in the tree — `firered_parallel_for`, `marblenet_parallel_for`, `ov_parallel_for`, and the inline loops in `core/mel.cpp` and `core/foxnose_pipeline.cpp` are all file-local, none sits in a shared header. Unifying all of them is a real cleanup but has its own testing surface (two VAD models plus omnivoice), so it is a **separate PR** rather than a rider on a perf change.

It differs from those four in handing out task **indices** from an atomic counter instead of splitting `[0, n)` into contiguous per-thread chunks: they parallelise uniform-cost items like audio frames, whereas a k=8 spectral run costs many times a k=2 one, so a static split would leave the thread holding the cheap candidates idle.

Two "just use the standard/platform" routes were considered and **tested**, not assumed:

- **`std::execution::par`** — in-standard here (crispasr-core is C++17), but it does not build on the toolchain this was measured on. Apple clang 21.0.0 / macOS SDK 26.5, `-std=c++17`: `error: no member named 'par' in namespace 'std::execution'` (libc++ gates `<execution>` behind `_LIBCPP_HAS_EXPERIMENTAL_PSTL`); forcing it with `-D_LIBCPP_ENABLE_EXPERIMENTAL` compiles but fails to **link** — `Undefined symbols: std::__1::__pstl::__libdispatch::__dispatch_apply`, `__partition_chunks`. libstdc++ implements PSTL over Intel TBB, which is nowhere in this tree (not verified locally — no GCC on the dev box).
- **OpenMP** — the tree uses it heavily (~28 pragma sites), and `schedule(dynamic)` for non-uniform work is already established at `mel_band_roformer.cpp:666`, so neither would be novel. But every site is `#ifdef _OPENMP`-guarded and OpenMP is **not found on the stock macOS/AppleClang toolchain** (this build configures with "Could NOT find OpenMP_CXX"), so a pragma-based sweep would have delivered 0% of the speedup below on the machine it was measured on. The tree has been bitten by exactly this — see the `firered-asr` note in `src/CMakeLists.txt` about pragmas that "were no-ops and the AED beam decoder ran single-threaded".

## Measured

esrit.wav (215 s), `-t 8`, M-series, warm runs, arms interleaved base/PR. ASR-only baseline 2.39 s.

| arm | end-to-end | diarization delta |
|---|---|---|
| base | 10.82 s | 8.43 s |
| **this PR** | **9.63 s** | **7.24 s (1.16x)** |

The remaining estimation cost is real work rather than redundancy — pinning the count with `--diarize-num-speakers` still saves roughly another second on top of this.

## Correctness

Labels are **bit-identical**, which is the design constraint the whole change is built around:

- `test-spectral-diarize` 259 assertions unchanged, plus `test-der` (75).
- Diarization JSON **byte-identical** to base on `esrit.wav`.
- DER on the pinned 8-file VoxConverse shard: **identical per file, mean 7.32%**.

## Related

Independent of #389 (embedder → Accelerate) and #391 (window batching + GPU); merges cleanly in any order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


