### PR TITLE
refactor(core): unify the five hand-rolled parallel-for helpers

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -859,6 +859,7 @@ add_library(crispasr-core STATIC
             # Speaker-count estimation + spectral clustering (#324). Lives in
             # crispasr-core because both the diarizer and its unit tests use it
             # and it depends on nothing but the standard library.
+            core/parallel_for.h
             core/spectral_diarize.h
             core/spectral_diarize.cpp
             core/diarize_smooth.h

--- a/src/core/foxnose_pipeline.cpp
+++ b/src/core/foxnose_pipeline.cpp
@@ -2,12 +2,12 @@
 
 #include "foxnose_pipeline.h"
 
+#include "parallel_for.h"
+
 #include "diarize_smooth.h"
 #include "spectral_diarize.h"
 
 #include <algorithm>
-#include <atomic>
-#include <thread>
 #include <cmath>
 #include <cstdlib>
 #include <map>
@@ -164,27 +164,11 @@ Result diarize(const float* pcm, int n_samples, int sample_rate, const std::vect
             ok[(size_t)(sp.first + k)] = good;
     };
 
-    if (n_workers == 1) {
-        for (int si = 0; si < n_spans; si++)
-            do_span(si, 0);
-    } else {
-        std::atomic<int> next{0};
-        auto run = [&](int worker) {
-            for (;;) {
-                const int si = next.fetch_add(1);
-                if (si >= n_spans)
-                    return;
-                do_span(si, worker);
-            }
-        };
-        std::vector<std::thread> pool;
-        pool.reserve((size_t)n_workers - 1);
-        for (int t = 1; t < n_workers; t++)
-            pool.emplace_back(run, t);
-        run(0);
-        for (auto& t : pool)
-            t.join();
-    }
+    // Spans are handed out from an atomic counter rather than split into
+    // contiguous per-worker blocks: a span's cost depends on how many windows
+    // it holds, and `slot` is what tells do_span WHICH embedder context to use
+    // (one per worker, never two concurrent calls on the same one).
+    core_parallel::for_each_task(n_spans, n_workers, [&](int si, int slot) { do_span(si, slot); });
 
     for (int i = 0; i < n_win; i++) {
         if (!ok[i]) {

--- a/src/core/mel.cpp
+++ b/src/core/mel.cpp
@@ -3,6 +3,8 @@
 
 #include "mel.h"
 
+#include "parallel_for.h"
+
 #include <algorithm>
 #include <chrono>
 #include <cmath>
@@ -169,28 +171,17 @@ std::vector<float> compute(const float* samples, int n_samples, const float* win
 #else
             // Portable std::thread path (§305): AppleClang ships no libomp, so the
             // OpenMP path above is compiled out on macOS — without this the STFT
-            // stayed single-threaded there. Each thread owns its FFT scratch and
+            // stayed single-threaded there. Each chunk owns its FFT scratch and
             // frames write disjoint `power` rows → data-race free, bit-identical.
+            // The 8-thread default cap is deliberate and predates the shared
+            // helper, so it is passed in rather than left to hardware_concurrency.
             const unsigned hw = std::thread::hardware_concurrency();
             const int cap = p.n_threads > 0 ? p.n_threads : (int)((hw == 0) ? 1u : std::min(hw, 8u));
-            const int nt = std::min(cap, T);
-            std::vector<std::thread> pool;
-            pool.reserve(nt > 0 ? nt - 1 : 0);
-            const int chunk = (T + nt - 1) / nt;
-            auto run = [&](int t0, int t1) {
+            core_parallel::for_each_chunk(T, cap, [&](int t0, int t1) {
                 std::vector<float> fft_in((size_t)n_fft), fft_out((size_t)n_fft * 2);
                 for (int t = t0; t < t1; t++)
                     compute_frame(t, fft_in.data(), fft_out.data());
-            };
-            for (int i = 1; i < nt; i++) {
-                const int a = i * chunk, b = std::min(T, a + chunk);
-                if (a >= b)
-                    break;
-                pool.emplace_back([&run, a, b]() { run(a, b); });
-            }
-            run(0, std::min(T, chunk));
-            for (auto& th : pool)
-                th.join();
+            });
 #endif
         } else {
             std::vector<float> fft_in((size_t)n_fft);

--- a/src/core/parallel_for.h
+++ b/src/core/parallel_for.h
@@ -1,0 +1,118 @@
+// core/parallel_for.h — one place for "run this loop across the cores".
+//
+// Five copies of this had accumulated, each written for its own file:
+//   firered_vad.cpp        firered_parallel_for   (static template)
+//   marblenet_vad.cpp      marblenet_parallel_for (static template, identical)
+//   omnivoice.cpp          ov_parallel_for        (std::function variant)
+//   core/mel.cpp           inlined, no helper
+//   core/foxnose_pipeline.cpp  inlined, no helper
+//
+// They come in TWO genuinely different shapes, and both are kept here rather
+// than forcing one onto the other:
+//
+//   for_each_chunk — splits [0, n) into one contiguous block per thread.
+//     Right when every item costs about the same (audio frames, feature rows),
+//     which is what four of the five above do. Cheapest possible: no atomics,
+//     one call per thread.
+//
+//   for_each_task — hands out item indices from an atomic counter, so threads
+//     take more work as they finish. Right when per-item cost varies a lot,
+//     where a static split would leave a thread idle holding the cheap items.
+//     Also carries a SLOT index for callers that own per-thread resources
+//     (foxnose_pipeline gives each worker its own model context this way).
+//
+// Both reuse the CALLING thread as one of the workers, so `n_threads == 1`
+// costs nothing beyond the loop itself.
+//
+// DETERMINISM CONTRACT (why every caller here is safe to parallelise): `fn`
+// must write only to storage owned by its own index/range. Any order-sensitive
+// reduction — argmin, argmax, accumulation — belongs in a SERIAL pass
+// afterwards, so results do not depend on thread timing.
+//
+// Not std::execution::par: libc++ gates <execution> behind
+// _LIBCPP_HAS_EXPERIMENTAL_PSTL and ships no backend to link against (verified
+// on Apple clang 21: the parallel overloads fail to resolve, and force-enabling
+// them fails to link __pstl::__libdispatch::__dispatch_apply), while libstdc++
+// implements it over Intel TBB, which this tree does not depend on.
+//
+// Not OpenMP: the tree does use it (~28 pragma sites), but every one is
+// #ifdef _OPENMP-guarded and OpenMP is absent from the stock macOS toolchain,
+// so those loops run serial there. core/mel.cpp keeps its OpenMP path for the
+// platforms that have it and uses this helper as the portable path; the rest
+// had no OpenMP path to begin with.
+
+#pragma once
+
+#include <algorithm>
+#include <atomic>
+#include <thread>
+#include <vector>
+
+namespace core_parallel {
+
+// Number of threads to use for `n_items`, given a caller budget.
+// `n_threads <= 0` means "ask the machine".
+inline int resolve_threads(int n_items, int n_threads) {
+    if (n_items <= 1)
+        return 1;
+    if (n_threads <= 0) {
+        const unsigned hw = std::thread::hardware_concurrency();
+        n_threads = (int)(hw == 0 ? 1u : hw);
+    }
+    return std::max(1, std::min(n_threads, n_items));
+}
+
+// fn(begin, end) over contiguous blocks partitioning [0, n_items).
+template <typename F> void for_each_chunk(int n_items, int n_threads, F&& fn) {
+    if (n_items <= 0)
+        return;
+    const int nt = resolve_threads(n_items, n_threads);
+    if (nt == 1) {
+        fn(0, n_items);
+        return;
+    }
+    const int chunk = (n_items + nt - 1) / nt;
+    std::vector<std::thread> pool;
+    pool.reserve((size_t)nt - 1);
+    for (int t = 1; t < nt; t++) {
+        const int a = t * chunk, b = std::min(n_items, a + chunk);
+        if (a >= b)
+            break;
+        pool.emplace_back([&fn, a, b]() { fn(a, b); });
+    }
+    fn(0, std::min(n_items, chunk)); // calling thread takes the first block
+    for (auto& t : pool)
+        t.join();
+}
+
+// fn(task_index, slot) for every task in [0, n_tasks), pulled from an atomic
+// counter. `slot` is in [0, n_threads) and identifies WHICH per-thread
+// resource to use; no two concurrent calls share a slot.
+template <typename F> void for_each_task(int n_tasks, int n_threads, F&& fn) {
+    if (n_tasks <= 0)
+        return;
+    const int nt = resolve_threads(n_tasks, n_threads);
+    if (nt == 1) {
+        for (int i = 0; i < n_tasks; i++)
+            fn(i, 0);
+        return;
+    }
+    std::atomic<int> next{0};
+    auto run = [&](int slot) {
+        for (;;) {
+            const int i = next.fetch_add(1);
+            if (i >= n_tasks)
+                return;
+            fn(i, slot);
+        }
+    };
+    std::vector<std::thread> pool;
+    pool.reserve((size_t)nt - 1);
+    for (int t = 1; t < nt; t++)
+        pool.emplace_back(run, t);
+    run(0); // calling thread is slot 0
+    for (auto& t : pool)
+        t.join();
+}
+
+} // namespace core_parallel

--- a/src/firered_vad.cpp
+++ b/src/firered_vad.cpp
@@ -7,6 +7,7 @@
 #include "core/gguf_loader.h"
 #include "core/gpu_backend_pref.h" // crispasr_init_gpu_backend (#214)
 #include "core/crispasr_env.h"
+#include "core/parallel_for.h"
 #include "ggml.h"
 #include "ggml-backend.h"
 #include "gguf.h"
@@ -66,27 +67,6 @@ static int firered_vad_nthreads() {
     return v;
 }
 
-// Run fn(begin, end) over a partition of [0, n) across threads. fn must be safe
-// to call concurrently on disjoint sub-ranges (all callers write disjoint cells).
-template <class F> static void firered_parallel_for(int n, F&& fn) {
-    const int nt = std::min(firered_vad_nthreads(), n);
-    if (nt <= 1) {
-        fn(0, n);
-        return;
-    }
-    std::vector<std::thread> pool;
-    pool.reserve(nt - 1);
-    const int chunk = (n + nt - 1) / nt;
-    for (int t = 1; t < nt; t++) {
-        const int a = t * chunk, b = std::min(n, a + chunk);
-        if (a >= b)
-            break;
-        pool.emplace_back([&fn, a, b]() { fn(a, b); });
-    }
-    fn(0, std::min(n, chunk)); // this thread takes the first chunk
-    for (auto& th : pool)
-        th.join();
-}
 
 struct firered_vad_bench_stage {
     const char* name;
@@ -203,7 +183,7 @@ static void cpu_fsmn(const float* x, float* out, const float* lb_w, const float*
     int lb_pad = (N1 - 1) * S1;
     int lb_out_len = T + lb_pad; // T + (N1-1)*S1
     std::vector<float> lb_conv(P * lb_out_len, 0.0f);
-    firered_parallel_for(P, [&](int p0, int p1) {
+    core_parallel::for_each_chunk(P, firered_vad_nthreads(), [&](int p0, int p1) {
         for (int p = p0; p < p1; p++) {
             for (int t_out = 0; t_out < lb_out_len; t_out++) {
                 float s = 0;
@@ -232,7 +212,7 @@ static void cpu_fsmn(const float* x, float* out, const float* lb_w, const float*
         int la_pad = (N2 - 1) * S2;
         int la_out_len = T + la_pad;
         std::vector<float> la_conv(P * la_out_len, 0.0f);
-        firered_parallel_for(P, [&](int p0, int p1) {
+        core_parallel::for_each_chunk(P, firered_vad_nthreads(), [&](int p0, int p1) {
             for (int p = p0; p < p1; p++) {
                 for (int t_out = 0; t_out < la_out_len; t_out++) {
                     float s = 0;
@@ -330,7 +310,7 @@ static void compute_fbank_vad(const float* pcm, int n_samples, std::vector<float
 
     // Frames are independent (disjoint features[] writes); give each thread its
     // own FFT scratch. Bit-identical to the serial loop (#305).
-    firered_parallel_for(n_frames, [&](int t0, int t1) {
+    core_parallel::for_each_chunk(n_frames, firered_vad_nthreads(), [&](int t0, int t1) {
         std::vector<float> fre(n_fft), fim(n_fft);
         for (int t = t0; t < t1; t++) {
             int off = t * hop;

--- a/src/marblenet_vad.cpp
+++ b/src/marblenet_vad.cpp
@@ -23,6 +23,7 @@
 #include <thread>
 #include <vector>
 #include "core/crispasr_env.h"
+#include "core/parallel_for.h"
 #include "core/ggml_cpu_backend.h"
 
 #ifndef M_PI
@@ -119,28 +120,6 @@ static int marblenet_vad_nthreads() {
     return v;
 }
 
-// Run fn(begin, end) over a partition of [0, n) across threads; sub-ranges are
-// disjoint (each frame writes its own mel column), so this is bit-identical.
-template <class F> static void marblenet_parallel_for(int n, F&& fn) {
-    const int nt = std::min(marblenet_vad_nthreads(), n);
-    if (nt <= 1) {
-        fn(0, n);
-        return;
-    }
-    std::vector<std::thread> pool;
-    pool.reserve(nt - 1);
-    const int chunk = (n + nt - 1) / nt;
-    for (int t = 1; t < nt; t++) {
-        const int a = t * chunk, b = std::min(n, a + chunk);
-        if (a >= b)
-            break;
-        pool.emplace_back([&fn, a, b]() { fn(a, b); });
-    }
-    fn(0, std::min(n, chunk));
-    for (auto& th : pool)
-        th.join();
-}
-
 // ── Mel ────────────────────────────────────────────────────────────────────
 
 static void mbn_fft_dft(const float* in, int N, float* out) {
@@ -207,7 +186,7 @@ static std::vector<float> mbn_compute_mel(const float* pcm, int n_samples, const
 
     // Frames are independent (each writes its own mel column t); give each thread
     // its own FFT scratch. Bit-identical to the serial loop (#305).
-    marblenet_parallel_for(n_frames, [&](int t0, int t1) {
+    core_parallel::for_each_chunk(n_frames, marblenet_vad_nthreads(), [&](int t0, int t1) {
         std::vector<float> si(4 * n_fft, 0), so(8 * n_fft, 0);
         for (int t = t0; t < t1; t++) {
             // Window (win_len) centered in n_fft-sized frame, zero-padded

--- a/src/omnivoice.cpp
+++ b/src/omnivoice.cpp
@@ -23,6 +23,7 @@
 
 #include <cctype>
 #include "core/activation.h"
+#include "core/parallel_for.h"
 #include "core/attention.h"
 #include "core/bpe.h"
 #include "core/conv.h"
@@ -116,25 +117,6 @@ struct ov_bench_stage {
 // Parallel-for over [0, n) in contiguous chunks (scoring hot loop)
 // ---------------------------------------------------------------------------
 
-static void ov_parallel_for(int n_threads, int n, const std::function<void(int, int)>& fn) {
-    n_threads = std::max(1, std::min(n_threads, n));
-    if (n_threads == 1) {
-        fn(0, n);
-        return;
-    }
-    const int chunk = (n + n_threads - 1) / n_threads;
-    std::vector<std::thread> workers;
-    workers.reserve(n_threads);
-    for (int i = 0; i < n_threads; i++) {
-        const int a = i * chunk;
-        const int b = std::min(n, a + chunk);
-        if (a >= b)
-            break;
-        workers.emplace_back(fn, a, b);
-    }
-    for (auto& w : workers)
-        w.join();
-}
 
 // ---------------------------------------------------------------------------
 // Hyperparameters
@@ -2171,7 +2153,7 @@ static ov_gen_result generate_iterative(omnivoice_context* ctx, const std::strin
         // loop. This pass is ~13M exp() calls per step at T_target≈545.
         {
             ov_bench_stage b("  score_cfg");
-            ov_parallel_for(ctx->n_threads, T_target, [&](int t0, int t1) {
+            core_parallel::for_each_chunk(T_target, ctx->n_threads, [&](int t0, int t1) {
                 std::vector<float> c_lp(V), u_lp(V), guided(V), final_lp(V);
                 for (int t = t0; t < t1; t++) {
                     for (uint32_t cb = 0; cb < hp.n_codebooks; cb++) {
@@ -2209,7 +2191,7 @@ static ov_gen_result generate_iterative(omnivoice_context* ctx, const std::strin
                 for (size_t i = 0; i < pos_noise.size(); i++)
                     pos_noise[i] = gumbel_noise();
             }
-            ov_parallel_for(ctx->n_threads, T_target, [&](int t0, int t1) {
+            core_parallel::for_each_chunk(T_target, ctx->n_threads, [&](int t0, int t1) {
                 for (int t = t0; t < t1; t++) {
                     for (uint32_t cb = 0; cb < hp.n_codebooks; cb++) {
                         const float* lp = log_probs.data() + (size_t)t * out_dim + cb * V;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2019,6 +2019,23 @@ catch_discover_tests(test-diarize-smooth
     PROPERTIES LABELS "unit;diarize_smooth"
 )
 
+# ─── test-parallel-for — hermetic unit tests for the shared fan-out helpers
+# in core/parallel_for.h. No model, no audio, no threads-of-convenience. ──────
+add_executable(test-parallel-for
+    test-parallel-for.cpp
+)
+target_include_directories(test-parallel-for PRIVATE
+    ${PROJECT_SOURCE_DIR}/src
+)
+target_link_libraries(test-parallel-for PRIVATE
+    Catch2::Catch2WithMain
+    crispasr-core
+)
+catch_discover_tests(test-parallel-for
+    TEST_SPEC "[parallel]"
+    PROPERTIES LABELS "unit;parallel"
+)
+
 # ─── test-spectral-diarize — hermetic unit tests for the speaker-clustering
 # numerics. No model, no audio (#324). ────────────────────────────────────────
 add_executable(test-spectral-diarize

--- a/tests/test-parallel-for.cpp
+++ b/tests/test-parallel-for.cpp
@@ -1,0 +1,130 @@
+// test-parallel-for — core/parallel_for.h, the shared fan-out helpers.
+//
+// These replaced five hand-rolled copies, so the contract they all relied on
+// has to be pinned: every item is visited exactly once, ranges partition the
+// input, slots are unique among CONCURRENT callers, and the result never
+// depends on the thread count.
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "core/parallel_for.h"
+
+#include <atomic>
+#include <mutex>
+#include <numeric>
+#include <set>
+#include <thread>
+#include <vector>
+
+using namespace core_parallel;
+
+TEST_CASE("for_each_chunk covers every item exactly once", "[parallel]") {
+    for (int n : {1, 2, 3, 7, 8, 9, 64, 1000}) {
+        for (int nt : {0, 1, 2, 3, 8, 64}) {
+            std::vector<int> hits((size_t)n, 0);
+            for_each_chunk(n, nt, [&](int a, int b) {
+                for (int i = a; i < b; i++)
+                    hits[(size_t)i]++;
+            });
+            for (int i = 0; i < n; i++) {
+                INFO("n=" << n << " nt=" << nt << " i=" << i);
+                REQUIRE(hits[(size_t)i] == 1);
+            }
+        }
+    }
+}
+
+TEST_CASE("for_each_chunk hands out ordered, non-overlapping ranges", "[parallel]") {
+    std::mutex m;
+    std::vector<std::pair<int, int>> ranges;
+    for_each_chunk(1000, 8, [&](int a, int b) {
+        std::lock_guard<std::mutex> g(m);
+        ranges.emplace_back(a, b);
+    });
+    std::sort(ranges.begin(), ranges.end());
+    int expect = 0;
+    for (auto& r : ranges) {
+        CHECK(r.first == expect); // contiguous, no gaps or overlaps
+        CHECK(r.second > r.first);
+        expect = r.second;
+    }
+    CHECK(expect == 1000);
+}
+
+TEST_CASE("for_each_task covers every task exactly once", "[parallel]") {
+    for (int n : {1, 5, 33, 500}) {
+        for (int nt : {0, 1, 4, 16}) {
+            std::vector<int> hits((size_t)n, 0);
+            std::mutex m;
+            for_each_task(n, nt, [&](int i, int) {
+                std::lock_guard<std::mutex> g(m);
+                hits[(size_t)i]++;
+            });
+            for (int i = 0; i < n; i++) {
+                INFO("n=" << n << " nt=" << nt << " i=" << i);
+                REQUIRE(hits[(size_t)i] == 1);
+            }
+        }
+    }
+}
+
+// foxnose_pipeline hands each worker its OWN model context and relies on never
+// getting two concurrent calls with the same slot; that is the invariant here.
+TEST_CASE("for_each_task never reuses a slot concurrently", "[parallel]") {
+    constexpr int kSlots = 4;
+    std::vector<std::atomic<int>> live(kSlots);
+    for (auto& v : live)
+        v.store(0);
+    std::atomic<bool> clash{false};
+    std::atomic<int> max_slot{-1};
+
+    for_each_task(200, kSlots, [&](int, int slot) {
+        if (slot < 0 || slot >= kSlots) {
+            clash.store(true);
+            return;
+        }
+        int prev = max_slot.load();
+        while (slot > prev && !max_slot.compare_exchange_weak(prev, slot)) {
+        }
+        if (live[(size_t)slot].fetch_add(1) != 0)
+            clash.store(true); // someone else already inside this slot
+        for (volatile int spin = 0; spin < 2000; spin++) {
+        }
+        live[(size_t)slot].fetch_sub(1);
+    });
+
+    CHECK_FALSE(clash.load());
+    CHECK(max_slot.load() < kSlots);
+}
+
+// The reason for_each_task exists: with wildly uneven per-task cost a static
+// split idles threads, so results must still be complete and independent of
+// how the work happened to land.
+TEST_CASE("for_each_task result is independent of thread count", "[parallel]") {
+    auto run = [](int nt) {
+        std::vector<long> out(16, 0);
+        for_each_task(16, nt, [&](int i, int) {
+            long acc = 0;
+            const long work = (i % 4 == 3) ? 200000L : 1000L; // deliberately uneven
+            for (long j = 0; j < work; j++)
+                acc += j % 7;
+            out[(size_t)i] = acc + i;
+        });
+        return out;
+    };
+    const auto serial = run(1);
+    CHECK(run(2) == serial);
+    CHECK(run(8) == serial);
+    CHECK(run(0) == serial);
+}
+
+TEST_CASE("empty and degenerate inputs are no-ops", "[parallel]") {
+    int calls = 0;
+    for_each_chunk(0, 4, [&](int, int) { calls++; });
+    for_each_task(0, 4, [&](int, int) { calls++; });
+    for_each_chunk(-1, 4, [&](int, int) { calls++; });
+    for_each_task(-5, 4, [&](int, int) { calls++; });
+    CHECK(calls == 0);
+    CHECK(resolve_threads(1, 8) == 1);  // one item never spawns
+    CHECK(resolve_threads(4, 100) == 4); // never more threads than items
+}


### PR DESCRIPTION
## Why

Five copies of "run this loop across the cores" had accumulated, each written for its own file, none shared:

| site | form |
|---|---|
| `firered_vad.cpp:71` | `firered_parallel_for` — static template |
| `marblenet_vad.cpp:124` | `marblenet_parallel_for` — identical copy |
| `omnivoice.cpp:119` | `ov_parallel_for` — `std::function` variant |
| `core/mel.cpp:161` | inlined, no helper |
| `core/foxnose_pipeline.cpp:180` | inlined, no helper |

`docs/contributing.md` points contributors at `src/core/` primitives and the `arch_backend_map.h` note records what divergent copies cost, so this is the same cleanup applied to threading.

## What

They collapse to **two** genuinely different shapes, and `core/parallel_for.h` keeps both rather than forcing one onto the other:

- **`for_each_chunk(n, n_threads, fn(begin, end))`** — one contiguous block per thread, no atomics. Right when every item costs the same, which is what four of the five do (audio frames, feature rows).
- **`for_each_task(n, n_threads, fn(task, slot))`** — indices from an atomic counter, so threads take more work as they finish. Right when per-item cost varies. `slot` says *which* per-thread resource to use — `foxnose_pipeline` needs exactly this, since each worker owns its own model context and must never see two concurrent calls on the same one.

Behaviour is preserved exactly, including the per-site thread-count policies, which are now **passed in** rather than baked into each copy: `firered_vad_nthreads()`, `marblenet_vad_nthreads()`, `ctx->n_threads` for omnivoice, and mel's deliberate `min(hw, 8)` default cap.

`core/mel.cpp` keeps its `#ifdef _OPENMP` path **untouched** — only the portable `std::thread` branch moves — so platforms that do have OpenMP are unaffected.

Net: **−107 lines of duplication, +118 of shared helper**, and the next caller doesn't write a sixth copy.

## Verification

Bit-identical against a pre-refactor build of the same tree, not merely compiled:

| path | check |
|---|---|
| `core/mel.cpp` (31 consumers) | parakeet on `samples/jfk.wav` — **identical JSON** |
| `core/foxnose_pipeline.cpp` | foxnose diarization, 215 s file — **identical JSON** |
| `firered_vad.cpp` | `--vad -vm firered`, same file — **identical JSON** |
| clustering numerics | `test-spectral-diarize` (259 assertions), `test-der` (75) — unchanged |

New **`test-parallel-for` (8745 assertions)** pins the contract all five copies relied on: every item visited exactly once, ranges partition the input with no gaps or overlaps, slots never reused concurrently, and results independent of thread count even with deliberately uneven per-task cost.

**Not verified end-to-end:** `marblenet_vad.cpp` and `omnivoice.cpp` — no usable local model. Worth noting that marblenet's CLI path fails **identically before and after** this change: the auto-downloaded `marblenet-vad.gguf` is routed to `whisper_vad`'s loader and rejected as `invalid model data (bad magic)`. That looks like a pre-existing dispatch bug unrelated to this PR, but it does mean that call site is compile-checked only, and a reviewer with the model should exercise it.

## Related

Independent of #389 / #390 / #391. Note it touches `core/foxnose_pipeline.cpp`, which #391 also modifies — whichever lands second needs a small rebase in that file's worker loop; happy to do it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)