### PR TITLE
feat(diarize): forward FoxNose speaker turns across the C ABI (#395)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -9,6 +9,46 @@ WebSocket appends, emit genuine partials, flush and reset deterministically on
 commit, fix turn-cap overflow and backpressure/metrics semantics, and validate
 with unit, reference-parity, long-session, live model, and relevant GPU tests.
 
+## CLAIMED 2026-08-26 — #395 FoxNose turns were unreachable from the C ABI
+
+Additive plumbing of a value the library already computed. `apply_foxnose`
+labels each caller segment with the turn it overlaps MOST, so a segment
+straddling a speaker change was silently awarded to the majority speaker —
+and callers could not send a finer grid either, because FoxNose skips spans
+under `kMinSegmentSeconds = 0.4 s`. The C++ entry point had exposed the
+audio-derived turns since #324 (`out_turns`); the C ABI was the one layer
+that dropped them, so no Rust/Dart/Go/Python consumer could see them.
+
+Landed: `crispasr_diarize_segments_turns_abi` (a NEW symbol — the existing
+ABI is untouched, same append-only convention as `crispasr_diarize_opts_abi`)
+plus `crispasr_diarize_turn_abi`, the `crispasr-sys` `extern "C"` mirror with
+a layout test, and `crispasr::diarize_segments_with_turns` in the safe crate.
+Turns come out in centiseconds on the CALLER's absolute timeline
+(`slice_t0_cs` added back), so they compare directly with the caller's
+segments. Truncation follows the `crispasr_detect_language_pcm` house style:
+rc 2, with `*out_n_turns` holding the required capacity; the Rust wrapper
+sizes from the audio length (one slot per 0.5 s, above the 0.6 s embedding
+hop) and retries once, so callers never see it.
+
+Tests: model-free contract in `tests/test-session-abi-nulls.cpp` (validation,
+"no turn buffer == the older symbol", 0 turns from the methods that derive
+none) and `tests/test-diarize-foxnose-turns-live.cpp` for everything that
+needs REAL turns — well-formedness, the truncation protocol, the
+`slice_t0_cs` shift, and "asking for turns does not change the labels".
+Opt-in via `CRISPASR_TEST_FOXNOSE_WAV` + `CRISPASR_TEST_FOXNOSE_EMBEDDER`;
+verified locally on `samples/multispeaker.wav` + wespeaker-resnet34-lm, where
+the fixture does exercise a segment covering two speakers. Same pair of
+levels on the Rust side in `crispasr/tests/integration.rs`.
+
+**Not done, and deliberately: the other bindings.** Go, Python, Java, Ruby,
+Dart and JS still expose only `crispasr_diarize_segments_abi`. Nothing there
+is broken — the new symbol is additive — but a caller on those surfaces still
+cannot split a segment. Extending them is a mechanical follow-up (each has a
+hand-written mirror; the new turn struct is its own 24-byte POD, NOT an
+append to the opts struct). `tests/test_binding_parity.py`'s curated symbol
+list is unchanged for the same reason: adding the symbol there would fail
+until the Python binding declares it.
+
 ## CLAIMED 2026-08-19 — Issue #375 Canary streaming regression
 
 Root cause found + fixed 2026-08-19: NOT `73bb9b2f` (exonerated,

--- a/crispasr-sys/src/lib.rs
+++ b/crispasr-sys/src/lib.rs
@@ -153,6 +153,22 @@ pub struct CrispasrDiarizeSegAbi {
     pub _pad: c_int,
 }
 
+/// ABI speaker turn for [`crispasr_diarize_segments_turns_abi`] (#395).
+///
+/// A turn the METHOD derived from the audio, independent of the caller's
+/// segment grid — only FoxNose produces them. `t0_cs` / `t1_cs` are
+/// centiseconds on the same absolute timeline as [`CrispasrDiarizeSegAbi`]
+/// (`slice_t0_cs` already added back), so turns and caller segments compare
+/// directly. `speaker` is dense and zero-based, never -1.
+#[repr(C)]
+#[derive(Clone, Copy, Debug)]
+pub struct CrispasrDiarizeTurnAbi {
+    pub t0_cs: i64,
+    pub t1_cs: i64,
+    pub speaker: c_int,
+    pub _pad: c_int,
+}
+
 /// ABI options for [`crispasr_diarize_segments_abi`]. `method` is a
 /// value in 0..4: 0 = Energy, 1 = Xcorr, 2 = VadTurns, 3 = Pyannote,
 /// 4 = FoxNose. `pyannote_model_path` is required for Pyannote,
@@ -314,6 +330,40 @@ extern "C" {
         segs: *mut CrispasrDiarizeSegAbi,
         n_segs: c_int,
         opts: *const CrispasrDiarizeOptsAbi,
+    ) -> c_int;
+
+    /// Diarize AND hand back the speaker turns the method derived from the
+    /// audio (0.8.30+, issue #395). Identical to
+    /// [`crispasr_diarize_segments_abi`] plus the three trailing turn
+    /// parameters; passing `null` / `0` / `null` for them is exactly the
+    /// older call.
+    ///
+    /// Callers need this because labelling alone can never resolve finer
+    /// than the segment grid they sent in: a segment straddling a speaker
+    /// change is silently awarded to whoever holds the majority of it.
+    /// Only FoxNose derives turns; the other methods report 0, which is not
+    /// an error.
+    ///
+    /// `out_n_turns`, when non-null, always receives the TOTAL turn count —
+    /// also when it exceeds `n_turns_cap`, so a caller can size and retry
+    /// (at the cost of a second full pass; the ABI keeps no state).
+    /// `out_turns`, when non-null, receives up to `n_turns_cap` of them.
+    ///
+    /// Returns 0 on success, 2 when a turn buffer was given and could not
+    /// hold every turn (the segments are still fully labelled and the first
+    /// `n_turns_cap` turns are still written), 1 on model load failure, -1
+    /// on invalid args.
+    pub fn crispasr_diarize_segments_turns_abi(
+        left_pcm: *const c_float,
+        right_pcm: *const c_float,
+        n_samples: c_int,
+        is_stereo: c_int,
+        segs: *mut CrispasrDiarizeSegAbi,
+        n_segs: c_int,
+        opts: *const CrispasrDiarizeOptsAbi,
+        out_turns: *mut CrispasrDiarizeTurnAbi,
+        n_turns_cap: c_int,
+        out_n_turns: *mut c_int,
     ) -> c_int;
 
     /// Shared language identification (0.4.6+). `method` is 0 for
@@ -1288,6 +1338,9 @@ mod tests {
     fn diarize_abi_layout() {
         use std::mem::{offset_of, size_of};
         assert_eq!(size_of::<CrispasrDiarizeSegAbi>(), 24);
+        assert_eq!(size_of::<CrispasrDiarizeTurnAbi>(), 24);
+        assert_eq!(offset_of!(CrispasrDiarizeTurnAbi, t1_cs), 8);
+        assert_eq!(offset_of!(CrispasrDiarizeTurnAbi, speaker), 16);
         assert_eq!(size_of::<CrispasrDiarizeOptsAbi>(), 48);
         assert_eq!(offset_of!(CrispasrDiarizeOptsAbi, slice_t0_cs), 8);
         assert_eq!(offset_of!(CrispasrDiarizeOptsAbi, pyannote_model_path), 16);

--- a/crispasr/src/lib.rs
+++ b/crispasr/src/lib.rs
@@ -2709,6 +2709,22 @@ impl Default for DiarizeOptions {
     }
 }
 
+/// A speaker turn the diarizer derived from the AUDIO, independent of the
+/// caller's segment grid (#395).
+///
+/// Only [`DiarizeMethod::FoxNose`] produces these; the other methods label
+/// the caller's segments directly and yield none. `t0` / `t1` are seconds on
+/// the same absolute timeline as [`DiarizeSegment`] (i.e.
+/// [`DiarizeOptions::slice_t0`] is already accounted for), so a turn and a
+/// segment compare directly. `speaker` is dense and zero-based — a turn is
+/// always labelled, unlike a segment.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct DiarizeTurn {
+    pub t0: f64,
+    pub t1: f64,
+    pub speaker: i32,
+}
+
 /// Assign a speaker index to each of `segs`, mutating each
 /// [`DiarizeSegment::speaker`] in place.
 ///
@@ -2720,6 +2736,11 @@ impl Default for DiarizeOptions {
 /// Returns `Ok(())` on success. Only the model-backed methods
 /// ([`DiarizeMethod::Pyannote`], [`DiarizeMethod::FoxNose`]) can fail
 /// (model load failure).
+///
+/// Labelling alone can never resolve finer than the grid you pass in: a
+/// segment that straddles a speaker change is silently awarded to whoever
+/// holds the majority of it. Use [`diarize_segments_with_turns`] when you
+/// have word timings and want to split such a segment.
 pub fn diarize_segments(
     segs: &mut [DiarizeSegment],
     left: &[f32],
@@ -2727,8 +2748,40 @@ pub fn diarize_segments(
     is_stereo: bool,
     opts: &DiarizeOptions,
 ) -> Result<(), String> {
+    diarize_inner(segs, left, right, is_stereo, opts, false).map(|_| ())
+}
+
+/// Same as [`diarize_segments`], and additionally returns the speaker turns
+/// the method derived from the audio (#395).
+///
+/// The turns are what let a caller resolve a speaker change INSIDE one of its
+/// own segments — split a merged run wherever the turn id changes, instead of
+/// accepting the majority label for the whole span. Only
+/// [`DiarizeMethod::FoxNose`] derives turns; every other method returns an
+/// empty `Vec`, which is not an error.
+///
+/// The segments are labelled exactly as [`diarize_segments`] would label
+/// them; asking for turns changes nothing about the labels.
+pub fn diarize_segments_with_turns(
+    segs: &mut [DiarizeSegment],
+    left: &[f32],
+    right: Option<&[f32]>,
+    is_stereo: bool,
+    opts: &DiarizeOptions,
+) -> Result<Vec<DiarizeTurn>, String> {
+    diarize_inner(segs, left, right, is_stereo, opts, true)
+}
+
+fn diarize_inner(
+    segs: &mut [DiarizeSegment],
+    left: &[f32],
+    right: Option<&[f32]>,
+    is_stereo: bool,
+    opts: &DiarizeOptions,
+    want_turns: bool,
+) -> Result<Vec<DiarizeTurn>, String> {
     if segs.is_empty() || left.is_empty() {
-        return Ok(());
+        return Ok(Vec::new());
     }
 
     let path_c = match (&opts.pyannote_model_path, opts.method) {
@@ -2779,26 +2832,95 @@ pub fn diarize_segments(
         _ => left.as_ptr(),
     };
 
-    let rc = unsafe {
-        crispasr_sys::crispasr_diarize_segments_abi(
-            left.as_ptr(),
-            right_ptr,
-            left.len() as i32,
-            if is_stereo { 1 } else { 0 },
-            abi_segs.as_mut_ptr(),
-            abi_segs.len() as i32,
-            &abi_opts,
-        )
-    };
+    if !want_turns {
+        let rc = unsafe {
+            crispasr_sys::crispasr_diarize_segments_abi(
+                left.as_ptr(),
+                right_ptr,
+                left.len() as i32,
+                if is_stereo { 1 } else { 0 },
+                abi_segs.as_mut_ptr(),
+                abi_segs.len() as i32,
+                &abi_opts,
+            )
+        };
+        return finish(rc, segs, &abi_segs, &[], 0).map(|_| Vec::new());
+    }
+
+    // The ABI keeps no state between calls, so a buffer that turns out to be
+    // too small costs a SECOND full diarization pass. Size the first attempt
+    // so that can't happen: turns are merged embedding windows, the hop is
+    // 0.6 s, and no turn is shorter than one hop — so one slot per 0.5 s of
+    // audio (plus one per segment, plus slack) is comfortably above the
+    // ceiling. The retry below is the belt to that pair of braces.
+    let mut cap = (left.len() as f64 / 16_000.0 / 0.5).ceil() as usize + segs.len() + 16;
+    let mut turns: Vec<crispasr_sys::CrispasrDiarizeTurnAbi> = Vec::new();
+    for attempt in 0..2 {
+        turns.clear();
+        turns.resize(
+            cap,
+            crispasr_sys::CrispasrDiarizeTurnAbi {
+                t0_cs: 0,
+                t1_cs: 0,
+                speaker: -1,
+                _pad: 0,
+            },
+        );
+        let mut n_turns: i32 = 0;
+        let rc = unsafe {
+            crispasr_sys::crispasr_diarize_segments_turns_abi(
+                left.as_ptr(),
+                right_ptr,
+                left.len() as i32,
+                if is_stereo { 1 } else { 0 },
+                abi_segs.as_mut_ptr(),
+                abi_segs.len() as i32,
+                &abi_opts,
+                turns.as_mut_ptr(),
+                cap as i32,
+                &mut n_turns,
+            )
+        };
+        // rc 2 = the buffer was short; n_turns is the required capacity.
+        if rc == 2 && attempt == 0 {
+            cap = n_turns.max(1) as usize;
+            continue;
+        }
+        return finish(rc, segs, &abi_segs, &turns, n_turns);
+    }
+    unreachable!("the retry loop returns on its second pass")
+}
+
+/// Shared tail of both diarize entry points: map the ABI return code, copy the
+/// labels back, and convert the turns out of centiseconds.
+fn finish(
+    rc: i32,
+    segs: &mut [DiarizeSegment],
+    abi_segs: &[crispasr_sys::CrispasrDiarizeSegAbi],
+    abi_turns: &[crispasr_sys::CrispasrDiarizeTurnAbi],
+    n_turns: i32,
+) -> Result<Vec<DiarizeTurn>, String> {
     match rc {
         0 => {
             for (i, s) in segs.iter_mut().enumerate() {
                 s.speaker = abi_segs[i].speaker;
             }
-            Ok(())
+            let n = (n_turns.max(0) as usize).min(abi_turns.len());
+            Ok(abi_turns[..n]
+                .iter()
+                .map(|t| DiarizeTurn {
+                    t0: t.t0_cs as f64 / 100.0,
+                    t1: t.t1_cs as f64 / 100.0,
+                    speaker: t.speaker,
+                })
+                .collect())
         }
         1 => Err("diarize model load failed (pyannote / foxnose embedder)".to_string()),
         -1 => Err("invalid arguments to crispasr_diarize_segments_abi".to_string()),
+        2 => Err(format!(
+            "diarize turn buffer too small — {n_turns} turns needed; this is a \
+             crispasr bug, please report it with the audio length and segment count"
+        )),
         other => Err(format!("crispasr_diarize_segments_abi returned {other}")),
     }
 }

--- a/crispasr/tests/integration.rs
+++ b/crispasr/tests/integration.rs
@@ -794,6 +794,165 @@ fn diarize_foxnose_missing_model_errors() {
     assert!(err.contains("load failed"), "unexpected error: {err}");
 }
 
+/// #395: the turn-forwarding wrapper labels exactly like the plain one, and a
+/// method that derives no turns says so with an empty Vec rather than an error.
+#[test]
+fn diarize_with_turns_matches_plain_and_yields_no_turns_for_vad() {
+    let pcm = vec![0.01f32; 16000 * 4];
+    let mk = || {
+        vec![
+            crispasr::DiarizeSegment::new(0.0, 1.0),
+            crispasr::DiarizeSegment::new(2.0, 3.0),
+        ]
+    };
+    let opts = crispasr::DiarizeOptions::default(); // VadTurns
+
+    let mut plain = mk();
+    crispasr::diarize_segments(&mut plain, &pcm, None, false, &opts)
+        .expect("vad_turns diarize failed");
+
+    let mut with_turns = mk();
+    let turns = crispasr::diarize_segments_with_turns(&mut with_turns, &pcm, None, false, &opts)
+        .expect("vad_turns diarize_with_turns failed");
+
+    assert!(
+        turns.is_empty(),
+        "only FoxNose derives turns; VadTurns must report none"
+    );
+    for (a, b) in plain.iter().zip(with_turns.iter()) {
+        assert_eq!(a.speaker, b.speaker, "asking for turns changed the labels");
+    }
+}
+
+/// The error path must stay an error on the turns entry point too — a model
+/// load failure is not "zero turns".
+#[test]
+fn diarize_with_turns_foxnose_missing_model_errors() {
+    let pcm = vec![0.01f32; 16000];
+    let mut segs = vec![crispasr::DiarizeSegment::new(0.0, 1.0)];
+    let mut opts = crispasr::DiarizeOptions::default();
+    opts.method = crispasr::DiarizeMethod::FoxNose;
+    opts.foxnose_embedder_path = Some("/nonexistent/wespeaker.gguf".to_string());
+    let err = crispasr::diarize_segments_with_turns(&mut segs, &pcm, None, false, &opts)
+        .expect_err("foxnose with a missing embedder must fail, not crash");
+    assert!(err.contains("load failed"), "unexpected error: {err}");
+}
+
+/// Live: the case the issue is about — real turns, on the caller's own
+/// absolute timeline, finer than the caller's segment grid. Opt-in via
+/// CRISPASR_TEST_FOXNOSE_WAV + CRISPASR_TEST_FOXNOSE_EMBEDDER (16 kHz 16-bit
+/// mono WAV); skipped when either is unset.
+#[test]
+fn diarize_with_turns_foxnose_live() {
+    let (Ok(wav), Ok(embedder)) = (
+        std::env::var("CRISPASR_TEST_FOXNOSE_WAV"),
+        std::env::var("CRISPASR_TEST_FOXNOSE_EMBEDDER"),
+    ) else {
+        eprintln!("skipping: set CRISPASR_TEST_FOXNOSE_WAV + CRISPASR_TEST_FOXNOSE_EMBEDDER");
+        return;
+    };
+    let Some(pcm) = read_wav_mono_16k(&wav) else {
+        panic!("could not read {wav} as 16 kHz 16-bit PCM WAV");
+    };
+
+    // A deliberately coarse 3 s grid, offset 10 s into a longer recording —
+    // both halves of what the ABI has to get right.
+    const SLICE_T0: f64 = 10.0;
+    let total = pcm.len() as f64 / 16_000.0;
+    let mut segs: Vec<crispasr::DiarizeSegment> = (0..)
+        .map(|i| i as f64 * 3.0)
+        .take_while(|t| t + 3.0 <= total)
+        .map(|t| crispasr::DiarizeSegment::new(SLICE_T0 + t, SLICE_T0 + t + 3.0))
+        .collect();
+    assert!(segs.len() >= 2, "fixture too short for a 3 s grid");
+
+    let mut opts = crispasr::DiarizeOptions::default();
+    opts.method = crispasr::DiarizeMethod::FoxNose;
+    opts.foxnose_embedder_path = Some(embedder);
+    opts.slice_t0 = SLICE_T0;
+    opts.num_speakers = 2;
+
+    let turns = crispasr::diarize_segments_with_turns(&mut segs, &pcm, None, false, &opts)
+        .expect("foxnose diarize_with_turns failed");
+
+    assert!(!turns.is_empty(), "FoxNose must derive turns");
+    let mut prev_end = f64::NEG_INFINITY;
+    for t in &turns {
+        assert!(t.t1 > t.t0, "empty turn {t:?}");
+        assert!(t.speaker >= 0, "a turn is always labelled: {t:?}");
+        assert!(t.t0 >= prev_end - 1e-9, "turns out of order at {t:?}");
+        // The wrapper must hand back the CALLER's timeline, not the buffer's.
+        assert!(
+            t.t0 >= SLICE_T0 - 1e-9 && t.t1 <= SLICE_T0 + total + 0.02,
+            "turn {t:?} outside [{SLICE_T0}, {}]",
+            SLICE_T0 + total
+        );
+        prev_end = t.t1;
+    }
+
+    // At least one caller segment covers two speakers — the whole reason the
+    // turns had to be forwarded in the first place.
+    let straddling = segs
+        .iter()
+        .filter(|g| {
+            let mut spk: Vec<i32> = turns
+                .iter()
+                .filter(|t| t.t1.min(g.t1) - t.t0.max(g.t0) > 0.2)
+                .map(|t| t.speaker)
+                .collect();
+            spk.sort_unstable();
+            spk.dedup();
+            spk.len() > 1
+        })
+        .count();
+    assert!(
+        straddling > 0,
+        "fixture no longer exercises a segment spanning two speakers"
+    );
+}
+
+/// Minimal 16-bit PCM WAV reader for the live diarize test. Returns None
+/// unless the file is 16 kHz 16-bit (mono or stereo, downmixed).
+fn read_wav_mono_16k(path: &str) -> Option<Vec<f32>> {
+    let raw = std::fs::read(path).ok()?;
+    if raw.len() < 44 || &raw[0..4] != b"RIFF" || &raw[8..12] != b"WAVE" {
+        return None;
+    }
+    let u16at = |o: usize| u16::from_le_bytes([raw[o], raw[o + 1]]);
+    let u32at = |o: usize| u32::from_le_bytes([raw[o], raw[o + 1], raw[o + 2], raw[o + 3]]);
+
+    let (mut channels, mut bits, mut rate) = (0usize, 0usize, 0u32);
+    let mut pos = 12usize;
+    while pos + 8 <= raw.len() {
+        let id = &raw[pos..pos + 4];
+        let sz = u32at(pos + 4) as usize;
+        let body = pos + 8;
+        if id == b"fmt " && body + 16 <= raw.len() {
+            channels = u16at(body + 2) as usize;
+            rate = u32at(body + 4);
+            bits = u16at(body + 14) as usize;
+        } else if id == b"data" {
+            if bits != 16 || channels == 0 || rate != 16_000 {
+                return None;
+            }
+            let end = (body + sz).min(raw.len());
+            let frames = (end - body) / 2 / channels;
+            let mut out = Vec::with_capacity(frames);
+            for f in 0..frames {
+                let mut acc = 0i32;
+                for c in 0..channels {
+                    let o = body + (f * channels + c) * 2;
+                    acc += i16::from_le_bytes([raw[o], raw[o + 1]]) as i32;
+                }
+                out.push(acc as f32 / channels as f32 / 32768.0);
+            }
+            return Some(out);
+        }
+        pos = body + sz + (sz & 1);
+    }
+    None
+}
+
 // =========================================================================
 // Chat / LLM (crispasr_chat.h)
 // =========================================================================

--- a/docs/bindings.md
+++ b/docs/bindings.md
@@ -207,7 +207,7 @@ Install: `pip install crispasr` (or build locally from `python/`).
 
 ```rust
 use crispasr::{
-    Session, DiarizeMethod, DiarizeOptions, DiarizeSegment,
+    Session, DiarizeMethod, DiarizeOptions, DiarizeSegment, DiarizeTurn,
     LidMethod, detect_language_pcm, align_words,
     cache_ensure_file, registry_default_bundle,
     // Diarize pipeline primitives (#107):
@@ -235,6 +235,17 @@ for s in &segs {
 }
 let labels = agglomerative_cluster(&flat, (flat.len() / emb.dim() as usize) as i32,
                                    emb.dim(), 0.5, 8)?;
+
+// #395: labels alone can only ever be as fine as the grid you send in. Ask for
+// the turns FoxNose derived from the AUDIO to split a segment that spans two
+// speakers. Segments are labelled exactly as diarize_segments() labels them;
+// the other methods return an empty Vec, which is not an error.
+let mut grid: Vec<DiarizeSegment> = /* your coarse, well-clustering segments */ vec![];
+let turns: Vec<DiarizeTurn> =
+    crispasr::diarize_segments_with_turns(&mut grid, &pcm, None, false, &opts)?;
+for t in &turns {
+    println!("{:.2}–{:.2} speaker {}", t.t0, t.t1, t.speaker); // caller's timeline
+}
 ```
 
 Crates: `crispasr-sys/` (raw FFI) + `crispasr/` (high-level) at the repo

--- a/docs/diarization-speakers.md
+++ b/docs/diarization-speakers.md
@@ -266,6 +266,50 @@ outside Annex III(1)(a), and what the Act requires of you as deployer — is in
 
 See [`cli.md`](cli.md#diarization) for the full diarization flag reference.
 
+## Splitting a segment that spans two speakers (#395)
+
+Diarization **labels** the segments you hand it. That means the label
+resolution can never be finer than your own segment grid: a segment that
+straddles a speaker change is awarded to whoever holds the majority of it, and
+the other speaker's words are silently absorbed. It is not a clustering
+failure — FoxNose finds the boundary, the caller's grid just cannot express it.
+
+You cannot fix this by sending a finer grid, either. FoxNose skips any span
+shorter than `kMinSegmentSeconds = 0.4 s`
+(`src/core/foxnose_pipeline.h`), so a per-word grid starves the embedder and
+the clusterer under-counts speakers. Coarse segments cluster well and label
+coarsely; fine segments cluster badly. The way out is the third option: label
+coarse, then **split on the turns the method derived from the audio**.
+
+FoxNose produces those turns anyway — they are what the labelling reads. Ask
+for them and you get the audio's own boundaries, independent of your grid:
+
+| Surface | Entry point |
+|---|---|
+| C++ | `crispasr_diarize_segments(..., std::vector<CrispasrDiarizeTurn>* out_turns)` |
+| C ABI | `crispasr_diarize_segments_turns_abi(...)` (0.8.30+) |
+| Rust | `crispasr::diarize_segments_with_turns(...) -> Result<Vec<DiarizeTurn>, String>` |
+
+All three are additive: the segments come back labelled exactly as they would
+without the turns, and every other method reports zero turns rather than an
+error. Turn timestamps are on the **same absolute timeline as your segments**
+(the ABI adds `slice_t0_cs` back on the way out), so they compare directly.
+
+With word timings, the recipe is: merge words into utterance-length spans,
+then cut each merged run wherever the turn id changes rather than only at a
+gap threshold, re-merging within those bounds so every piece still clears the
+0.4 s floor — a piece that cannot reach it joins the neighbour it overlaps
+most instead of being dropped.
+
+The C ABI is a **new symbol**, not a signature change, so existing callers are
+untouched (the same append-only convention as `crispasr_diarize_opts_abi`).
+Its turn buffer is caller-allocated: pass `out_n_turns` to learn the count,
+`out_turns` + `n_turns_cap` to receive them, and expect `2` when the buffer
+was short — the segments are still labelled, `*out_n_turns` holds the required
+capacity, and a retry costs a second full pass because the ABI keeps no state
+between calls. The Rust wrapper sizes the buffer from the audio length and
+hides all of that.
+
 ## pyannote segmentation: chunked inference and the powerset layout (#326)
 
 Two changes landed together here, one a speed fix and one a correctness fix

--- a/include/crispasr_session.h
+++ b/include/crispasr_session.h
@@ -39,6 +39,8 @@ struct crispasr_diarize_opts_abi;
 typedef struct crispasr_diarize_opts_abi crispasr_diarize_opts_abi;
 struct crispasr_diarize_seg_abi;
 typedef struct crispasr_diarize_seg_abi crispasr_diarize_seg_abi;
+struct crispasr_diarize_turn_abi;
+typedef struct crispasr_diarize_turn_abi crispasr_diarize_turn_abi;
 struct crispasr_open_params_v1;
 typedef struct crispasr_open_params_v1 crispasr_open_params_v1;
 struct crispasr_session;
@@ -282,6 +284,35 @@ CRISPASR_SESSION_API crispasr_session_result* crispasr_session_transcribe_vad(
 CRISPASR_SESSION_API int crispasr_diarize_segments_abi(const float* left_pcm, const float* right_pcm, int32_t n_samples,
                                                        int32_t is_stereo, crispasr_diarize_seg_abi* segs,
                                                        int32_t n_segs, const crispasr_diarize_opts_abi* opts);
+// 0.8.30+ (issue #395): diarize AND hand back the speaker turns the method
+// derived from the audio, so a caller can split one of its own segments that
+// spans a speaker change — labelling alone can never resolve finer than the
+// segment grid the caller sent in. Only FoxNose (method 4) derives turns; the
+// other methods report 0, which is not an error.
+//
+// A NEW SYMBOL rather than a signature change, so the existing ABI stays
+// stable (same append-only convention as crispasr_diarize_opts_abi).
+// `out_turns == NULL, n_turns_cap == 0, out_n_turns == NULL` behaves exactly
+// like crispasr_diarize_segments_abi.
+//
+// `out_n_turns`, when non-NULL, always receives the TOTAL turn count — also
+// when it exceeds n_turns_cap, so a caller can size and retry (at the cost of
+// a second full pass: the ABI keeps no state between calls). `out_turns`,
+// when non-NULL, receives up to n_turns_cap turns.
+//
+// Turn timestamps are centiseconds on the SAME absolute timeline as
+// crispasr_diarize_seg_abi (i.e. `opts->slice_t0_cs` is already added back),
+// so turns and caller segments compare directly.
+//
+// Returns 0 on success, 2 when a turn buffer was given and could not hold
+// every turn (the segments are still fully labelled and the first n_turns_cap
+// turns are still written), 1 on model load failure, -1 on invalid arguments.
+CRISPASR_SESSION_API int crispasr_diarize_segments_turns_abi(const float* left_pcm, const float* right_pcm,
+                                                             int32_t n_samples, int32_t is_stereo,
+                                                             crispasr_diarize_seg_abi* segs, int32_t n_segs,
+                                                             const crispasr_diarize_opts_abi* opts,
+                                                             crispasr_diarize_turn_abi* out_turns, int32_t n_turns_cap,
+                                                             int32_t* out_n_turns);
 CRISPASR_SESSION_API int crispasr_detect_language_pcm(const float* samples, int32_t n_samples, int32_t method,
                                                       const char* model_path, int32_t n_threads, int32_t use_gpu,
                                                       int32_t gpu_device, int32_t flash_attn, char* out_lang_buf,

--- a/src/crispasr_c_api.cpp
+++ b/src/crispasr_c_api.cpp
@@ -7402,11 +7402,30 @@ CA_EXPORT crispasr_session_result* crispasr_session_transcribe_vad(crispasr_sess
 // Returns 0 on success, 1 when Pyannote was requested but the model
 // failed to load, -1 on invalid arguments. `speaker = -1` in a seg
 // means the method had no information to pick a label for that segment.
+//
+// #395: crispasr_diarize_segments_turns_abi below is the same call plus the
+// audio-derived speaker turns, for callers that need to resolve a speaker
+// change INSIDE one of their own segments.
 // ---------------------------------------------------------------------------
 struct crispasr_diarize_seg_abi {
     int64_t t0_cs;
     int64_t t1_cs;
     int32_t speaker; // out: -1 if unassigned
+    int32_t _pad;
+};
+
+// #395: a speaker turn the METHOD derived from the audio, independent of the
+// caller's segment grid. Only FoxNose produces these; the other methods label
+// caller segments directly and emit none.
+//
+// Same centisecond units AND the same absolute timeline as
+// crispasr_diarize_seg_abi: the library works buffer-relative, and this ABI
+// adds `opts->slice_t0_cs` back on the way out, so a turn can be compared with
+// a caller segment without a frame conversion.
+struct crispasr_diarize_turn_abi {
+    int64_t t0_cs;
+    int64_t t1_cs;
+    int32_t speaker; // dense, zero-based; never -1
     int32_t _pad;
 };
 
@@ -7443,6 +7462,8 @@ struct crispasr_diarize_opts_abi {
 static constexpr bool k_abi_is_64bit = sizeof(void*) == 8;
 static_assert(!k_abi_is_64bit || sizeof(crispasr_diarize_seg_abi) == 24,
               "diarize seg ABI layout changed — update every binding mirror");
+static_assert(!k_abi_is_64bit || sizeof(crispasr_diarize_turn_abi) == 24,
+              "diarize turn ABI layout changed — update every binding mirror");
 static_assert(!k_abi_is_64bit || sizeof(crispasr_diarize_opts_abi) == 48,
               "diarize opts ABI layout changed — update every binding mirror");
 static_assert(!k_abi_is_64bit || offsetof(crispasr_diarize_opts_abi, pyannote_model_path) == 16,
@@ -7452,12 +7473,28 @@ static_assert(!k_abi_is_64bit || offsetof(crispasr_diarize_opts_abi, foxnose_emb
 static_assert(!k_abi_is_64bit || offsetof(crispasr_diarize_opts_abi, min_speakers) == 32,
               "diarize opts ABI layout drifted");
 
-CA_EXPORT int crispasr_diarize_segments_abi(const float* left_pcm, const float* right_pcm, int32_t n_samples,
-                                            int32_t is_stereo, crispasr_diarize_seg_abi* segs, int32_t n_segs,
-                                            const crispasr_diarize_opts_abi* opts) {
+// #395: the turn-forwarding superset of crispasr_diarize_segments_abi. Both
+// entry points share this body; the older one passes no turn buffer and is
+// byte-for-byte unchanged in behaviour.
+//
+// `out_turns` / `n_turns_cap` / `out_n_turns` are all optional:
+//   - out_n_turns non-NULL always receives the TOTAL number of turns the
+//     method derived, whether or not they fit (so a caller can size and
+//     retry — at the cost of a second full pass, since the ABI is stateless).
+//   - out_turns non-NULL receives up to n_turns_cap of them.
+// Returns 2 when a turn buffer was supplied and could not hold them all; the
+// segments are still fully labelled in that case, and the first n_turns_cap
+// turns are still written. With out_turns == NULL nothing can be truncated,
+// so the count query alone returns 0.
+static int diarize_segments_abi_impl(const float* left_pcm, const float* right_pcm, int32_t n_samples,
+                                     int32_t is_stereo, crispasr_diarize_seg_abi* segs, int32_t n_segs,
+                                     const crispasr_diarize_opts_abi* opts, crispasr_diarize_turn_abi* out_turns,
+                                     int32_t n_turns_cap, int32_t* out_n_turns) {
     if (!left_pcm || !segs || n_segs <= 0 || !opts)
         return -1;
     if (opts->method < 0 || opts->method > 4)
+        return -1;
+    if (n_turns_cap < 0)
         return -1;
 
     CrispasrDiarizeOptions lib_opts;
@@ -7478,14 +7515,69 @@ CA_EXPORT int crispasr_diarize_segments_abi(const float* left_pcm, const float* 
         lib_segs.push_back({segs[i].t0_cs, segs[i].t1_cs, segs[i].speaker});
 
     const float* r = (is_stereo && right_pcm) ? right_pcm : left_pcm;
-    const bool ok = crispasr_diarize_segments(left_pcm, r, n_samples, is_stereo != 0, lib_segs, lib_opts);
+    // Only collect turns when someone asked, so the legacy entry point keeps
+    // its allocation profile exactly.
+    std::vector<CrispasrDiarizeTurn> lib_turns;
+    const bool want_turns = (out_turns != nullptr) || (out_n_turns != nullptr);
+    const bool ok = crispasr_diarize_segments(left_pcm, r, n_samples, is_stereo != 0, lib_segs, lib_opts,
+                                              want_turns ? &lib_turns : nullptr);
     if (!ok)
         return 1;
 
     for (int i = 0; i < n_segs; i++) {
         segs[i].speaker = lib_segs[i].speaker;
     }
+
+    const int64_t n_turns = (int64_t)lib_turns.size();
+    if (out_n_turns)
+        *out_n_turns = (int32_t)std::min<int64_t>(n_turns, INT32_MAX);
+    if (out_turns) {
+        const int64_t n_copy = std::min<int64_t>(n_turns, n_turns_cap);
+        for (int64_t i = 0; i < n_copy; i++) {
+            const CrispasrDiarizeTurn& t = lib_turns[(size_t)i];
+            // Library turns are buffer-relative seconds; segments are absolute
+            // centiseconds. Hand back the frame the caller already speaks.
+            out_turns[i].t0_cs = opts->slice_t0_cs + (int64_t)std::llround(t.start_s * 100.0);
+            out_turns[i].t1_cs = opts->slice_t0_cs + (int64_t)std::llround(t.end_s * 100.0);
+            out_turns[i].speaker = t.speaker;
+            out_turns[i]._pad = 0;
+        }
+        if (n_turns > n_turns_cap)
+            return 2; // segments are labelled; the turn buffer was short
+    }
     return 0;
+}
+
+CA_EXPORT int crispasr_diarize_segments_abi(const float* left_pcm, const float* right_pcm, int32_t n_samples,
+                                            int32_t is_stereo, crispasr_diarize_seg_abi* segs, int32_t n_segs,
+                                            const crispasr_diarize_opts_abi* opts) {
+    return diarize_segments_abi_impl(left_pcm, right_pcm, n_samples, is_stereo, segs, n_segs, opts, nullptr, 0,
+                                     nullptr);
+}
+
+// ---------------------------------------------------------------------------
+// #395: diarize AND hand back the audio-derived speaker turns.
+//
+// Identical to crispasr_diarize_segments_abi in every respect, plus the three
+// trailing turn parameters. A caller that passes NULL / 0 / NULL for them gets
+// exactly the older function.
+//
+// Why this exists: labelling alone can never resolve finer than the segment
+// grid the caller sent in — a segment straddling a speaker change is silently
+// awarded to whoever holds the majority of it. FoxNose derives its own turns
+// from the audio and already exposes them on the C++ API; callers with word
+// timestamps use them to SPLIT such a segment before labelling.
+//
+// Only FoxNose (method 4) derives turns. The other methods label the caller's
+// segments directly and report 0 turns — not an error.
+// ---------------------------------------------------------------------------
+CA_EXPORT int crispasr_diarize_segments_turns_abi(const float* left_pcm, const float* right_pcm, int32_t n_samples,
+                                                  int32_t is_stereo, crispasr_diarize_seg_abi* segs, int32_t n_segs,
+                                                  const crispasr_diarize_opts_abi* opts,
+                                                  crispasr_diarize_turn_abi* out_turns, int32_t n_turns_cap,
+                                                  int32_t* out_n_turns) {
+    return diarize_segments_abi_impl(left_pcm, right_pcm, n_samples, is_stereo, segs, n_segs, opts, out_turns,
+                                     n_turns_cap, out_n_turns);
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -724,6 +724,29 @@ catch_discover_tests(test-diarize-pyannote-live
         WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"
 )
 
+# ─── test-diarize-foxnose-turns-live — the #395 turn-forwarding ABI ───────────
+#
+# Everything about crispasr_diarize_segments_turns_abi that needs REAL turns,
+# and therefore a real speaker embedder: well-formedness, the truncation
+# protocol, the absolute-timeline conversion, and "asking for turns does not
+# change the labels". The model-free half of the contract is in
+# test-session-abi-nulls.cpp. Opt-in via CRISPASR_TEST_FOXNOSE_WAV +
+# CRISPASR_TEST_FOXNOSE_EMBEDDER; skips cleanly without them.
+add_executable(test-diarize-foxnose-turns-live
+    test-diarize-foxnose-turns-live.cpp
+)
+target_link_libraries(test-diarize-foxnose-turns-live PRIVATE
+    Catch2::Catch2WithMain
+    crispasr-lib
+)
+catch_discover_tests(test-diarize-foxnose-turns-live
+    TEST_SPEC "[live]"
+    PROPERTIES
+        LABELS live
+        SKIP_RETURN_CODE 4
+        WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"
+)
+
 # Agglomerative cosine clustering used by --diarize-embedder (#107 P3b).
 # Pure arithmetic on synthetic embeddings; no model, no audio.
 add_executable(test-speaker-cluster

--- a/tests/test-diarize-foxnose-turns-live.cpp
+++ b/tests/test-diarize-foxnose-turns-live.cpp
@@ -1,0 +1,321 @@
+// Live end-to-end test for crispasr_diarize_segments_turns_abi (issue #395).
+//
+// The turn-forwarding ABI is what lets a caller split one of its OWN segments
+// that spans a speaker change: labelling alone can never resolve finer than
+// the segment grid the caller sent in. Only FoxNose derives turns, and FoxNose
+// needs a real speaker embedder — so the parts that can be checked without a
+// model live in tests/test-session-abi-nulls.cpp, and everything that needs
+// actual turns lives here.
+//
+// What this pins, none of which the model-free contract test can reach:
+//   - turns come back at all, well-formed, inside the audio, in order;
+//   - the truncation protocol (rc 2 + full required count + the first
+//     n_turns_cap turns still written);
+//   - the count-only query agrees with the filled buffer;
+//   - turns are on the SAME absolute timeline as the caller's segments —
+//     shifting slice_t0_cs shifts every turn by exactly that much;
+//   - the segment labels are byte-identical to crispasr_diarize_segments_abi,
+//     i.e. this is additive plumbing and not a behaviour change.
+//
+// Opt-in; skips cleanly when either env var is unset:
+//
+//   CRISPASR_TEST_FOXNOSE_WAV=samples/multispeaker.wav                (required)
+//   CRISPASR_TEST_FOXNOSE_EMBEDDER=~/.cache/crispasr/wespeaker-...gguf (required)
+//
+// The wav must be 16 kHz 16-bit PCM (mono or stereo; stereo is downmixed).
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <algorithm>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <set>
+#include <string>
+#include <vector>
+
+extern "C" {
+// Hand-written mirrors of the ABI structs in src/crispasr_c_api.cpp, kept
+// byte-identical on purpose (see test-session-abi-nulls.cpp for why).
+struct diarize_seg_abi {
+    int64_t t0_cs;
+    int64_t t1_cs;
+    int32_t speaker;
+    int32_t _pad;
+};
+struct diarize_turn_abi {
+    int64_t t0_cs;
+    int64_t t1_cs;
+    int32_t speaker;
+    int32_t _pad;
+};
+struct diarize_opts_abi {
+    int32_t method;
+    int32_t n_threads;
+    int64_t slice_t0_cs;
+    const char* pyannote_model_path;
+    const char* foxnose_embedder_path;
+    int32_t min_speakers;
+    int32_t max_speakers;
+    int32_t num_speakers;
+    int32_t _pad2;
+};
+int crispasr_diarize_segments_abi(const float* left_pcm, const float* right_pcm, int32_t n_samples, int32_t is_stereo,
+                                  diarize_seg_abi* segs, int32_t n_segs, const diarize_opts_abi* opts);
+int crispasr_diarize_segments_turns_abi(const float* left_pcm, const float* right_pcm, int32_t n_samples,
+                                        int32_t is_stereo, diarize_seg_abi* segs, int32_t n_segs,
+                                        const diarize_opts_abi* opts, diarize_turn_abi* out_turns, int32_t n_turns_cap,
+                                        int32_t* out_n_turns);
+}
+
+namespace {
+
+// Minimal 16-bit PCM WAV loader, mono/stereo → float32 mono at the file's
+// native rate. Same shape as tests/test-diarize-pyannote-live.cpp.
+bool load_wav_mono(const std::string& path, std::vector<float>& out, int& sample_rate) {
+    FILE* f = std::fopen(path.c_str(), "rb");
+    if (!f)
+        return false;
+
+    char riff[4], wave[4];
+    uint32_t file_size = 0;
+    if (std::fread(riff, 1, 4, f) != 4 || std::fread(&file_size, 4, 1, f) != 1 || std::fread(wave, 1, 4, f) != 4 ||
+        std::memcmp(riff, "RIFF", 4) != 0 || std::memcmp(wave, "WAVE", 4) != 0) {
+        std::fclose(f);
+        return false;
+    }
+
+    int channels = 0, bits = 0;
+    sample_rate = 0;
+    std::vector<int16_t> pcm;
+
+    while (true) {
+        char id[4];
+        uint32_t sz = 0;
+        if (std::fread(id, 1, 4, f) != 4 || std::fread(&sz, 4, 1, f) != 1)
+            break;
+        if (std::memcmp(id, "fmt ", 4) == 0) {
+            uint16_t fmt = 0, ch = 0;
+            uint32_t sr = 0;
+            uint16_t bps = 0;
+            std::fread(&fmt, 2, 1, f);
+            std::fread(&ch, 2, 1, f);
+            std::fread(&sr, 4, 1, f);
+            std::fseek(f, 4 + 2, SEEK_CUR);
+            std::fread(&bps, 2, 1, f);
+            channels = ch;
+            sample_rate = (int)sr;
+            bits = bps;
+            if (sz > 16)
+                std::fseek(f, sz - 16, SEEK_CUR);
+        } else if (std::memcmp(id, "data", 4) == 0) {
+            int n = (int)(sz / (bits / 8) / channels);
+            pcm.resize((size_t)n * channels);
+            std::fread(pcm.data(), bits / 8, (size_t)n * channels, f);
+            break;
+        } else {
+            std::fseek(f, sz, SEEK_CUR);
+        }
+    }
+    std::fclose(f);
+
+    if (bits != 16 || channels < 1 || sample_rate <= 0 || pcm.empty())
+        return false;
+
+    out.resize(pcm.size() / channels);
+    for (size_t i = 0; i < out.size(); i++) {
+        int32_t acc = 0;
+        for (int c = 0; c < channels; c++)
+            acc += pcm[i * channels + c];
+        out[i] = (float)acc / (float)channels / 32768.0f;
+    }
+    return true;
+}
+
+// The caller grid this test hands in: fixed 3 s blocks over the whole file.
+// Deliberately coarse — that IS the failure mode #395 is about, and the turns
+// are what a caller would use to cut these blocks up afterwards.
+std::vector<diarize_seg_abi> block_grid(int64_t n_samples, int sr, int64_t slice_t0_cs) {
+    std::vector<diarize_seg_abi> segs;
+    const int64_t total_cs = n_samples * 100 / sr;
+    for (int64_t t = 0; t + 300 <= total_cs; t += 300)
+        segs.push_back({slice_t0_cs + t, slice_t0_cs + t + 300, -1, 0});
+    return segs;
+}
+
+struct Fixture {
+    std::vector<float> pcm;
+    int sr = 0;
+    std::string embedder;
+};
+
+// Returns false when the fixtures are not configured, so each test can SKIP.
+bool load_fixture(Fixture& fx) {
+    const char* wav = std::getenv("CRISPASR_TEST_FOXNOSE_WAV");
+    const char* emb = std::getenv("CRISPASR_TEST_FOXNOSE_EMBEDDER");
+    if (!wav || !*wav || !emb || !*emb)
+        return false;
+    if (!load_wav_mono(wav, fx.pcm, fx.sr))
+        return false;
+    fx.embedder = emb;
+    return true;
+}
+
+diarize_opts_abi foxnose_opts(const Fixture& fx, int64_t slice_t0_cs) {
+    diarize_opts_abi o = {};
+    o.method = 4; // FoxNose
+    o.n_threads = 4;
+    o.slice_t0_cs = slice_t0_cs;
+    o.foxnose_embedder_path = fx.embedder.c_str();
+    o.num_speakers = 2; // pinned: the count estimator is not what's under test
+    return o;
+}
+
+} // namespace
+
+TEST_CASE("FoxNose turns reach the caller through the ABI", "[live][diarize]") {
+    Fixture fx;
+    if (!load_fixture(fx))
+        SKIP("set CRISPASR_TEST_FOXNOSE_WAV + CRISPASR_TEST_FOXNOSE_EMBEDDER to run this");
+    REQUIRE(fx.sr == 16000);
+
+    auto segs = block_grid((int64_t)fx.pcm.size(), fx.sr, 0);
+    REQUIRE(segs.size() >= 2);
+    diarize_opts_abi opts = foxnose_opts(fx, 0);
+
+    // One turn per 0.6 s of audio is well above what the pipeline can emit
+    // (its embedding hop), so this cap cannot truncate.
+    const int32_t cap = (int32_t)((int64_t)fx.pcm.size() / fx.sr / 0.6) + (int32_t)segs.size() + 16;
+    std::vector<diarize_turn_abi> turns((size_t)cap);
+    int32_t n_turns = -1;
+
+    REQUIRE(crispasr_diarize_segments_turns_abi(fx.pcm.data(), nullptr, (int32_t)fx.pcm.size(), 0, segs.data(),
+                                                (int32_t)segs.size(), &opts, turns.data(), cap, &n_turns) == 0);
+    REQUIRE(n_turns > 0);
+    REQUIRE(n_turns <= cap);
+
+    const int64_t total_cs = (int64_t)fx.pcm.size() * 100 / fx.sr;
+    int64_t prev_end = -1;
+    std::set<int> speakers;
+    for (int32_t i = 0; i < n_turns; i++) {
+        const diarize_turn_abi& t = turns[(size_t)i];
+        CHECK(t.t1_cs > t.t0_cs);
+        CHECK(t.t0_cs >= 0);
+        CHECK(t.t1_cs <= total_cs + 1); // +1 cs of rounding slack
+        CHECK(t.speaker >= 0);          // turns are always labelled, unlike segs
+        CHECK(t.t0_cs >= prev_end);     // sorted and non-overlapping
+        prev_end = t.t1_cs;
+        speakers.insert(t.speaker);
+    }
+    CHECK(speakers.size() == 2); // num_speakers was pinned to 2
+
+    // The whole point of #395: at least one of the caller's segments covers
+    // two DIFFERENT speakers, so labelling it can only ever be half right —
+    // and the turns are what a caller splits it on. If this ever stops
+    // holding for the fixture, the test has lost the case it was written for.
+    int straddling = 0;
+    for (const auto& g : segs) {
+        std::set<int> spk;
+        for (int32_t i = 0; i < n_turns; i++) {
+            const diarize_turn_abi& t = turns[(size_t)i];
+            const int64_t ov = std::min(g.t1_cs, t.t1_cs) - std::max(g.t0_cs, t.t0_cs);
+            if (ov > 20) // >0.2 s of real overlap, not a boundary graze
+                spk.insert(t.speaker);
+        }
+        if (spk.size() > 1)
+            straddling++;
+    }
+    INFO("segments straddling a speaker change: " << straddling << " of " << segs.size());
+    CHECK(straddling > 0);
+}
+
+TEST_CASE("a short turn buffer truncates with 2 and reports what was needed", "[live][diarize]") {
+    Fixture fx;
+    if (!load_fixture(fx))
+        SKIP("set CRISPASR_TEST_FOXNOSE_WAV + CRISPASR_TEST_FOXNOSE_EMBEDDER to run this");
+
+    auto segs = block_grid((int64_t)fx.pcm.size(), fx.sr, 0);
+    diarize_opts_abi opts = foxnose_opts(fx, 0);
+
+    // Pass 1: count only, no buffer. Nothing can be truncated, so rc 0.
+    int32_t needed = -1;
+    REQUIRE(crispasr_diarize_segments_turns_abi(fx.pcm.data(), nullptr, (int32_t)fx.pcm.size(), 0, segs.data(),
+                                                (int32_t)segs.size(), &opts, nullptr, 0, &needed) == 0);
+    REQUIRE(needed > 1);
+
+    // Pass 2: deliberately one short. rc 2, the count is still the FULL
+    // requirement (that is what makes size-and-retry possible), and the turns
+    // that did fit are written.
+    const int32_t cap = needed - 1;
+    std::vector<diarize_turn_abi> turns((size_t)cap);
+    int32_t n_turns = -1;
+    for (auto& s : segs)
+        s.speaker = -1;
+    REQUIRE(crispasr_diarize_segments_turns_abi(fx.pcm.data(), nullptr, (int32_t)fx.pcm.size(), 0, segs.data(),
+                                                (int32_t)segs.size(), &opts, turns.data(), cap, &n_turns) == 2);
+    CHECK(n_turns == needed);
+    CHECK(turns[0].t1_cs > turns[0].t0_cs);
+    CHECK(turns[(size_t)cap - 1].t1_cs > turns[(size_t)cap - 1].t0_cs);
+
+    // Truncation is about the TURNS only — the segments came back labelled.
+    bool any_labelled = false;
+    for (const auto& s : segs)
+        any_labelled = any_labelled || s.speaker >= 0;
+    CHECK(any_labelled);
+}
+
+TEST_CASE("turns share the caller's absolute timeline, not the buffer's", "[live][diarize]") {
+    Fixture fx;
+    if (!load_fixture(fx))
+        SKIP("set CRISPASR_TEST_FOXNOSE_WAV + CRISPASR_TEST_FOXNOSE_EMBEDDER to run this");
+
+    const int64_t shift_cs = 1000; // the buffer starts 10 s into the recording
+    const int32_t cap = (int32_t)((int64_t)fx.pcm.size() / fx.sr / 0.6) + 64;
+
+    auto segs_a = block_grid((int64_t)fx.pcm.size(), fx.sr, 0);
+    diarize_opts_abi opts_a = foxnose_opts(fx, 0);
+    std::vector<diarize_turn_abi> turns_a((size_t)cap);
+    int32_t n_a = -1;
+    REQUIRE(crispasr_diarize_segments_turns_abi(fx.pcm.data(), nullptr, (int32_t)fx.pcm.size(), 0, segs_a.data(),
+                                                (int32_t)segs_a.size(), &opts_a, turns_a.data(), cap, &n_a) == 0);
+
+    // Same audio, same segments, both shifted by shift_cs: identical work,
+    // so the turns must come back shifted by exactly the same amount.
+    auto segs_b = block_grid((int64_t)fx.pcm.size(), fx.sr, shift_cs);
+    diarize_opts_abi opts_b = foxnose_opts(fx, shift_cs);
+    std::vector<diarize_turn_abi> turns_b((size_t)cap);
+    int32_t n_b = -1;
+    REQUIRE(crispasr_diarize_segments_turns_abi(fx.pcm.data(), nullptr, (int32_t)fx.pcm.size(), 0, segs_b.data(),
+                                                (int32_t)segs_b.size(), &opts_b, turns_b.data(), cap, &n_b) == 0);
+
+    REQUIRE(n_a == n_b);
+    for (int32_t i = 0; i < n_a; i++) {
+        CHECK(turns_b[(size_t)i].t0_cs == turns_a[(size_t)i].t0_cs + shift_cs);
+        CHECK(turns_b[(size_t)i].t1_cs == turns_a[(size_t)i].t1_cs + shift_cs);
+        CHECK(turns_b[(size_t)i].speaker == turns_a[(size_t)i].speaker);
+    }
+}
+
+TEST_CASE("asking for turns does not change the labels", "[live][diarize]") {
+    Fixture fx;
+    if (!load_fixture(fx))
+        SKIP("set CRISPASR_TEST_FOXNOSE_WAV + CRISPASR_TEST_FOXNOSE_EMBEDDER to run this");
+
+    auto segs_old = block_grid((int64_t)fx.pcm.size(), fx.sr, 0);
+    auto segs_new = block_grid((int64_t)fx.pcm.size(), fx.sr, 0);
+    diarize_opts_abi opts = foxnose_opts(fx, 0);
+
+    REQUIRE(crispasr_diarize_segments_abi(fx.pcm.data(), nullptr, (int32_t)fx.pcm.size(), 0, segs_old.data(),
+                                          (int32_t)segs_old.size(), &opts) == 0);
+
+    const int32_t cap = (int32_t)((int64_t)fx.pcm.size() / fx.sr / 0.6) + 64;
+    std::vector<diarize_turn_abi> turns((size_t)cap);
+    int32_t n_turns = -1;
+    REQUIRE(crispasr_diarize_segments_turns_abi(fx.pcm.data(), nullptr, (int32_t)fx.pcm.size(), 0, segs_new.data(),
+                                                (int32_t)segs_new.size(), &opts, turns.data(), cap, &n_turns) == 0);
+
+    REQUIRE(segs_old.size() == segs_new.size());
+    for (size_t i = 0; i < segs_old.size(); i++)
+        CHECK(segs_new[i].speaker == segs_old[i].speaker);
+}

--- a/tests/test-session-abi-nulls.cpp
+++ b/tests/test-session-abi-nulls.cpp
@@ -47,8 +47,20 @@ struct diarize_opts_abi {
     int32_t num_speakers;
     int32_t _pad2;
 };
+// #395: the turn struct is NOT append-only-shared with the opts struct — it is
+// its own 24-byte POD, mirrored here for the same reason as the others.
+struct diarize_turn_abi {
+    int64_t t0_cs;
+    int64_t t1_cs;
+    int32_t speaker;
+    int32_t _pad;
+};
 int crispasr_diarize_segments_abi(const float* left_pcm, const float* right_pcm, int32_t n_samples, int32_t is_stereo,
                                   diarize_seg_abi* segs, int32_t n_segs, const diarize_opts_abi* opts);
+int crispasr_diarize_segments_turns_abi(const float* left_pcm, const float* right_pcm, int32_t n_samples,
+                                        int32_t is_stereo, diarize_seg_abi* segs, int32_t n_segs,
+                                        const diarize_opts_abi* opts, diarize_turn_abi* out_turns, int32_t n_turns_cap,
+                                        int32_t* out_n_turns);
 }
 
 namespace {
@@ -154,4 +166,90 @@ TEST_CASE("FoxNose with a missing embedder fails with 1, not a crash", "[unit][d
     diarize_opts_abi opts = default_opts(4); // FoxNose
     opts.foxnose_embedder_path = "/nonexistent/wespeaker.gguf";
     CHECK(crispasr_diarize_segments_abi(pcm.data(), nullptr, 16000, 0, &seg, 1, &opts) == 1);
+}
+
+// ── #395: the turn-forwarding entry point ────────────────────────────────────
+//
+// The turns themselves need the FoxNose embedder, so what is model-free here
+// is the CONTRACT: the same argument validation, the same labelling as the
+// older symbol when no turn buffer is asked for, and 0 turns (not an error)
+// from the methods that don't derive any.
+
+TEST_CASE("turns ABI rejects the same invalid arguments, plus a negative cap", "[unit][diarize]") {
+    std::vector<float> pcm(16000, 0.01f);
+    diarize_seg_abi seg = {0, 100, -1, 0};
+    diarize_opts_abi opts = default_opts(2); // VadTurns
+    diarize_turn_abi turns[4] = {};
+    int32_t n_turns = -7;
+
+    CHECK(crispasr_diarize_segments_turns_abi(nullptr, nullptr, 16000, 0, &seg, 1, &opts, turns, 4, &n_turns) == -1);
+    CHECK(crispasr_diarize_segments_turns_abi(pcm.data(), nullptr, 16000, 0, nullptr, 1, &opts, turns, 4, &n_turns) ==
+          -1);
+    CHECK(crispasr_diarize_segments_turns_abi(pcm.data(), nullptr, 16000, 0, &seg, 0, &opts, turns, 4, &n_turns) == -1);
+    CHECK(crispasr_diarize_segments_turns_abi(pcm.data(), nullptr, 16000, 0, &seg, 1, nullptr, turns, 4, &n_turns) ==
+          -1);
+    CHECK(crispasr_diarize_segments_turns_abi(pcm.data(), nullptr, 16000, 0, &seg, 1, &opts, turns, -1, &n_turns) ==
+          -1);
+
+    diarize_opts_abi bad_method = default_opts(5); // one past FoxNose
+    CHECK(crispasr_diarize_segments_turns_abi(pcm.data(), nullptr, 16000, 0, &seg, 1, &bad_method, turns, 4,
+                                              &n_turns) == -1);
+
+    // A rejected call writes nothing — not even the count.
+    CHECK(n_turns == -7);
+}
+
+TEST_CASE("turns ABI with no turn buffer is the older symbol", "[unit][diarize]") {
+    // Same input as "VadTurns alternates speakers across a >600 ms gap", run
+    // through both entry points: the labels must agree exactly.
+    std::vector<float> pcm(16000 * 4, 0.01f);
+    diarize_seg_abi old_segs[2] = {{0, 100, -1, 0}, {200, 300, -1, 0}};
+    diarize_seg_abi new_segs[2] = {{0, 100, -1, 0}, {200, 300, -1, 0}};
+    diarize_opts_abi opts = default_opts(2);
+
+    REQUIRE(crispasr_diarize_segments_abi(pcm.data(), nullptr, (int32_t)pcm.size(), 0, old_segs, 2, &opts) == 0);
+    REQUIRE(crispasr_diarize_segments_turns_abi(pcm.data(), nullptr, (int32_t)pcm.size(), 0, new_segs, 2, &opts,
+                                                nullptr, 0, nullptr) == 0);
+    CHECK(new_segs[0].speaker == old_segs[0].speaker);
+    CHECK(new_segs[1].speaker == old_segs[1].speaker);
+}
+
+TEST_CASE("a method that derives no turns reports 0, not an error", "[unit][diarize]") {
+    // Energy labels caller segments directly; only FoxNose derives turns.
+    const int sr = 16000;
+    std::vector<float> left(sr, 0.5f), right(sr, 0.05f);
+    diarize_seg_abi seg = {0, 100, -1, 0};
+    diarize_opts_abi opts = default_opts(0); // Energy
+    diarize_turn_abi turns[4] = {};
+    int32_t n_turns = -7;
+
+    // With a buffer: 0 turns can never overflow it, so no truncation code.
+    REQUIRE(crispasr_diarize_segments_turns_abi(left.data(), right.data(), sr, 1, &seg, 1, &opts, turns, 4, &n_turns) ==
+            0);
+    CHECK(n_turns == 0);
+    CHECK(seg.speaker == 0); // labelling still happened
+
+    // Count-only query (no buffer) is legal and returns 0 as well.
+    seg.speaker = -1;
+    n_turns = -7;
+    REQUIRE(crispasr_diarize_segments_turns_abi(left.data(), right.data(), sr, 1, &seg, 1, &opts, nullptr, 0,
+                                                &n_turns) == 0);
+    CHECK(n_turns == 0);
+    CHECK(seg.speaker == 0);
+
+    // A zero cap is not truncation when there is nothing to truncate.
+    REQUIRE(crispasr_diarize_segments_turns_abi(left.data(), right.data(), sr, 1, &seg, 1, &opts, turns, 0, &n_turns) ==
+            0);
+    CHECK(n_turns == 0);
+}
+
+TEST_CASE("turns ABI: FoxNose with a missing embedder still fails with 1", "[unit][diarize]") {
+    std::vector<float> pcm(16000, 0.01f);
+    diarize_seg_abi seg = {0, 100, -1, 0};
+    diarize_opts_abi opts = default_opts(4); // FoxNose
+    opts.foxnose_embedder_path = "/nonexistent/wespeaker.gguf";
+    diarize_turn_abi turns[4] = {};
+    int32_t n_turns = -7;
+    CHECK(crispasr_diarize_segments_turns_abi(pcm.data(), nullptr, 16000, 0, &seg, 1, &opts, turns, 4, &n_turns) == 1);
+    CHECK(n_turns == -7); // a failed run writes no count
 }


### PR DESCRIPTION
Closes #395.

## What

Adds `crispasr_diarize_segments_turns_abi` — a **new symbol**, so the current ABI stays stable (the same append-only convention already documented for `crispasr_diarize_opts_abi`) — plus the `crispasr_diarize_turn_abi` POD, the matching `crispasr-sys` `extern "C"` block, and a `crispasr::diarize_segments_with_turns` wrapper so Rust callers don't hand-roll FFI.

Additive plumbing of a value the library already computes. No new model, no algorithm change, no behaviour change for existing callers.

## Why

`apply_foxnose` labels each caller segment with the turn it overlaps most, so a segment straddling a speaker change is silently awarded to the majority speaker and the minority speaker's words disappear. Callers can't send a finer grid either: `core_foxnose` skips spans under `kMinSegmentSeconds = 0.4 s`, so a per-word grid starves the embedder and the clusterer under-counts speakers.

The turns that resolve this already existed — `crispasr_diarize_segments()` has exposed them since #324 via `out_turns`, and its doc comment describes exactly this use case. The C ABI was the only layer that dropped them, so `crispasr-sys`, the `crispasr` crate, and every other binding never saw them.

## Shape

Both entry points share one body; `NULL / 0 / NULL` for the three trailing parameters is exactly the older call.

```c
typedef struct crispasr_diarize_turn_abi {
    int64_t t0_cs;
    int64_t t1_cs;
    int32_t speaker;
    int32_t _pad;
} crispasr_diarize_turn_abi;
```

- **Timeline.** Turns come out in centiseconds on the **caller's absolute timeline** (`opts->slice_t0_cs` is added back on the way out), so a turn and a caller segment compare directly with no frame conversion. The library itself works buffer-relative.
- **Out-array convention.** `crispasr_detect_language_pcm`'s house style: rc `2` when the buffer was short, with `*out_n_turns` holding the required capacity. The segments are still fully labelled in that case and the first `n_turns_cap` turns are still written. `out_turns == NULL` with `out_n_turns` set is a pure count query and returns `0` — nothing can be truncated when no buffer was offered.
- **Rust.** `diarize_segments_with_turns` sizes the buffer from the audio length (one slot per 0.5 s, comfortably above the 0.6 s embedding hop) and retries once, so callers never see the truncation protocol. Retry verified by forcing an undersized first buffer.
- **Non-FoxNose methods** report 0 turns, which is not an error.

## Tests

Two levels, because only FoxNose derives turns and FoxNose needs a real embedder:

- `tests/test-session-abi-nulls.cpp` — model-free contract: argument validation (including a negative cap), "no turn buffer == the older symbol" on identical input, 0 turns from methods that derive none, and the FoxNose load-failure path still returning `1` without writing a count.
- `tests/test-diarize-foxnose-turns-live.cpp` (new) — everything needing **real** turns: well-formedness (ordered, non-overlapping, inside the audio, always labelled), the truncation protocol end to end, the `slice_t0_cs` shift (same audio shifted by 10 s ⇒ every turn shifted by exactly 10 s), and "asking for turns does not change the labels". Opt-in via `CRISPASR_TEST_FOXNOSE_WAV` + `CRISPASR_TEST_FOXNOSE_EMBEDDER`, skips cleanly without them.
- `crispasr/tests/integration.rs` — the same pair of levels on the Rust side.

Verified locally on `samples/multispeaker.wav` + `wespeaker-resnet34-lm.gguf`: 110 assertions green, and the fixture does exercise a caller segment covering two speakers (the test asserts that, so it fails loudly if it ever stops being the case rather than passing vacuously). `ctest -L unit` is green apart from one pre-existing unrelated failure on this branch (`every emitted backend name is a name a surface can open`, confucius4-tts naming — reproduced with these changes stashed). clang-format, rustfmt and clippy clean on the new code.

## Deliberately not done

Go, Python, Java, Ruby, Dart and JS still expose only `crispasr_diarize_segments_abi`. Nothing there is broken — the new symbol is additive — but a caller on those surfaces still can't split a segment. Each has a hand-written mirror, and the new turn struct is its own 24-byte POD rather than an append to the opts struct, so extending them is mechanical; recorded as a follow-up in `PLAN.md`. `tests/test_binding_parity.py`'s curated symbol list is unchanged for the same reason — adding the symbol there fails until the Python binding declares it.

Happy to reshape the out-array convention or fold in the other bindings if you'd prefer either in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)