### PR TITLE
perf(chatterbox): accelerate F0 Conv1d with SIMD

### DIFF
--- a/src/chatterbox_s3gen.cpp
+++ b/src/chatterbox_s3gen.cpp
@@ -19,6 +19,7 @@
 #include "chatterbox_campplus.h"
 #include "chatterbox_s3gen.h"
 #include "chatterbox_s3tok.h"
+#include "core/chatterbox_f0_conv.h"
 #include "core/conv.h"
 #include "core/dac_decoder.h" // core_dac::fastconv_cache (shared FASTCONV)
 #include "core/gguf_loader.h"
@@ -3030,31 +3031,13 @@ static std::vector<float> run_f0_predictor(chatterbox_s3gen_context* c,
         if (bt)
             ggml_backend_tensor_get(bt, b.data(), 0, C_out * sizeof(float));
 
-        // Conv1d with padding=1 (symmetric): out[t] = sum over k,c_in
-        // Input x is (T, C_in), weight is (C_out, C_in, K) in memory
-        // PyTorch Conv1d: out[co, t] = bias[co] + sum_ci sum_k w[co,ci,k] * x[ci, t+k-pad]
-        // Our layout: x[t * C_in + ci], w[co * C_in * K + ci * K + k]
+        // Conv1d(k=3,p=1) + ELU. x86 GCC/Clang dispatches at runtime to
+        // AVX-512F or AVX2; other hosts keep the scalar path. Each SIMD lane
+        // preserves the original k→ci accumulation order, and rows are split
+        // with the Chatterbox thread budget already stored in c->n_threads.
         std::vector<float> out(T_mel * C_out, 0.0f);
-        for (int t = 0; t < T_mel; t++) {
-            for (int co = 0; co < C_out; co++) {
-                float sum = b[co];
-                for (int k = 0; k < K; k++) {
-                    int tt = t + k - 1; // padding=1
-                    if (tt < 0 || tt >= T_mel)
-                        continue;
-                    for (int ci = 0; ci < C_in; ci++) {
-                        // w layout: (K, C_in, C_out) → w[k * C_in * C_out + ci * C_out + co]
-                        // Actually ggml stores as ne[0]=K, ne[1]=C_in, ne[2]=C_out
-                        // Memory: w[co * C_in * K + ci * K + k]
-                        sum += w_f32[co * C_in * K + ci * K + k] * x[tt * C_in + ci];
-                    }
-                }
-                // ELU activation
-                if (sum < 0)
-                    sum = std::exp(sum) - 1.0f;
-                out[t * C_out + co] = sum;
-            }
-        }
+        core_chatterbox_f0::Conv1dEluK3{x.data(), w_f32.data(), b.data(), out.data(), T_mel, C_in, C_out}.run(
+            c->n_threads);
         x = std::move(out);
     }
 

--- a/src/core/chatterbox_f0_conv.h
+++ b/src/core/chatterbox_f0_conv.h
@@ -1,0 +1,223 @@
+#pragma once
+
+#include "core/parallel_for.h"
+
+#include <array>
+#include <cmath>
+#include <cstddef>
+#include <vector>
+
+#if (defined(__x86_64__) || defined(__i386__)) && (defined(__GNUC__) || defined(__clang__))
+#include <immintrin.h>
+#define CRISPASR_CHATTERBOX_F0_X86_TARGET_DISPATCH 1
+#else
+#define CRISPASR_CHATTERBOX_F0_X86_TARGET_DISPATCH 0
+#endif
+
+namespace core_chatterbox_f0 {
+
+enum class Isa {
+    scalar,
+    avx2,
+    avx512f,
+};
+
+inline bool isa_available(Isa isa) {
+    if (isa == Isa::scalar)
+        return true;
+#if CRISPASR_CHATTERBOX_F0_X86_TARGET_DISPATCH
+    if (isa == Isa::avx512f)
+        return __builtin_cpu_supports("avx512f");
+    if (isa == Isa::avx2)
+        return __builtin_cpu_supports("avx2");
+#endif
+    return false;
+}
+
+inline Isa best_isa() {
+    static const Isa isa = [] {
+        if (isa_available(Isa::avx512f))
+            return Isa::avx512f;
+        if (isa_available(Isa::avx2))
+            return Isa::avx2;
+        return Isa::scalar;
+    }();
+    return isa;
+}
+
+// Non-owning view of one k=3, p=1 Conv1d + ELU operation.
+struct Conv1dEluK3 {
+    const float* input;
+    const float* weights;
+    const float* bias;
+    float* output;
+    int frames;
+    int input_channels;
+    int output_channels;
+
+    void run(int n_threads, Isa isa = best_isa()) const;
+    void run_scalar(int n_threads = 1) const;
+};
+
+namespace detail {
+
+inline float elu(float value) {
+    return value < 0.0f ? std::exp(value) - 1.0f : value;
+}
+
+inline void run_scalar_rows(const Conv1dEluK3& conv, int begin, int end) {
+    for (int frame = begin; frame < end; ++frame) {
+        for (int output_channel = 0; output_channel < conv.output_channels; ++output_channel) {
+            float sum = conv.bias[output_channel];
+            for (int kernel = 0; kernel < 3; ++kernel) {
+                const int input_frame = frame + kernel - 1;
+                if (input_frame < 0 || input_frame >= conv.frames)
+                    continue;
+                const float* input_row = conv.input + static_cast<std::size_t>(input_frame) * conv.input_channels;
+                const float* kernel_weights =
+                    conv.weights + static_cast<std::size_t>(output_channel) * conv.input_channels * 3 + kernel;
+                for (int input_channel = 0; input_channel < conv.input_channels; ++input_channel)
+                    sum += kernel_weights[input_channel * 3] * input_row[input_channel];
+            }
+            conv.output[static_cast<std::size_t>(frame) * conv.output_channels + output_channel] = elu(sum);
+        }
+    }
+}
+
+inline std::vector<float> pack_weights(const Conv1dEluK3& conv, int width) {
+    std::vector<float> packed(static_cast<std::size_t>(conv.output_channels) * conv.input_channels * 3);
+    for (int output = 0; output < conv.output_channels; output += width) {
+        const int block = output / width;
+        for (int kernel = 0; kernel < 3; ++kernel) {
+            for (int input = 0; input < conv.input_channels; ++input) {
+                float* destination =
+                    packed.data() +
+                    ((static_cast<std::size_t>(block) * 3 + kernel) * conv.input_channels + input) * width;
+                for (int lane = 0; lane < width; ++lane) {
+                    destination[lane] = conv.weights[static_cast<std::size_t>(output + lane) * conv.input_channels * 3 +
+                                                     input * 3 + kernel];
+                }
+            }
+        }
+    }
+    return packed;
+}
+
+#if CRISPASR_CHATTERBOX_F0_X86_TARGET_DISPATCH
+
+#if defined(__clang__)
+#define CRISPASR_CHATTERBOX_F0_TARGET_AVX2 __attribute__((target("avx2")))
+#define CRISPASR_CHATTERBOX_F0_TARGET_AVX512 __attribute__((target("avx512f")))
+#define CRISPASR_CHATTERBOX_F0_NO_CONTRACT
+#define CRISPASR_CHATTERBOX_F0_CLANG_NO_CONTRACT _Pragma("clang fp contract(off)")
+#else
+#define CRISPASR_CHATTERBOX_F0_TARGET_AVX2 __attribute__((target("avx2")))
+#define CRISPASR_CHATTERBOX_F0_TARGET_AVX512 __attribute__((target("avx512f")))
+#define CRISPASR_CHATTERBOX_F0_NO_CONTRACT __attribute__((optimize("fp-contract=off")))
+#define CRISPASR_CHATTERBOX_F0_CLANG_NO_CONTRACT
+#endif
+
+constexpr int avx2_width = 8;
+constexpr int avx512_width = 16;
+
+CRISPASR_CHATTERBOX_F0_TARGET_AVX2
+CRISPASR_CHATTERBOX_F0_NO_CONTRACT
+inline void run_avx2_rows(const Conv1dEluK3& conv, const float* packed, int begin, int end) {
+    CRISPASR_CHATTERBOX_F0_CLANG_NO_CONTRACT
+    for (int frame = begin; frame < end; ++frame) {
+        for (int block = 0; block < conv.output_channels / avx2_width; ++block) {
+            __m256 sum = _mm256_loadu_ps(conv.bias + block * avx2_width);
+            const float* block_weights =
+                packed + static_cast<std::size_t>(block) * 3 * conv.input_channels * avx2_width;
+            for (int kernel = 0; kernel < 3; ++kernel) {
+                const int input_frame = frame + kernel - 1;
+                if (input_frame < 0 || input_frame >= conv.frames)
+                    continue;
+                const float* input = conv.input + static_cast<std::size_t>(input_frame) * conv.input_channels;
+                const float* weights =
+                    block_weights + static_cast<std::size_t>(kernel) * conv.input_channels * avx2_width;
+                for (int channel = 0; channel < conv.input_channels; ++channel) {
+                    const __m256 weight = _mm256_loadu_ps(weights + channel * avx2_width);
+                    const __m256 value = _mm256_set1_ps(input[channel]);
+                    sum = _mm256_add_ps(sum, _mm256_mul_ps(weight, value));
+                }
+            }
+            std::array<float, avx2_width> lanes;
+            _mm256_storeu_ps(lanes.data(), sum);
+            float* output = conv.output + static_cast<std::size_t>(frame) * conv.output_channels + block * avx2_width;
+            for (const auto value : lanes)
+                *output++ = elu(value);
+        }
+    }
+}
+
+CRISPASR_CHATTERBOX_F0_TARGET_AVX512
+CRISPASR_CHATTERBOX_F0_NO_CONTRACT
+inline void run_avx512_rows(const Conv1dEluK3& conv, const float* packed, int begin, int end) {
+    CRISPASR_CHATTERBOX_F0_CLANG_NO_CONTRACT
+    for (int frame = begin; frame < end; ++frame) {
+        for (int block = 0; block < conv.output_channels / avx512_width; ++block) {
+            __m512 sum = _mm512_loadu_ps(conv.bias + block * avx512_width);
+            const float* block_weights =
+                packed + static_cast<std::size_t>(block) * 3 * conv.input_channels * avx512_width;
+            for (int kernel = 0; kernel < 3; ++kernel) {
+                const int input_frame = frame + kernel - 1;
+                if (input_frame < 0 || input_frame >= conv.frames)
+                    continue;
+                const float* input = conv.input + static_cast<std::size_t>(input_frame) * conv.input_channels;
+                const float* weights =
+                    block_weights + static_cast<std::size_t>(kernel) * conv.input_channels * avx512_width;
+                for (int channel = 0; channel < conv.input_channels; ++channel) {
+                    const __m512 weight = _mm512_loadu_ps(weights + channel * avx512_width);
+                    const __m512 value = _mm512_set1_ps(input[channel]);
+                    sum = _mm512_add_ps(sum, _mm512_mul_ps(weight, value));
+                }
+            }
+            std::array<float, avx512_width> lanes;
+            _mm512_storeu_ps(lanes.data(), sum);
+            float* output = conv.output + static_cast<std::size_t>(frame) * conv.output_channels + block * avx512_width;
+            for (const auto value : lanes)
+                *output++ = elu(value);
+        }
+    }
+}
+
+using SimdRows = void (*)(const Conv1dEluK3&, const float*, int, int);
+
+inline void run_simd(const Conv1dEluK3& conv, int width, int n_threads, SimdRows run_rows) {
+    const auto packed = pack_weights(conv, width);
+    core_parallel::for_each_chunk(conv.frames, n_threads,
+                                  [&](int begin, int end) { run_rows(conv, packed.data(), begin, end); });
+}
+
+#undef CRISPASR_CHATTERBOX_F0_CLANG_NO_CONTRACT
+#undef CRISPASR_CHATTERBOX_F0_TARGET_AVX2
+#undef CRISPASR_CHATTERBOX_F0_TARGET_AVX512
+#undef CRISPASR_CHATTERBOX_F0_NO_CONTRACT
+
+#endif // CRISPASR_CHATTERBOX_F0_X86_TARGET_DISPATCH
+
+} // namespace detail
+
+inline void Conv1dEluK3::run_scalar(int n_threads) const {
+    core_parallel::for_each_chunk(frames, n_threads,
+                                  [this](int begin, int end) { detail::run_scalar_rows(*this, begin, end); });
+}
+
+inline void Conv1dEluK3::run(int n_threads, Isa isa) const {
+#if CRISPASR_CHATTERBOX_F0_X86_TARGET_DISPATCH
+    if (isa == Isa::avx512f && isa_available(isa) && output_channels % detail::avx512_width == 0) {
+        detail::run_simd(*this, detail::avx512_width, n_threads, detail::run_avx512_rows);
+        return;
+    }
+    if (isa == Isa::avx2 && isa_available(isa) && output_channels % detail::avx2_width == 0) {
+        detail::run_simd(*this, detail::avx2_width, n_threads, detail::run_avx2_rows);
+        return;
+    }
+#endif
+    run_scalar(n_threads);
+}
+
+} // namespace core_chatterbox_f0
+
+#undef CRISPASR_CHATTERBOX_F0_X86_TARGET_DISPATCH

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -35,6 +35,13 @@ if (EMSCRIPTEN)
     return()
 endif()
 
+add_executable(test-chatterbox-f0-simd test-chatterbox-f0-simd.cpp)
+target_include_directories(test-chatterbox-f0-simd PRIVATE ${PROJECT_SOURCE_DIR}/src)
+target_link_libraries(test-chatterbox-f0-simd PRIVATE Catch2::Catch2WithMain Threads::Threads)
+catch_discover_tests(test-chatterbox-f0-simd
+    TEST_SPEC "[unit][tts][chatterbox][simd]"
+    PROPERTIES LABELS "unit;tts;chatterbox")
+
 set(TEST_TARGET test-crispasr-cli-tiny)
 add_test(NAME ${TEST_TARGET}
     COMMAND $<TARGET_FILE:crispasr-cli>

--- a/tests/test-chatterbox-f0-simd.cpp
+++ b/tests/test-chatterbox-f0-simd.cpp
@@ -1,0 +1,59 @@
+#include "core/chatterbox_f0_conv.h"
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <array>
+#include <cstdint>
+#include <cstring>
+#include <vector>
+
+namespace {
+
+void fill_exact(std::vector<float>& values, std::uint32_t seed) {
+    std::size_t index = 0;
+    for (auto& value : values) {
+        const auto integer = static_cast<int>((index++ * 37u + seed * 17u) % 127u) - 63;
+        value = static_cast<float>(integer) / 4096.0f;
+    }
+}
+
+void require_matches_scalar(int T, int C_in, int n_threads, core_chatterbox_f0::Isa isa) {
+    constexpr int C_out = 512;
+    std::vector<float> x(static_cast<std::size_t>(T) * C_in);
+    std::vector<float> w(static_cast<std::size_t>(C_out) * C_in * 3);
+    std::vector<float> bias(C_out);
+    fill_exact(x, 11);
+    fill_exact(w, 23);
+    fill_exact(bias, 47);
+
+    std::vector<float> reference(static_cast<std::size_t>(T) * C_out);
+    std::vector<float> actual(reference.size());
+    core_chatterbox_f0::Conv1dEluK3{x.data(), w.data(), bias.data(), reference.data(), T, C_in, C_out}.run_scalar();
+    core_chatterbox_f0::Conv1dEluK3{x.data(), w.data(), bias.data(), actual.data(), T, C_in, C_out}.run(n_threads, isa);
+
+    INFO("isa=" << static_cast<int>(isa) << " T=" << T << " C_in=" << C_in << " threads=" << n_threads);
+    REQUIRE(std::memcmp(reference.data(), actual.data(), reference.size() * sizeof(float)) == 0);
+}
+
+} // namespace
+
+TEST_CASE("Chatterbox F0 SIMD Conv1d is bit-identical to scalar", "[unit][tts][chatterbox][simd]") {
+    const std::array<core_chatterbox_f0::Isa, 3> candidates{{
+        core_chatterbox_f0::Isa::scalar,
+        core_chatterbox_f0::Isa::avx2,
+        core_chatterbox_f0::Isa::avx512f,
+    }};
+
+    for (const auto isa : candidates) {
+        if (!core_chatterbox_f0::isa_available(isa))
+            continue;
+        require_matches_scalar(7, 80, 1, isa);
+        require_matches_scalar(7, 512, 1, isa);
+        require_matches_scalar(17, 80, 4, isa);
+        require_matches_scalar(17, 512, 4, isa);
+    }
+}
+
+TEST_CASE("Chatterbox F0 auto dispatch preserves scalar output", "[unit][tts][chatterbox][simd]") {
+    require_matches_scalar(17, 512, 4, core_chatterbox_f0::best_isa());
+}


### PR DESCRIPTION
## Summary

Speed up the Chatterbox HiFT F0 predictor by replacing its hand-written scalar `Conv1d(k=3)` loop with a bit-identical SIMD + row-parallel implementation.

- runtime dispatch on x86 GCC/Clang: AVX-512F -> AVX2 -> scalar
- reuse Chatterbox's existing `c->n_threads` budget and `core_parallel::for_each_chunk()`
- keep scalar fallback on non-x86 / unsupported compilers and CPUs
- preserve the original `k -> ci` accumulation order independently in every SIMD lane
- explicitly prevent FP contraction in the SIMD kernels so multiply + add rounding matches the scalar path
- add a model-free Catch2 unit test that checks bit identity for both the 80->512 and 512->512 F0 layers, single-threaded and multi-threaded

No new environment variables or public API are added.

## Why

`run_f0_predictor()` currently computes five Conv1d layers with nested scalar loops. On a Ryzen 7 8745HS the F0 predictor dominated HiFT CPU time: about 200 ms of Conv1d work for a 94-frame Chatterbox Nano utterance.

The output channels are independent. Packing weights in output-channel blocks lets one SIMD vector update 8 AVX2 or 16 AVX-512 output channels while preserving the exact accumulation sequence of each channel. Mel-frame rows are also independent, so they can use the thread budget Chatterbox already resolves for the host.

## Benchmark

Downstream benchmark on Ryzen 7 8745HS (Zen 4), Linux, Chatterbox Nano, 94 generated mel frames, S3Gen on Vulkan. The benchmark build was pinned to CrispASR `3721d402`; current `main@7d5c3a8` still contains the same scalar F0 Conv1d loop, and this PR ports the tested kernel to current main.

| F0 Conv1d | 1 thread | 4 threads | 8 threads | 16 threads |
| --- | ---: | ---: | ---: | ---: |
| scalar | 199.86 ms | - | - | - |
| AVX2 | 27.00 ms | 11.24 ms | 6.92 ms | 8.69 ms |
| AVX-512F | 15.12 ms | 7.97 ms | **4.85 ms** | 6.97 ms |

With the normal Chatterbox auto thread budget on this 8C/16T host (`min(8, hardware_concurrency)`), AVX-512F used 8 threads:

- F0 Conv1d: 199.86 -> 4.84 ms (~41x)
- F0 total: 203.66 -> 10.22 ms (~20x)
- HiFT vocoder: 381.1 -> 168.2 ms
- end-to-end TTS wall time in this sample: 1241.6 -> 1024.0 ms

AVX-512F also beats AVX2 at the same thread count; at one thread it is 15.12 ms vs 27.00 ms.

## Correctness

The real-model verification recomputed every optimized F0 Conv1d layer with the original scalar loop from the exact same input, weights and bias. For all five layers at 94 mel frames:

- `bit_equal=1`
- `mismatches=0/48128`
- `max_abs=0`

The included unit test additionally generates deterministic synthetic tensors and compares the optimized result with the scalar reference using `memcmp` for:

- 80 -> 512 and 512 -> 512 layers
- 1 thread and 4 threads
- AVX2 when available
- AVX-512F when available
- automatic runtime dispatch

During development the standalone kernel was checked with GCC 14 and Clang 17. Both produced bit-identical results. Assembly inspection also confirmed no fused multiply-add instructions in the SIMD accumulation (`vmulps` + `vaddps`, no `vfmadd`).

## Portability

The optimized kernels are compiled with per-function target attributes on x86 GCC/Clang, so the whole CrispASR binary does not acquire an AVX2/AVX-512 baseline requirement. Runtime CPU detection selects the best supported path. Other targets fall back to the original scalar algorithm.

Threading uses the existing `core_parallel::for_each_chunk()` helper and `c->n_threads`; it does not introduce an F0-specific thread setting. This keeps `CRISPASR_CHATTERBOX_THREADS` and the existing Chatterbox host policy authoritative.
