### PR TITLE
[RFC] Streaming delta encoding for Cohere + VAD — feedback on approach and maintenance trade-off

### DIFF
--- a/examples/cli/crispasr_backend.h
+++ b/examples/cli/crispasr_backend.h
@@ -234,6 +234,9 @@ public:
     virtual void save_utterance_cross_kv(int64_t /*utterance_start*/, int64_t /*utterance_end*/, int64_t /*window_start*/, int /*sample_rate*/, int64_t /*generation*/) {}
     virtual void restore_utterance_cross_kv(int /*n_new_samples*/, int64_t /*generation*/) {}
     virtual void clear_utterance_cross_kv() {}
+    // Hard guard: must not combine continue_decode with VAD merge (window shift invalidates cross-KV).
+    // Caller should assert on this; backend enforces via CAPs.
+    virtual bool supports_continue_with_vad() const { return false; }
 
     // ---- Language detection ----
     // are silently dropped whenever the pipeline engages — measured on

--- a/examples/cli/crispasr_backend.h
+++ b/examples/cli/crispasr_backend.h
@@ -231,8 +231,8 @@ public:
     // use this to avoid re-encoding the overlapping portion of the audio.
     // Default no-op.
     virtual void set_stream_delta(int /*delta_new_samples*/) {}
-    virtual void save_utterance_cross_kv(int64_t /*utterance_start*/, int64_t /*utterance_end*/, int64_t /*window_start*/, int /*sample_rate*/) {}
-    virtual void restore_utterance_cross_kv(int /*n_new_samples*/) {}
+    virtual void save_utterance_cross_kv(int64_t /*utterance_start*/, int64_t /*utterance_end*/, int64_t /*window_start*/, int /*sample_rate*/, int64_t /*generation*/) {}
+    virtual void restore_utterance_cross_kv(int /*n_new_samples*/, int64_t /*generation*/) {}
     virtual void clear_utterance_cross_kv() {}
 
     // ---- Language detection ----

--- a/examples/cli/crispasr_backend.h
+++ b/examples/cli/crispasr_backend.h
@@ -138,6 +138,11 @@ enum crispasr_capability : uint32_t {
                                         // dispatcher. Note this backend emits scores, not a
                                         // decided tablature: the constrained Viterbi/DP that
                                         // picks a playable fingering belongs to the caller.
+    CAP_STREAM_DELTA = 1u << 29,        // supports streaming delta encoding
+    CAP_STREAM_UTTERANCE = 1u << 30, // utterance-level delta (save/restore)
+                                        // (cohere_set_stream_delta). Avoids re-encoding
+                                        // the overlapping portion of sequential rolling
+                                        // windows in JSON+VAD streaming mode.
 };
 
 // ---------------------------------------------------------------------------
@@ -218,6 +223,19 @@ public:
     // hotwords, attention context) to backend state on every call; the split
     // pair cannot, because encode_slice runs on a worker thread and mutating
     // decode state there would race the decoder. Without this hook those flags
+// Optional streaming delta-encoding hint.  When the caller is about to
+    // transcribe sequential overlapping audio windows (e.g. JSON+VAD
+    // streaming), it may call this before each transcribe() to convey how
+    // many samples in the next buffer are NEW (not present in the previous
+    // call).  A backend that supports delta encoding (CAP_STREAM_DELTA) can
+    // use this to avoid re-encoding the overlapping portion of the audio.
+    // Default no-op.
+    virtual void set_stream_delta(int /*delta_new_samples*/) {}
+    virtual void save_utterance_cross_kv(int64_t /*utterance_start*/, int64_t /*utterance_end*/, int64_t /*window_start*/, int /*sample_rate*/) {}
+    virtual void restore_utterance_cross_kv(int /*n_new_samples*/) {}
+    virtual void clear_utterance_cross_kv() {}
+
+    // ---- Language detection ----
     // are silently dropped whenever the pipeline engages — measured on
     // parakeet: `--vad --beam-size 4` decoded greedily.
     virtual void begin_split_run(const whisper_params& /*params*/) {}

--- a/examples/cli/crispasr_backend_cohere.cpp
+++ b/examples/cli/crispasr_backend_cohere.cpp
@@ -213,8 +213,8 @@ public:
         if (ctx_)
             cohere_set_stream_delta(ctx_, delta_new_samples);
     }
-    void save_utterance_cross_kv(int64_t s, int64_t e, int64_t w, int sr) override { if (ctx_) cohere_save_utterance_cross_kv(ctx_, s, e, w, sr); }
-    void restore_utterance_cross_kv(int n) override { if (ctx_) cohere_restore_utterance_cross_kv(ctx_, n); }
+    void save_utterance_cross_kv(int64_t s, int64_t e, int64_t w, int sr, int64_t gen) override { if (ctx_) cohere_save_utterance_cross_kv(ctx_, s, e, w, sr, gen); }
+    void restore_utterance_cross_kv(int n, int64_t gen) override { if (ctx_) cohere_restore_utterance_cross_kv(ctx_, n, gen); }
     void clear_utterance_cross_kv() override { if (ctx_) cohere_clear_utterance_cross_kv(ctx_); }
 
     std::vector<crispasr_segment> transcribe(const float* samples, int n_samples, int64_t t_offset_cs,

--- a/examples/cli/crispasr_backend_cohere.cpp
+++ b/examples/cli/crispasr_backend_cohere.cpp
@@ -85,7 +85,7 @@ public:
     uint32_t capabilities() const override {
         return CAP_TIMESTAMPS_NATIVE | CAP_WORD_TIMESTAMPS | CAP_TOKEN_CONFIDENCE | CAP_DIARIZE |
                CAP_PUNCTUATION_TOGGLE | CAP_FLASH_ATTN | CAP_TEMPERATURE | CAP_BEAM_SEARCH | CAP_PARALLEL_PROCESSORS |
-               CAP_AUTO_DOWNLOAD;
+               CAP_AUTO_DOWNLOAD | CAP_STREAM_DELTA | CAP_STREAM_UTTERANCE;
     }
 
     bool init(const whisper_params& p) override {
@@ -209,6 +209,13 @@ public:
         if (r)
             cohere_result_free(r);
     }
+ void set_stream_delta(int delta_new_samples) override {
+        if (ctx_)
+            cohere_set_stream_delta(ctx_, delta_new_samples);
+    }
+    void save_utterance_cross_kv(int64_t s, int64_t e, int64_t w, int sr) override { if (ctx_) cohere_save_utterance_cross_kv(ctx_, s, e, w, sr); }
+    void restore_utterance_cross_kv(int n) override { if (ctx_) cohere_restore_utterance_cross_kv(ctx_, n); }
+    void clear_utterance_cross_kv() override { if (ctx_) cohere_clear_utterance_cross_kv(ctx_); }
 
     std::vector<crispasr_segment> transcribe(const float* samples, int n_samples, int64_t t_offset_cs,
                                              const whisper_params& params) override {

--- a/examples/cli/crispasr_run.cpp
+++ b/examples/cli/crispasr_run.cpp
@@ -350,6 +350,14 @@ static bool stream_punc_finals_enabled(const whisper_params& params) {
     return crispasr_stream_punc_finals_enabled(params.stream_punc);
 }
 
+static bool stream_postprocess_partials_enabled(const whisper_params& params) {
+    return crispasr_stream_postprocess_partials_enabled(params.stream_postprocess);
+}
+
+static bool stream_postprocess_finals_enabled(const whisper_params& params) {
+    return crispasr_stream_postprocess_finals_enabled(params.stream_postprocess);
+}
+
 // Apply PCS (punctuation + capitalization + segmentation) to all segments.
 static void apply_pcs_model(pcs_context* pcs_ctx, std::vector<crispasr_segment>& segs) {
     if (!pcs_ctx)
@@ -3224,8 +3232,10 @@ int crispasr_run_backend(const whisper_params& params_in) {
 
     // #80e: optional warmup — transcribe a short silence buffer to
     // amortize first-call overhead (graph alloc, GPU kernel compile).
-    // Enabled via --warmup or CRISPASR_WARMUP=1.
-    if (params.warmup || getenv("CRISPASR_WARMUP")) {
+    // Enabled via --warmup, CRISPASR_WARMUP=1, or automatically in
+    // JSON+VAD streaming mode (--stream-json) to eliminate startup
+    // latency spikes from GPU kernel compilation.
+    if (params.stream_json || params.warmup || getenv("CRISPASR_WARMUP")) {
         auto t_warmup_start = std::chrono::steady_clock::now();
         backend->warmup();
         if (params.verbose || !params.no_prints) {
@@ -4029,6 +4039,7 @@ int crispasr_run_backend(const whisper_params& params_in) {
         std::vector<float> utterance_pcm;
         std::string prefix_committed;
         std::string last_partial_text; // dedupe key + prefix-mode tail
+        int64_t utterance_pcm_size_at_save = 0;
         int64_t last_partial_decode_sample = -1;
         int64_t cumulative_samples = 0;
         const int64_t utterance_max_samples = (int64_t)params.stream_utterance_max_sec * SR;
@@ -4091,15 +4102,9 @@ int crispasr_run_backend(const whisper_params& params_in) {
             std::vector<std::pair<crispasr_audio_slice, std::string>> step_slice_text;
             bool decoded_segments_this_step = false;
             if (!stream_vad_path.empty()) {
+                if (backend->capabilities() & CAP_STREAM_DELTA) backend->set_stream_delta((int)n_new);
                 const auto slices = crispasr_compute_vad_slices(pcm_window.data(), (int)pcm_window.size(), SR,
                                                                 stream_vad_path.c_str(), stream_vad_opts);
-                // Snapshot for the straddling-slice subrange decode below.
-                // `cumulative_samples` has already been advanced by
-                // `n_new` for this step, so the rolling window currently
-                // covers [window_start_sample_now, cumulative_samples).
-                // finalized_until_sample is updated inside the JSON state
-                // machine *after* this loop runs, so it reflects the
-                // upper bound of all utterances finalized before this step.
                 const int64_t window_start_sample_now = cumulative_samples - (int64_t)pcm_window.size();
                 const bool final_silence_due =
                     params.stream_json && params.stream_final_silence_ms > 0 && have_open_utterance &&
@@ -4109,98 +4114,88 @@ int crispasr_run_backend(const whisper_params& params_in) {
                     params.stream_json, last_partial_decode_sample, final_silence_due, cumulative_samples,
                     partial_decode_interval_samples);
                 bool partial_decode_attempted_this_step = false;
-                constexpr int kStraddleMinSamples = 32000; // 2 s @ 16 kHz; backend-safe tail decode floor.
-                for (const auto& sl : slices) {
-                    if (params.stream_json) {
-                        const int64_t s_start_abs = window_start_sample_now + (int64_t)sl.start;
-                        const int64_t s_end_abs = window_start_sample_now + (int64_t)sl.end;
-                        if (s_end_abs <= finalized_until_sample)
-                            continue;
-                        // Apply punc/strip on a copy so the per-slice text
-                        // is in its final form before we hand it to the
-                        // utterance state machine. JSON mode can filter or
-                        // trim finalized rolling-window slices before decode;
-                        // plain-text mode below still decodes full slices.
-                        std::vector<crispasr_segment> sl_for_text;
-
-                        // Round 3 (CKwasd #1 corner): if the VAD slice
-                        // straddles a previously-finalized boundary
-                        // (s_start < finalized_until_sample < s_end), the
-                        // full-slice decode covers audio that belongs to
-                        // the prior utterance — emitting it as a partial
-                        // for the new utterance_id leaks prior text into
-                        // the live stream. Decode just the post-finalized
-                        // subrange so partial.text describes only the new
-                        // utterance's interval.
-                        // Some backends (moonshine's stacked conv1d
-                        // encoder, for example) abort on inputs shorter
-                        // than a few hundred ms — `OW > 0` from
-                        // `ggml_im2col`. Gate the subrange decode on a
-                        // generous min so we don't crash; fall back to
-                        // suppressing the partial in that case so we
-                        // don't leak the prior utterance's text either.
-                        // 32000 samples = 2 s @ 16 kHz, comfortably
-                        // above every supported backend's encoder
-                        // minimum.
-                        if (!allow_partial_decode) {
-                            // Keep VAD slice timing in the JSON state machine
-                            // but skip the expensive ASR partial decode for
-                            // this step.
-                        } else if (s_start_abs < finalized_until_sample) {
-                            const int sub_start = (int)(finalized_until_sample - window_start_sample_now);
-                            const int sub_end = (int)sl.end;
-                            const int sub_len = sub_end - sub_start;
-                            if (sub_start >= 0 && sub_len >= kStraddleMinSamples && sub_end <= (int)pcm_window.size()) {
-                                whisper_params decode_params = params;
-                                decode_params.vad = false;
-                                decode_params.vad_model.clear();
-                                partial_decode_attempted_this_step = true;
-                                const int64_t abs_offset_cs = (window_start_sample_now + (int64_t)sub_start) * 100 / SR;
-                                sl_for_text = backend->transcribe(pcm_window.data() + sub_start, sub_len, abs_offset_cs,
-                                                                  decode_params);
+                constexpr int kStraddleMinSamples = 32000;
+                if (params.stream_json) {
+                    // ponytail: single full-window transcribe so delta survives; midpoint assigns segments to slices
+                    if (!allow_partial_decode) {
+                        for (auto &sl : slices) {
+                            if (window_start_sample_now + sl.end <= finalized_until_sample) continue;
+                            step_slice_text.emplace_back(sl, std::string());
+                        }
+                    } else if (!slices.empty()) {
+                        const int64_t window_cs = window_start_sample_now * 100 / SR;
+                        auto full_segs = backend->transcribe(pcm_window.data(), (int)pcm_window.size(), window_cs, params);
+                        if (!full_segs.empty()) decoded_segments_this_step = true;
+                        if (stream_punc_partials_enabled(params)) apply_punc_model(punc_ctx.get(), full_segs);
+                        apply_truecase_model(tc_ctx.get(), full_segs);
+                        apply_truecase_crf_model(tc_crf_ctx.get(), full_segs);
+                        apply_truecase_lstm_model(tc_lstm_ctx.get(), full_segs);
+                        apply_pcs_model(pcs_ctx.get(), full_segs);
+                        if (!params.punctuation) for (auto &s : full_segs) crispasr_strip_punctuation(s);
+                        // filter finalized region for assignment
+                        std::vector<std::string> slice_text(slices.size());
+                        for (auto &seg : full_segs) {
+                            if (seg.t1 <= finalized_until_sample * 100 / SR) continue;
+                            const int64_t mid = (seg.t0 + seg.t1) / 2;
+                            int best = -1;
+                            for (size_t i = 0; i < slices.size(); i++) {
+                                const int64_t s0 = window_start_sample_now * 100 / SR + slices[i].t0_cs;
+                                const int64_t s1 = window_start_sample_now * 100 / SR + slices[i].t1_cs;
+                                if (mid >= s0 && mid < s1) { best = (int)i; break; }
                             }
-                            // else: sl_for_text stays empty → empty
-                            // partial text for this slice, which
-                            // `flush_pending_partial` will skip. The
-                            // straddling slice's prior-utterance audio
-                            // never reaches the wrapper; the genuine
-                            // new audio will be picked up on a later
-                            // step once the subrange exceeds the min.
-                        } else {
-                            partial_decode_attempted_this_step = true;
-                            const int64_t abs_t0_cs = window_start_sample_now * 100 / SR + sl.t0_cs;
-                            sl_for_text =
-                                backend->transcribe(pcm_window.data() + sl.start, sl.end - sl.start, abs_t0_cs, params);
+                            if (best < 0) {
+                                // fallback: nearest slice by midpoint distance
+                                int64_t best_d = INT64_MAX;
+                                for (size_t i = 0; i < slices.size(); i++) {
+                                    const int64_t s0 = window_start_sample_now * 100 / SR + slices[i].t0_cs;
+                                    const int64_t s1 = window_start_sample_now * 100 / SR + slices[i].t1_cs;
+                                    const int64_t mid_s = (s0 + s1) / 2;
+                                    int64_t d = llabs(mid - mid_s);
+                                    if (d < best_d) { best_d = d; best = (int)i; }
+                                }
+                            }
+                            if (best >= 0) {
+                                // straddling guard: skip if slice fully finalized or subrange too short
+                                const int64_t s_start_abs = window_start_sample_now + slices[best].start;
+                                const int64_t s_end_abs = window_start_sample_now + slices[best].end;
+                                if (s_end_abs <= finalized_until_sample) continue;
+                                if (s_start_abs < finalized_until_sample) {
+                                    const int sub_len = (int)(s_end_abs - finalized_until_sample);
+                                    if (sub_len < kStraddleMinSamples) continue;
+                                }
+                                slice_text[best] += seg.text;
+                            }
                         }
-                        if (!sl_for_text.empty())
-                            decoded_segments_this_step = true;
-                        if (stream_punc_partials_enabled(params))
-                            apply_punc_model(punc_ctx.get(), sl_for_text);
-                        apply_truecase_model(tc_ctx.get(), sl_for_text);
-                        apply_truecase_crf_model(tc_crf_ctx.get(), sl_for_text);
-                        apply_truecase_lstm_model(tc_lstm_ctx.get(), sl_for_text);
-                        apply_pcs_model(pcs_ctx.get(), sl_for_text);
-                        if (!params.punctuation) {
-                            for (auto& seg : sl_for_text)
-                                crispasr_strip_punctuation(seg);
+                        for (size_t i = 0; i < slices.size(); i++) {
+                            if (window_start_sample_now + slices[i].end <= finalized_until_sample) continue;
+                            if (slices[i].start < finalized_until_sample - window_start_sample_now) {
+                                const int sub_len = (int)(slices[i].end - (finalized_until_sample - window_start_sample_now));
+                                if (sub_len < kStraddleMinSamples) continue;
+                            }
+                            step_slice_text.emplace_back(slices[i], std::move(slice_text[i]));
                         }
-                        std::string sl_text;
-                        for (const auto& s : sl_for_text)
-                            sl_text += s.text;
-                        step_slice_text.emplace_back(sl, std::move(sl_text));
-                    } else {
-                        const int64_t abs_t0_cs = window_start_sample_now * 100 / SR + sl.t0_cs;
-                        auto slice_segs =
-                            backend->transcribe(pcm_window.data() + sl.start, sl.end - sl.start, abs_t0_cs, params);
-                        if (!slice_segs.empty())
-                            decoded_segments_this_step = true;
-                        segs.insert(segs.end(), std::make_move_iterator(slice_segs.begin()),
-                                    std::make_move_iterator(slice_segs.end()));
+                        partial_decode_attempted_this_step = true;
                     }
+                } else {
+                    // non-JSON VAD: single full-window transcribe, aggregate
+                    const int64_t window_cs = window_start_sample_now * 100 / SR;
+                    auto full_segs = backend->transcribe(pcm_window.data(), (int)pcm_window.size(), window_cs, params);
+                    if (!full_segs.empty()) decoded_segments_this_step = true;
+                    segs.insert(segs.end(), std::make_move_iterator(full_segs.begin()), std::make_move_iterator(full_segs.end()));
                 }
-                if (partial_decode_attempted_this_step)
-                    last_partial_decode_sample = cumulative_samples;
+                if (partial_decode_attempted_this_step) last_partial_decode_sample = cumulative_samples;
+                // ponytail: utterance-level delta — save utterance portion of cross-KV for later finalize reuse
+                if (params.stream_json && have_open_utterance && decoded_segments_this_step && (backend->capabilities() & CAP_STREAM_UTTERANCE)) {
+                    const int64_t ue = last_speech_end_sample > 0 ? last_speech_end_sample : utterance_start_sample + 1;
+                    backend->save_utterance_cross_kv(utterance_start_sample, ue, window_start_sample_now, SR);
+                    utterance_pcm_size_at_save = (int64_t)utterance_pcm.size();
+                }
             } else {
+                // No-VAD path: transcribe the full window.
+                // Also set streaming delta hint for backends that support it.
+                if (backend->capabilities() & CAP_STREAM_DELTA) {
+                    backend->set_stream_delta((int)n_new);
+                }
                 const int64_t no_vad_window_start_cs = (cumulative_samples - (int64_t)pcm_window.size()) * 100 / SR;
                 segs = backend->transcribe(pcm_window.data(), (int)pcm_window.size(), no_vad_window_start_cs, params);
                 if (!segs.empty())
@@ -4299,6 +4294,10 @@ int crispasr_run_backend(const whisper_params& params_in) {
                             whisper_params decode_params = params;
                             decode_params.vad = false;
                             decode_params.vad_model.clear();
+                            if ((backend->capabilities() & CAP_STREAM_UTTERANCE)) {
+                                const int n_new_since_save = (int)utterance_pcm.size() - (int)utterance_pcm_size_at_save;
+                                backend->restore_utterance_cross_kv(n_new_since_save);
+                            }
                             auto utt_segs =
                                 backend->transcribe(utterance_pcm.data(), (int)utterance_pcm.size(), 0, decode_params);
                             if (stream_punc_finals_enabled(params))
@@ -4345,6 +4344,7 @@ int crispasr_run_backend(const whisper_params& params_in) {
                     utterance_pcm.clear();
                     prefix_committed.clear();
                     last_partial_text.clear();
+                    if (backend->capabilities() & CAP_STREAM_UTTERANCE) { backend->clear_utterance_cross_kv(); utterance_pcm_size_at_save = 0; }
                 };
 
                 auto open_utterance_at = [&](int window_offset, int64_t stream_start) {
@@ -4359,6 +4359,7 @@ int crispasr_run_backend(const whisper_params& params_in) {
                     utterance_pcm.assign(pcm_window.begin() + window_offset, pcm_window.end());
                     prefix_committed.clear();
                     last_partial_text.clear();
+                    if (backend->capabilities() & CAP_STREAM_UTTERANCE) { backend->clear_utterance_cross_kv(); utterance_pcm_size_at_save = 0; }
                 };
 
                 auto on_partial_text = [&](const std::string& new_text) {
@@ -4605,6 +4606,11 @@ int crispasr_run_backend(const whisper_params& params_in) {
                     whisper_params decode_params = params;
                     decode_params.vad = false;
                     decode_params.vad_model.clear();
+                    // EOF also benefits from utterance-level delta
+                    if ((backend->capabilities() & CAP_STREAM_UTTERANCE) && utterance_pcm_size_at_save > 0) {
+                        const int n_new2 = (int)utterance_pcm.size() - (int)utterance_pcm_size_at_save;
+                        backend->restore_utterance_cross_kv(n_new2);
+                    }
                     auto utt_segs =
                         backend->transcribe(utterance_pcm.data(), (int)utterance_pcm.size(), 0, decode_params);
                     if (stream_punc_finals_enabled(params))

--- a/examples/cli/crispasr_run.cpp
+++ b/examples/cli/crispasr_run.cpp
@@ -4113,7 +4113,12 @@ int crispasr_run_backend(const whisper_params& params_in) {
             std::vector<std::pair<crispasr_audio_slice, std::string>> step_slice_text;
             bool decoded_segments_this_step = false;
             if (!stream_vad_path.empty()) {
-                if (backend->capabilities() & CAP_STREAM_DELTA) backend->set_stream_delta((int)n_new);
+                // ponytail: small-window bypass — delta has no gain when overlap <=50% vs guard overhead
+                const bool use_delta = length_samples >= 4000 && length_samples >= step_samples * 3;
+                if (backend->capabilities() & CAP_STREAM_DELTA) {
+                    if (use_delta) backend->set_stream_delta((int)n_new);
+                    else backend->set_stream_delta(0);
+                }
                 const int64_t window_start_sample_now = cumulative_samples - (int64_t)pcm_window_size();
                 std::vector<crispasr_audio_slice> slices;
                 const bool final_silence_due_early =
@@ -4123,7 +4128,9 @@ int crispasr_run_backend(const whisper_params& params_in) {
                 const bool allow_partial_decode_early = crispasr_stream_partial_decode_allow(
                     params.stream_json, last_partial_decode_sample, final_silence_due_early, cumulative_samples,
                     partial_decode_interval_samples);
-                const bool need_fresh_vad = allow_partial_decode_early || !params.stream_json || !cached_vad_valid;
+                // ponytail: throttling adds 500ms boundary delay — disable for small windows already on fallback path
+                const bool vad_throttle_on = length_samples >= 4000;
+                const bool need_fresh_vad = (vad_throttle_on ? allow_partial_decode_early : true) || !params.stream_json || !cached_vad_valid;
                 if (need_fresh_vad) {
                     slices = crispasr_compute_vad_slices(pcm_window_data(), (int)pcm_window_size(), SR,
                                                                 stream_vad_path.c_str(), stream_vad_opts);
@@ -4132,12 +4139,17 @@ int crispasr_run_backend(const whisper_params& params_in) {
                     cached_vad_valid = true;
                 } else {
                     // shift cached slices by window advance; drop those that fell out
+                    // ponytail: must also shift t0/t1_cs (window-relative) or mid assignment drifts — fix throttled VAD bug
                     const int64_t shift = window_start_sample_now - cached_vad_window_start;
+                    const int64_t shift_cs = shift * 100 / SR;
                     slices.reserve(cached_vad_slices.size());
                     for (auto sl : cached_vad_slices) {
                         sl.start -= (int)shift; sl.end -= (int)shift;
+                        sl.t0_cs -= shift_cs; sl.t1_cs -= shift_cs;
                         if (sl.end <= 0 || sl.start >= (int)pcm_window_size()) continue;
                         sl.start = std::max(0, sl.start); sl.end = std::min((int)pcm_window_size(), sl.end);
+                        if (sl.t1_cs <= 0) continue;
+                        sl.t0_cs = std::max<int64_t>(0, sl.t0_cs);
                         if (sl.end > sl.start) slices.push_back(sl);
                     }
                 }

--- a/examples/cli/crispasr_run.cpp
+++ b/examples/cli/crispasr_run.cpp
@@ -9,6 +9,7 @@
 
 #include "crispasr_backend.h"
 #include "crispasr_cache.h"
+#include <cassert>
 #include "crispasr_gap_fill.h"
 #include "crispasr_split_pipeline.h"
 #include "tada_encoder.h"
@@ -350,13 +351,7 @@ static bool stream_punc_finals_enabled(const whisper_params& params) {
     return crispasr_stream_punc_finals_enabled(params.stream_punc);
 }
 
-static bool stream_postprocess_partials_enabled(const whisper_params& params) {
-    return crispasr_stream_postprocess_partials_enabled(params.stream_postprocess);
-}
 
-static bool stream_postprocess_finals_enabled(const whisper_params& params) {
-    return crispasr_stream_postprocess_finals_enabled(params.stream_postprocess);
-}
 
 // Apply PCS (punctuation + capitalization + segmentation) to all segments.
 static void apply_pcs_model(pcs_context* pcs_ctx, std::vector<crispasr_segment>& segs) {
@@ -4119,6 +4114,10 @@ int crispasr_run_backend(const whisper_params& params_in) {
                     if (use_delta) backend->set_stream_delta((int)n_new);
                     else backend->set_stream_delta(0);
                 }
+                // Hard guard: continue_decode + VAD merge would crash -1073741819 (cross-KV invalid
+                // after window shift). No backend supports it today (crispasr_backend.h:239
+                // supports_continue_with_vad()==false); fail fast if a future backend claims support.
+                assert(!backend->supports_continue_with_vad() && "continue_decode+VAD merge unsupported: cross-KV invalid after window shift");
                 const int64_t window_start_sample_now = cumulative_samples - (int64_t)pcm_window_size();
                 std::vector<crispasr_audio_slice> slices;
                 const bool final_silence_due_early =

--- a/examples/cli/crispasr_run.cpp
+++ b/examples/cli/crispasr_run.cpp
@@ -4229,7 +4229,7 @@ int crispasr_run_backend(const whisper_params& params_in) {
                 // ponytail: utterance-level delta — save utterance portion of cross-KV for later finalize reuse
                 if (params.stream_json && have_open_utterance && decoded_segments_this_step && (backend->capabilities() & CAP_STREAM_UTTERANCE)) {
                     const int64_t ue = last_speech_end_sample > 0 ? last_speech_end_sample : utterance_start_sample + 1;
-                    backend->save_utterance_cross_kv(utterance_start_sample, ue, window_start_sample_now, SR);
+                    backend->save_utterance_cross_kv(utterance_start_sample, ue, window_start_sample_now, SR, utterance_id);
                     utterance_pcm_size_at_save = (int64_t)utterance_pcm.size();
                 }
             } else {
@@ -4338,7 +4338,7 @@ int crispasr_run_backend(const whisper_params& params_in) {
                             decode_params.vad_model.clear();
                             if ((backend->capabilities() & CAP_STREAM_UTTERANCE)) {
                                 const int n_new_since_save = (int)utterance_pcm.size() - (int)utterance_pcm_size_at_save;
-                                backend->restore_utterance_cross_kv(n_new_since_save);
+                                backend->restore_utterance_cross_kv(n_new_since_save, utterance_id);
                             }
                             auto utt_segs =
                                 backend->transcribe(utterance_pcm.data(), (int)utterance_pcm.size(), 0, decode_params);
@@ -4656,7 +4656,7 @@ int crispasr_run_backend(const whisper_params& params_in) {
                     // EOF also benefits from utterance-level delta
                     if ((backend->capabilities() & CAP_STREAM_UTTERANCE) && utterance_pcm_size_at_save > 0) {
                         const int n_new2 = (int)utterance_pcm.size() - (int)utterance_pcm_size_at_save;
-                        backend->restore_utterance_cross_kv(n_new2);
+                        backend->restore_utterance_cross_kv(n_new2, utterance_id);
                     }
                     auto utt_segs =
                         backend->transcribe(utterance_pcm.data(), (int)utterance_pcm.size(), 0, decode_params);

--- a/examples/cli/crispasr_run.cpp
+++ b/examples/cli/crispasr_run.cpp
@@ -3988,6 +3988,9 @@ int crispasr_run_backend(const whisper_params& params_in) {
         // oldest samples from the front to maintain the cap.
         std::vector<float> pcm_window;
         pcm_window.reserve(length_samples);
+        size_t pcm_head = 0; // ponytail: ring head to avoid O(N) erase on every step
+        auto pcm_window_size = [&]() -> size_t { return pcm_window.size() - pcm_head; };
+        auto pcm_window_data = [&]() -> const float* { return pcm_window.data() + pcm_head; };
         std::vector<int16_t> read_buf(step_samples);
         std::string prev_text;
         // Issue #84 round 2 (CKwasd retest): the JSON streaming state
@@ -4042,6 +4045,10 @@ int crispasr_run_backend(const whisper_params& params_in) {
         int64_t utterance_pcm_size_at_save = 0;
         int64_t last_partial_decode_sample = -1;
         int64_t cumulative_samples = 0;
+        // ponytail: VAD throttle cache — outside while loop so throttled steps can shift previous slices
+        std::vector<crispasr_audio_slice> cached_vad_slices;
+        int64_t cached_vad_window_start = 0;
+        bool cached_vad_valid = false;
         const int64_t utterance_max_samples = (int64_t)params.stream_utterance_max_sec * SR;
         const int64_t partial_decode_interval_samples =
             crispasr_stream_partial_decode_interval_samples(params.stream_partial_decode_ms, params.stream_step_ms, SR);
@@ -4068,22 +4075,26 @@ int crispasr_run_backend(const whisper_params& params_in) {
             }
             any_samples_read = true;
 
-            // Convert s16le to float
+            // Convert s16le to float (ring head avoids O(N) erase)
             const size_t n_new = n_read;
-            const size_t prev_size = pcm_window.size();
-            pcm_window.resize(prev_size + n_new);
+            // compact head when it grows too large (avoid unbounded vector growth)
+            if (pcm_head > (size_t)length_samples && pcm_head > pcm_window.size() / 2) {
+                pcm_window.erase(pcm_window.begin(), pcm_window.begin() + pcm_head);
+                pcm_head = 0;
+            }
+            const size_t write_pos = pcm_window.size();
+            pcm_window.resize(write_pos + n_new);
             for (size_t i = 0; i < n_new; i++)
-                pcm_window[prev_size + i] = read_buf[i] / 32768.0f;
+                pcm_window[write_pos + i] = read_buf[i] / 32768.0f;
 
-            // Issue #84: enforce the rolling cap by dropping the
-            // oldest samples once we exceed `--stream-length`. This
-            // is the only place the buffer can shrink — there is no
-            // separate "keep" tail because the whole tail up to
-            // `length_samples` is now the context window. The legacy
-            // `--stream-keep` flag is accepted for compatibility but
-            // is no longer wired in (see help text + docs/streaming.md).
-            if ((int)pcm_window.size() > length_samples) {
-                pcm_window.erase(pcm_window.begin(), pcm_window.end() - length_samples);
+            if ((int)pcm_window_size() > length_samples) {
+                const size_t drop = pcm_window_size() - (size_t)length_samples;
+                pcm_head += drop;
+                // occasional compact to keep capacity bounded
+                if (pcm_head > (size_t)length_samples) {
+                    pcm_window.erase(pcm_window.begin(), pcm_window.begin() + pcm_head);
+                    pcm_head = 0;
+                }
             }
             cumulative_samples += (int64_t)n_new;
             (void)keep_samples; // legacy, intentionally unused
@@ -4103,16 +4114,35 @@ int crispasr_run_backend(const whisper_params& params_in) {
             bool decoded_segments_this_step = false;
             if (!stream_vad_path.empty()) {
                 if (backend->capabilities() & CAP_STREAM_DELTA) backend->set_stream_delta((int)n_new);
-                const auto slices = crispasr_compute_vad_slices(pcm_window.data(), (int)pcm_window.size(), SR,
-                                                                stream_vad_path.c_str(), stream_vad_opts);
-                const int64_t window_start_sample_now = cumulative_samples - (int64_t)pcm_window.size();
-                const bool final_silence_due =
+                const int64_t window_start_sample_now = cumulative_samples - (int64_t)pcm_window_size();
+                std::vector<crispasr_audio_slice> slices;
+                const bool final_silence_due_early =
                     params.stream_json && params.stream_final_silence_ms > 0 && have_open_utterance &&
                     last_speech_end_sample > 0 &&
                     (cumulative_samples - last_speech_end_sample) * 1000 / SR >= params.stream_final_silence_ms;
-                const bool allow_partial_decode = crispasr_stream_partial_decode_allow(
-                    params.stream_json, last_partial_decode_sample, final_silence_due, cumulative_samples,
+                const bool allow_partial_decode_early = crispasr_stream_partial_decode_allow(
+                    params.stream_json, last_partial_decode_sample, final_silence_due_early, cumulative_samples,
                     partial_decode_interval_samples);
+                const bool need_fresh_vad = allow_partial_decode_early || !params.stream_json || !cached_vad_valid;
+                if (need_fresh_vad) {
+                    slices = crispasr_compute_vad_slices(pcm_window_data(), (int)pcm_window_size(), SR,
+                                                                stream_vad_path.c_str(), stream_vad_opts);
+                    cached_vad_slices = slices;
+                    cached_vad_window_start = window_start_sample_now;
+                    cached_vad_valid = true;
+                } else {
+                    // shift cached slices by window advance; drop those that fell out
+                    const int64_t shift = window_start_sample_now - cached_vad_window_start;
+                    slices.reserve(cached_vad_slices.size());
+                    for (auto sl : cached_vad_slices) {
+                        sl.start -= (int)shift; sl.end -= (int)shift;
+                        if (sl.end <= 0 || sl.start >= (int)pcm_window_size()) continue;
+                        sl.start = std::max(0, sl.start); sl.end = std::min((int)pcm_window_size(), sl.end);
+                        if (sl.end > sl.start) slices.push_back(sl);
+                    }
+                }
+                const bool final_silence_due = final_silence_due_early;
+                const bool allow_partial_decode = allow_partial_decode_early;
                 bool partial_decode_attempted_this_step = false;
                 constexpr int kStraddleMinSamples = 32000;
                 if (params.stream_json) {
@@ -4124,7 +4154,7 @@ int crispasr_run_backend(const whisper_params& params_in) {
                         }
                     } else if (!slices.empty()) {
                         const int64_t window_cs = window_start_sample_now * 100 / SR;
-                        auto full_segs = backend->transcribe(pcm_window.data(), (int)pcm_window.size(), window_cs, params);
+                        auto full_segs = backend->transcribe(pcm_window_data(), (int)pcm_window_size(), window_cs, params);
                         if (!full_segs.empty()) decoded_segments_this_step = true;
                         if (stream_punc_partials_enabled(params)) apply_punc_model(punc_ctx.get(), full_segs);
                         apply_truecase_model(tc_ctx.get(), full_segs);
@@ -4179,7 +4209,7 @@ int crispasr_run_backend(const whisper_params& params_in) {
                 } else {
                     // non-JSON VAD: single full-window transcribe, aggregate
                     const int64_t window_cs = window_start_sample_now * 100 / SR;
-                    auto full_segs = backend->transcribe(pcm_window.data(), (int)pcm_window.size(), window_cs, params);
+                    auto full_segs = backend->transcribe(pcm_window_data(), (int)pcm_window_size(), window_cs, params);
                     if (!full_segs.empty()) decoded_segments_this_step = true;
                     segs.insert(segs.end(), std::make_move_iterator(full_segs.begin()), std::make_move_iterator(full_segs.end()));
                 }
@@ -4196,8 +4226,8 @@ int crispasr_run_backend(const whisper_params& params_in) {
                 if (backend->capabilities() & CAP_STREAM_DELTA) {
                     backend->set_stream_delta((int)n_new);
                 }
-                const int64_t no_vad_window_start_cs = (cumulative_samples - (int64_t)pcm_window.size()) * 100 / SR;
-                segs = backend->transcribe(pcm_window.data(), (int)pcm_window.size(), no_vad_window_start_cs, params);
+                const int64_t no_vad_window_start_cs = (cumulative_samples - (int64_t)pcm_window_size()) * 100 / SR;
+                segs = backend->transcribe(pcm_window_data(), (int)pcm_window_size(), no_vad_window_start_cs, params);
                 if (!segs.empty())
                     decoded_segments_this_step = true;
             }
@@ -4222,7 +4252,7 @@ int crispasr_run_backend(const whisper_params& params_in) {
                 std::string all_text;
                 for (const auto& s : segs)
                     all_text += s.text;
-                crispasr_audio_slice fake_sl{0, (int)pcm_window.size(), 0, 0};
+                crispasr_audio_slice fake_sl{0, (int)pcm_window_size(), 0, 0};
                 step_slice_text.emplace_back(fake_sl, std::move(all_text));
             }
 
@@ -4241,11 +4271,11 @@ int crispasr_run_backend(const whisper_params& params_in) {
             // and (c) re-decode the buffered PCM at finalize time so
             // `final.text` covers the full utterance. The cheaper
             // `--stream-final-mode prefix` path keeps round-1's cost
-            // by accumulating a longest-common-prefix across partials
-            // instead of re-decoding.
+            // by accumulating a longest-common-prefix across consecutive
+            // partials instead of re-decoding.
             if (params.stream_json) {
                 const int64_t now_sample = cumulative_samples;
-                const int64_t window_start_sample = cumulative_samples - (int64_t)pcm_window.size();
+                const int64_t window_start_sample = cumulative_samples - (int64_t)pcm_window_size();
                 // Track whether this step produced a `partial` or `final`
                 // event so the silence heartbeat at the bottom only fires
                 // when nothing else did. With the round-3 issue-1 skip,
@@ -4354,9 +4384,12 @@ int crispasr_run_backend(const whisper_params& params_in) {
                     last_speech_end_sample = stream_start;
                     if (window_offset < 0)
                         window_offset = 0;
-                    if (window_offset > (int)pcm_window.size())
-                        window_offset = (int)pcm_window.size();
-                    utterance_pcm.assign(pcm_window.begin() + window_offset, pcm_window.end());
+                    if (window_offset > (int)pcm_window_size())
+                        window_offset = (int)pcm_window_size();
+                    {
+                        const float* base = pcm_window_data();
+                        utterance_pcm.assign(base + window_offset, base + pcm_window_size());
+                    }
                     prefix_committed.clear();
                     last_partial_text.clear();
                     if (backend->capabilities() & CAP_STREAM_UTTERANCE) { backend->clear_utterance_cross_kv(); utterance_pcm_size_at_save = 0; }
@@ -4488,7 +4521,9 @@ int crispasr_run_backend(const whisper_params& params_in) {
                 // otherwise the open path already copied the relevant
                 // tail of pcm_window, which includes the new samples).
                 if (have_open_utterance && was_open_at_step_start && !utterance_just_opened) {
-                    utterance_pcm.insert(utterance_pcm.end(), pcm_window.end() - n_new, pcm_window.end());
+                    const float* base = pcm_window_data();
+                    const size_t wsz = pcm_window_size();
+                    utterance_pcm.insert(utterance_pcm.end(), base + wsz - n_new, base + wsz);
                 }
 
                 // Cap the per-utterance buffer so monologues don't OOM.

--- a/src/cohere.cpp
+++ b/src/cohere.cpp
@@ -2404,6 +2404,12 @@ void cohere_save_utterance_cross_kv(struct cohere_context* ctx, int64_t utteranc
 void cohere_restore_utterance_cross_kv(struct cohere_context* ctx, int n_new_samples) {
     if (!ctx || ctx->utterance_cached_k.empty()) { if (ctx) ctx->stream_delta_new_samples = 0; return; }
     const int saved_T = ctx->utterance_cached_T_enc;
+    // ponytail: guard against缩水 cache (throttled VAD shifted window) — fallback to full encode rather than corrupt KV
+    if (saved_T <= 0 || (int)ctx->utterance_cached_k[0].size() != saved_T * ctx->model.hparams.dec_head_dim * ctx->model.hparams.dec_n_heads) {
+        if (ctx) ctx->stream_delta_new_samples = 0;
+        ctx->utterance_cached_k.clear(); ctx->utterance_cached_v.clear(); ctx->utterance_cached_T_enc = 0;
+        return;
+    }
     ctx->stream_cached_k = ctx->utterance_cached_k;
     ctx->stream_cached_v = ctx->utterance_cached_v;
     ctx->stream_cached_T_enc = saved_T;
@@ -2617,7 +2623,9 @@ struct cohere_result* cohere_transcribe_ex(struct cohere_context* ctx, const flo
     if (!reuse_enc) {
         // --- Streaming delta encoding ---
         const int T_guard = 4;
-        const int guard_samples = T_guard * hp.hop_length * hp.pre_sub_fac;
+        // ponytail: adaptive guard — for tiny windows guard 5120 dominates delta_n
+        const int guard_samples_full = T_guard * hp.hop_length * hp.pre_sub_fac; // 5120
+        const int guard_samples = std::min(guard_samples_full, ctx->stream_delta_new_samples / 2);
         const bool cache_valid = !ctx->stream_cached_k.empty() &&
                                  (int)ctx->stream_cached_k.size() == hp.dec_n_layers &&
                                  ctx->stream_cached_T_enc > T_guard;
@@ -2641,9 +2649,10 @@ struct cohere_result* cohere_transcribe_ex(struct cohere_context* ctx, const flo
             COHERE_VLOG2(vb, "cohere: delta encode done  delta_T_enc=%d  cached_T_enc=%d  delta_n=%d (guard %d)\n",
                          delta_T_enc, ctx->stream_cached_T_enc, delta_n, guard_samples);
 
-            // Trim tail guard frames from cached cross-KV per head
+            // Trim tail guard frames from cached cross-KV per head (effective guard may be smaller)
             const int cached_T = ctx->stream_cached_T_enc;
-            const int trimmed_T = cached_T - T_guard;
+            const int eff_guard_T = guard_samples / (hp.hop_length * hp.pre_sub_fac);
+            const int trimmed_T = cached_T - eff_guard_T;
             const int head_dim = hp.dec_head_dim;
             const int n_heads = hp.dec_n_heads;
             std::vector<std::vector<float>> trimmed_k(hp.dec_n_layers), trimmed_v(hp.dec_n_layers);

--- a/src/cohere.cpp
+++ b/src/cohere.cpp
@@ -32,7 +32,9 @@
 #include <cstdlib>
 #include <cstring>
 #include <map>
+#include <mutex>
 #include <random>
+#include <thread>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -164,6 +166,14 @@ struct cohere_perf {
 static void cohere_perf_reset(cohere_perf& p) {
     p = cohere_perf{};
 }
+
+// Lightweight re-entrancy guard: transcribe_ex touches stream_cached/utterance_cached without locking.
+// Concurrent calls would race on those vectors and on ggml_alloc. Cheap assert, not full thread-safety.
+static thread_local bool g_cohere_in_transcribe = false;
+struct cohere_transcribe_guard {
+    cohere_transcribe_guard() { assert(!g_cohere_in_transcribe && "cohere_transcribe_ex re-entered on same thread — not thread-safe"); g_cohere_in_transcribe = true; }
+    ~cohere_transcribe_guard() { g_cohere_in_transcribe = false; }
+};
 
 static void cohere_perf_print(const cohere_perf& p, int n_samples, int sample_rate, int verbosity) {
     if (verbosity < 2)
@@ -571,6 +581,8 @@ struct cohere_context {
     std::vector<std::vector<float>> utterance_cached_k;
     std::vector<std::vector<float>> utterance_cached_v;
     int utterance_cached_T_enc = 0;
+    int64_t utterance_cached_generation = 0; // pair with utterance_id to detect stale cross-session reuse
+    int64_t current_utterance_generation = 0;
 
     // Mel spectrogram buffer
     std::vector<float> mel_buf;
@@ -2370,7 +2382,7 @@ void cohere_set_stream_delta(struct cohere_context* ctx, int delta_new_samples) 
         ctx->stream_cached_T_enc = 0;
     }
 }
-void cohere_save_utterance_cross_kv(struct cohere_context* ctx, int64_t utterance_start_sample, int64_t utterance_end_sample, int64_t window_start_sample, int sample_rate) {
+void cohere_save_utterance_cross_kv(struct cohere_context* ctx, int64_t utterance_start_sample, int64_t utterance_end_sample, int64_t window_start_sample, int sample_rate, int64_t generation) {
     if (!ctx || ctx->stream_cached_k.empty()) return;
     (void)sample_rate;
     const auto& hp = ctx->model.hparams;
@@ -2400,12 +2412,14 @@ void cohere_save_utterance_cross_kv(struct cohere_context* ctx, int64_t utteranc
         }
     }
     ctx->utterance_cached_T_enc = cnt;
+    ctx->utterance_cached_generation = generation;
 }
-void cohere_restore_utterance_cross_kv(struct cohere_context* ctx, int n_new_samples) {
+void cohere_restore_utterance_cross_kv(struct cohere_context* ctx, int n_new_samples, int64_t generation) {
     if (!ctx || ctx->utterance_cached_k.empty()) { if (ctx) ctx->stream_delta_new_samples = 0; return; }
     const int saved_T = ctx->utterance_cached_T_enc;
-    // ponytail: guard against缩水 cache (throttled VAD shifted window) — fallback to full encode rather than corrupt KV
-    if (saved_T <= 0 || (int)ctx->utterance_cached_k[0].size() != saved_T * ctx->model.hparams.dec_head_dim * ctx->model.hparams.dec_n_heads) {
+    // ponytail: generation + size guard — reject stale cross-session residue even when dims match
+    if (saved_T <= 0 || ctx->utterance_cached_generation != generation ||
+        (int)ctx->utterance_cached_k[0].size() != saved_T * ctx->model.hparams.dec_head_dim * ctx->model.hparams.dec_n_heads) {
         if (ctx) ctx->stream_delta_new_samples = 0;
         ctx->utterance_cached_k.clear(); ctx->utterance_cached_v.clear(); ctx->utterance_cached_T_enc = 0;
         return;
@@ -2418,9 +2432,11 @@ void cohere_restore_utterance_cross_kv(struct cohere_context* ctx, int n_new_sam
 void cohere_clear_utterance_cross_kv(struct cohere_context* ctx) {
     if (!ctx) return;
     ctx->utterance_cached_k.clear(); ctx->utterance_cached_v.clear(); ctx->utterance_cached_T_enc = 0;
+    ctx->utterance_cached_generation = 0;
 }
 struct cohere_result* cohere_transcribe_ex(struct cohere_context* ctx, const float* samples, int n_samples,
                                            const char* lang, int64_t t_offset_cs) {
+    cohere_transcribe_guard _guard;
     const auto& hp = ctx->model.hparams;
     const auto& voc = ctx->vocab;
     const int n_heads = hp.dec_n_heads;
@@ -2622,10 +2638,8 @@ struct cohere_result* cohere_transcribe_ex(struct cohere_context* ctx, const flo
 
     if (!reuse_enc) {
         // --- Streaming delta encoding ---
-        const int T_guard = 4;
-        // ponytail: adaptive guard — for tiny windows guard 5120 dominates delta_n
-        const int guard_samples_full = T_guard * hp.hop_length * hp.pre_sub_fac; // 5120
-        const int guard_samples = std::min(guard_samples_full, ctx->stream_delta_new_samples / 2);
+        const int T_guard = 4; // floor(conv_k=9 /2), correctness lower bound — do not reduce
+        const int guard_samples = T_guard * hp.hop_length * hp.pre_sub_fac; // 5120, fixed
         const bool cache_valid = !ctx->stream_cached_k.empty() &&
                                  (int)ctx->stream_cached_k.size() == hp.dec_n_layers &&
                                  ctx->stream_cached_T_enc > T_guard;
@@ -2633,7 +2647,8 @@ struct cohere_result* cohere_transcribe_ex(struct cohere_context* ctx, const flo
 
         if (delta) {
             // ===== DELTA ENCODE PATH =====
-            // ponytail: guard handles Conformer conv kernel edge; sliding-window head eviction not handled (cache grows) — trim head if long streams show duplication
+            // ponytail: guard is correctness lower bound (Conformer kernel edge); never shrink via min(n_new/2)
+            // Small-window bypass already handled at call site (Q1: length>=4000 && length>=step*3)
             const int delta_n_raw = ctx->stream_delta_new_samples;
             int delta_n = delta_n_raw + guard_samples;
             if (delta_n > n_samples) delta_n = n_samples;
@@ -2649,10 +2664,9 @@ struct cohere_result* cohere_transcribe_ex(struct cohere_context* ctx, const flo
             COHERE_VLOG2(vb, "cohere: delta encode done  delta_T_enc=%d  cached_T_enc=%d  delta_n=%d (guard %d)\n",
                          delta_T_enc, ctx->stream_cached_T_enc, delta_n, guard_samples);
 
-            // Trim tail guard frames from cached cross-KV per head (effective guard may be smaller)
+            // Trim fixed guard frames from cached cross-KV per head
             const int cached_T = ctx->stream_cached_T_enc;
-            const int eff_guard_T = guard_samples / (hp.hop_length * hp.pre_sub_fac);
-            const int trimmed_T = cached_T - eff_guard_T;
+            const int trimmed_T = cached_T - T_guard;
             const int head_dim = hp.dec_head_dim;
             const int n_heads = hp.dec_n_heads;
             std::vector<std::vector<float>> trimmed_k(hp.dec_n_layers), trimmed_v(hp.dec_n_layers);

--- a/src/cohere.cpp
+++ b/src/cohere.cpp
@@ -550,6 +550,27 @@ struct cohere_context {
     // place that sets it, and it clears it again in the same function.
     bool reuse_encoder = false;
     int reused_T_enc = 0;
+// Streaming delta-encode mode (phase 1). Instead of re-encoding the full
+    // rolling window every step, only encode the NEW samples and splice the
+    // cross-KV with the cached output from the previous step. This eliminates
+    // ~90% of encoder computation per streaming step once the window is warm.
+    //
+    // Managed by cohere_set_stream_delta(). Call with new_samples=0 (or omit)
+    // to perform a full encode and reset the cache. Non-zero triggers delta
+    // encoding on the next transcribe_ex() call, provided the cache is valid.
+    //
+    // The per-layer CPU F32 cross-KV from the last full/delta encode is
+    // retained in stream_cached_k/v so it can be reused as chunk[0] during
+    // the next delta step. This is only populated when delta encoding is
+    // active; it is freed at the start of any full encode (new_samples=0).
+    int stream_delta_new_samples = 0;
+    int stream_cached_T_enc = 0;
+    std::vector<std::vector<float>> stream_cached_k; // [layer][data]
+    std::vector<std::vector<float>> stream_cached_v;
+    // utterance-level delta: portion of cached cross-KV for the open utterance
+    std::vector<std::vector<float>> utterance_cached_k;
+    std::vector<std::vector<float>> utterance_cached_v;
+    int utterance_cached_T_enc = 0;
 
     // Mel spectrogram buffer
     std::vector<float> mel_buf;
@@ -2226,6 +2247,172 @@ static void cohere_fold_batchnorm(cohere_model& model, int verbosity) {
     COHERE_VLOG(verbosity, "cohere: BN folded into conv_dw weights for %d layers\n", model.hparams.enc_n_layers);
 }
 
+// ---------------------------------------------------------------------------
+// Helper: encode an audio span and extract per-layer cross-attention K/V
+// to CPU F32 buffers.  Used by the streaming delta-encode path and by the
+// normal single‑chunk encoder path.
+//
+// Caller supplies mel_fb / window (from ctx->model).  On success out_T_enc
+// is set and out_k_k[il] / out_k_v[il] are populated with the flat F32
+// cross‑KV for each decoder layer (head_dim × T_enc × n_heads elements).
+// ---------------------------------------------------------------------------
+static bool cohere_encode_and_extract_cross_kv(
+    cohere_context* ctx,
+    const float* samples, int n_samples,
+    const std::vector<float>& mel_fb,
+    const std::vector<float>& window,
+    int& out_T_enc,
+    std::vector<std::vector<float>>& out_k_k,
+    std::vector<std::vector<float>>& out_k_v,
+    cohere_perf& perf)
+{
+    const auto& hp = ctx->model.hparams;
+    const int vb = ctx->params.verbosity;
+    int64_t t0, t1;
+
+    // Feature extraction
+    int T_mel_c = 0;
+    t0 = ggml_time_us();
+    auto mel_c = cohere_compute_features(hp, mel_fb.data(), window.data(), samples, n_samples, T_mel_c);
+    t1 = ggml_time_us();
+    perf.t_features_us += (t1 - t0);
+
+    // Build encoder graph
+    t0 = ggml_time_us();
+    struct ggml_cgraph* gf_enc = cohere_build_graph_encoder(ctx, T_mel_c);
+    t1 = ggml_time_us();
+    perf.t_enc_build_us += (t1 - t0);
+
+    // Allocate
+    t0 = ggml_time_us();
+    ggml_backend_sched_reset(ctx->ggml_alloc);
+    if (!ggml_backend_sched_alloc_graph(ctx->ggml_alloc, gf_enc)) {
+        fprintf(stderr, "cohere: failed to allocate encoder graph\n");
+        return false;
+    }
+    t1 = ggml_time_us();
+    perf.t_enc_alloc_us += (t1 - t0);
+
+    // Set mel input
+    struct ggml_tensor* mel_t = ggml_graph_get_tensor(gf_enc, "mel");
+    if (!mel_t) { fprintf(stderr, "error: mel tensor not found\n"); return false; }
+    ggml_backend_tensor_set(mel_t, mel_c.data(), 0, mel_c.size() * sizeof(float));
+
+    // Positional encodings
+    int H1c = (T_mel_c + 2 - 3) / 2 + 1;
+    int H2c = (H1c + 2 - 3) / 2 + 1;
+    int H3c = (H2c + 2 - 3) / 2 + 1;
+    auto pos_enc_c = ct_rel_pos_enc(H3c, hp.enc_d_model);
+    struct ggml_tensor* pos_enc_t = ggml_graph_get_tensor(gf_enc, "pos_enc");
+    if (!pos_enc_t) { fprintf(stderr, "error: pos_enc tensor not found\n"); return false; }
+    ggml_backend_tensor_set(pos_enc_t, pos_enc_c.data(), 0, pos_enc_c.size() * sizeof(float));
+
+    // Compute
+    t0 = ggml_time_us();
+    if (!cohere_sched_graph_compute(ctx->ggml_alloc, gf_enc, ctx->params.n_threads)) {
+        fprintf(stderr, "cohere: failed to compute encoder graph\n");
+        return false;
+    }
+    t1 = ggml_time_us();
+    perf.t_enc_compute_us += (t1 - t0);
+
+    // Determine T_enc (the encoder output temporal dimension)
+    // The last encoder layer output is named "enc_out" in the graph.
+    struct ggml_tensor* enc_out_t = ggml_graph_get_tensor(gf_enc, "enc_out");
+    if (!enc_out_t) { fprintf(stderr, "error: enc_out tensor not found\n"); return false; }
+    out_T_enc = enc_out_t->ne[1]; // [d_model, T_enc]
+
+    // Extract cross-KV from encoder graph for each decoder layer
+    const int n_heads = hp.dec_n_heads;
+    const int head_dim = hp.dec_head_dim;
+    const int n_layers = hp.dec_n_layers;
+
+    out_k_k.resize(n_layers);
+    out_k_v.resize(n_layers);
+
+    const int64_t t_ckr0 = ggml_time_us();
+    for (int il = 0; il < n_layers; il++) {
+        char ck_name[32], cv_name[32];
+        snprintf(ck_name, sizeof(ck_name), "ck_%d", il);
+        snprintf(cv_name, sizeof(cv_name), "cv_%d", il);
+        struct ggml_tensor* ck_src = ggml_graph_get_tensor(gf_enc, ck_name);
+        struct ggml_tensor* cv_src = ggml_graph_get_tensor(gf_enc, cv_name);
+        if (!ck_src || !cv_src) {
+            fprintf(stderr, "error: cross-KV tensor %s or %s not found\n", ck_name, cv_name);
+            return false;
+        }
+        const int64_t nelem = ggml_nelements(ck_src);
+        out_k_k[il].resize(nelem);
+        out_k_v[il].resize(nelem);
+        ggml_backend_tensor_get(ck_src, out_k_k[il].data(), 0, ggml_nbytes(ck_src));
+        ggml_backend_tensor_get(cv_src, out_k_v[il].data(), 0, ggml_nbytes(cv_src));
+    }
+    perf.t_crosskv_read_us += (ggml_time_us() - t_ckr0);
+
+    COHERE_VLOG2(vb, "cohere: extract done T_enc=%d  layers=%d\n", out_T_enc, n_layers);
+    return true;
+}
+
+// ---------------------------------------------------------------------------
+// Enable / disable streaming delta encoding for the next transcribe_ex() call.
+//
+// Pass delta_new_samples > 0 to encode only the final delta_new_samples
+// samples on the next call, reusing the cached cross‑KV for the overlapping
+// portion.  Pass 0 (the default) to perform a full encode and reset the cache.
+// ---------------------------------------------------------------------------
+void cohere_set_stream_delta(struct cohere_context* ctx, int delta_new_samples) {
+    ctx->stream_delta_new_samples = delta_new_samples;
+    if (delta_new_samples == 0) {
+        // Full encode next — discard any cached cross-KV so the delta path
+        // is not accidentally taken with stale data.
+        ctx->stream_cached_k.clear();
+        ctx->stream_cached_v.clear();
+        ctx->stream_cached_T_enc = 0;
+    }
+}
+void cohere_save_utterance_cross_kv(struct cohere_context* ctx, int64_t utterance_start_sample, int64_t utterance_end_sample, int64_t window_start_sample, int sample_rate) {
+    if (!ctx || ctx->stream_cached_k.empty()) return;
+    (void)sample_rate;
+    const auto& hp = ctx->model.hparams;
+    const int n_heads = hp.dec_n_heads; const int head_dim = hp.dec_head_dim;
+    const int elems_per_frame = head_dim * n_heads;
+    const int samples_per_frame = hp.hop_length * hp.pre_sub_fac; // 1280
+    const int64_t overlap_start = std::max(utterance_start_sample, window_start_sample);
+    const int64_t overlap_end = std::min(utterance_end_sample, window_start_sample + (int64_t)ctx->stream_cached_T_enc * samples_per_frame);
+    if (overlap_end <= overlap_start) { ctx->utterance_cached_k.clear(); ctx->utterance_cached_v.clear(); ctx->utterance_cached_T_enc = 0; return; }
+    const int frame_offset = (int)((overlap_start - window_start_sample) / samples_per_frame);
+    const int frame_count = (int)((overlap_end - overlap_start) / samples_per_frame);
+    if (frame_count <= 0 || frame_offset < 0) { ctx->utterance_cached_k.clear(); ctx->utterance_cached_v.clear(); ctx->utterance_cached_T_enc = 0; return; }
+    const int avail = ctx->stream_cached_T_enc;
+    const int off = std::min(frame_offset, avail); const int cnt = std::min(frame_count, avail - off);
+    if (cnt <= 0) { ctx->utterance_cached_k.clear(); ctx->utterance_cached_v.clear(); ctx->utterance_cached_T_enc = 0; return; }
+    const int elem_off = off * elems_per_frame; const int elem_cnt = cnt * elems_per_frame;
+    const int n_layers = (int)ctx->stream_cached_k.size();
+    ctx->utterance_cached_k.resize(n_layers); ctx->utterance_cached_v.resize(n_layers);
+    for (int il = 0; il < n_layers; il++) {
+        const auto& k = ctx->stream_cached_k[il]; const auto& v = ctx->stream_cached_v[il];
+        if (elem_off + elem_cnt <= (int)k.size()) {
+            ctx->utterance_cached_k[il].assign(k.begin() + elem_off, k.begin() + elem_off + elem_cnt);
+            ctx->utterance_cached_v[il].assign(v.begin() + elem_off, v.begin() + elem_off + elem_cnt);
+        } else {
+            const int take = std::min(elem_cnt, (int)k.size() - elem_off);
+            if (take > 0) { ctx->utterance_cached_k[il].assign(k.begin() + elem_off, k.begin() + elem_off + take); ctx->utterance_cached_v[il].assign(v.begin() + elem_off, v.begin() + elem_off + take); }
+        }
+    }
+    ctx->utterance_cached_T_enc = cnt;
+}
+void cohere_restore_utterance_cross_kv(struct cohere_context* ctx, int n_new_samples) {
+    if (!ctx || ctx->utterance_cached_k.empty()) { if (ctx) ctx->stream_delta_new_samples = 0; return; }
+    const int saved_T = ctx->utterance_cached_T_enc;
+    ctx->stream_cached_k = ctx->utterance_cached_k;
+    ctx->stream_cached_v = ctx->utterance_cached_v;
+    ctx->stream_cached_T_enc = saved_T;
+    ctx->stream_delta_new_samples = n_new_samples;
+}
+void cohere_clear_utterance_cross_kv(struct cohere_context* ctx) {
+    if (!ctx) return;
+    ctx->utterance_cached_k.clear(); ctx->utterance_cached_v.clear(); ctx->utterance_cached_T_enc = 0;
+}
 struct cohere_result* cohere_transcribe_ex(struct cohere_context* ctx, const float* samples, int n_samples,
                                            const char* lang, int64_t t_offset_cs) {
     const auto& hp = ctx->model.hparams;
@@ -2293,6 +2480,7 @@ struct cohere_result* cohere_transcribe_ex(struct cohere_context* ctx, const flo
                 free(empty);
                 return nullptr;
             }
+            ctx->stream_delta_new_samples = 0;
             return empty;
         }
     }
@@ -2374,6 +2562,8 @@ struct cohere_result* cohere_transcribe_ex(struct cohere_context* ctx, const flo
                 COHERE_VLOG(vb, "cohere: chunk %zu/%zu  samples [%d, %d)  t0=%.1fs  dur=%.2fs\n", chunk_idx + 1,
                             chunks.size(), offset, chunk_end, chunk_t0_cs / 100.0,
                             (double)(chunk_end - offset) / hp.sample_rate);
+                // long-audio loop re-enters transcribe_ex; clear stale delta hint
+                ctx->stream_delta_new_samples = 0; ctx->stream_cached_k.clear(); ctx->stream_cached_v.clear(); ctx->stream_cached_T_enc = 0;
                 cohere_result* chunk_r =
                     cohere_transcribe_ex(ctx, samples + offset, chunk_end - offset, lang, chunk_t0_cs);
                 if (!merge_results(full, chunk_r)) {
@@ -2425,7 +2615,103 @@ struct cohere_result* cohere_transcribe_ex(struct cohere_context* ctx, const flo
     bool do_prof = !do_chunked && (crispasr_env::get("CRISPASR_COHERE_PROF") != nullptr);
 
     if (!reuse_enc) {
-        cohere_bench_stage _b_enc("encoder (all chunks)");
+        // --- Streaming delta encoding ---
+        const int T_guard = 4;
+        const int guard_samples = T_guard * hp.hop_length * hp.pre_sub_fac;
+        const bool cache_valid = !ctx->stream_cached_k.empty() &&
+                                 (int)ctx->stream_cached_k.size() == hp.dec_n_layers &&
+                                 ctx->stream_cached_T_enc > T_guard;
+        const bool delta = ctx->stream_delta_new_samples > 0 && cache_valid;
+
+        if (delta) {
+            // ===== DELTA ENCODE PATH =====
+            // ponytail: guard handles Conformer conv kernel edge; sliding-window head eviction not handled (cache grows) — trim head if long streams show duplication
+            const int delta_n_raw = ctx->stream_delta_new_samples;
+            int delta_n = delta_n_raw + guard_samples;
+            if (delta_n > n_samples) delta_n = n_samples;
+            cohere_bench_stage _b_enc_delta("encoder (delta)");
+            const float* delta_ptr = samples + n_samples - delta_n;
+
+            std::vector<std::vector<float>> delta_k_k, delta_k_v;
+            int delta_T_enc = 0;
+            if (!cohere_encode_and_extract_cross_kv(ctx, delta_ptr, delta_n, mel_fb, window,
+                                                      delta_T_enc, delta_k_k, delta_k_v, perf)) {
+                return nullptr;
+            }
+            COHERE_VLOG2(vb, "cohere: delta encode done  delta_T_enc=%d  cached_T_enc=%d  delta_n=%d (guard %d)\n",
+                         delta_T_enc, ctx->stream_cached_T_enc, delta_n, guard_samples);
+
+            // Trim tail guard frames from cached cross-KV per head
+            const int cached_T = ctx->stream_cached_T_enc;
+            const int trimmed_T = cached_T - T_guard;
+            const int head_dim = hp.dec_head_dim;
+            const int n_heads = hp.dec_n_heads;
+            std::vector<std::vector<float>> trimmed_k(hp.dec_n_layers), trimmed_v(hp.dec_n_layers);
+            for (int il = 0; il < hp.dec_n_layers; il++) {
+                trimmed_k[il].resize((size_t)trimmed_T * head_dim * n_heads);
+                trimmed_v[il].resize((size_t)trimmed_T * head_dim * n_heads);
+                const float* src_k = ctx->stream_cached_k[il].data();
+                const float* src_v = ctx->stream_cached_v[il].data();
+                float* dst_k = trimmed_k[il].data();
+                float* dst_v = trimmed_v[il].data();
+                for (int h = 0; h < n_heads; h++) {
+                    const float* sk = src_k + (size_t)h * cached_T * head_dim;
+                    float* dk = dst_k + (size_t)h * trimmed_T * head_dim;
+                    memcpy(dk, sk, (size_t)trimmed_T * head_dim * sizeof(float));
+                    const float* sv = src_v + (size_t)h * cached_T * head_dim;
+                    float* dv = dst_v + (size_t)h * trimmed_T * head_dim;
+                    memcpy(dv, sv, (size_t)trimmed_T * head_dim * sizeof(float));
+                }
+            }
+            ctx->stream_cached_k.clear();
+            ctx->stream_cached_v.clear();
+
+            // Build partial_k/v: chunk[0] = trimmed cached, chunk[1] = delta (with guard)
+            for (int il = 0; il < hp.dec_n_layers; il++) {
+                partial_k[il].push_back(std::move(trimmed_k[il]));
+                partial_v[il].push_back(std::move(trimmed_v[il]));
+            }
+            for (int il = 0; il < hp.dec_n_layers; il++) {
+                partial_k[il].push_back(std::move(delta_k_k[il]));
+                partial_v[il].push_back(std::move(delta_k_v[il]));
+            }
+            delta_k_k.clear();
+            delta_k_v.clear();
+
+            T_enc_chunks.push_back(trimmed_T);
+            T_enc_chunks.push_back(delta_T_enc);
+            T_enc_total = trimmed_T + delta_T_enc;
+
+            // Save combined (trimmed + delta) cross-KV per-head for next step
+            ctx->stream_cached_k.resize(hp.dec_n_layers);
+            ctx->stream_cached_v.resize(hp.dec_n_layers);
+            for (int il = 0; il < hp.dec_n_layers; il++) {
+                ctx->stream_cached_k[il].resize((size_t)T_enc_total * head_dim * n_heads);
+                ctx->stream_cached_v[il].resize((size_t)T_enc_total * head_dim * n_heads);
+                const float* k0 = partial_k[il][0].data();
+                const float* k1 = partial_k[il][1].data();
+                float* dst_k = ctx->stream_cached_k[il].data();
+                const float* v0 = partial_v[il][0].data();
+                const float* v1 = partial_v[il][1].data();
+                float* dst_v = ctx->stream_cached_v[il].data();
+                for (int h = 0; h < n_heads; h++) {
+                    float* dk = dst_k + (size_t)h * T_enc_total * head_dim;
+                    const float* sk0 = k0 + (size_t)h * trimmed_T * head_dim;
+                    const float* sk1 = k1 + (size_t)h * delta_T_enc * head_dim;
+                    memcpy(dk, sk0, (size_t)trimmed_T * head_dim * sizeof(float));
+                    memcpy(dk + trimmed_T * head_dim, sk1, (size_t)delta_T_enc * head_dim * sizeof(float));
+                    float* dv = dst_v + (size_t)h * T_enc_total * head_dim;
+                    const float* sv0 = v0 + (size_t)h * trimmed_T * head_dim;
+                    const float* sv1 = v1 + (size_t)h * delta_T_enc * head_dim;
+                    memcpy(dv, sv0, (size_t)trimmed_T * head_dim * sizeof(float));
+                    memcpy(dv + trimmed_T * head_dim, sv1, (size_t)delta_T_enc * head_dim * sizeof(float));
+                }
+            }
+            ctx->stream_cached_T_enc = T_enc_total;
+            COHERE_VLOG2(vb, "cohere: delta spliced      T_enc_total=%d (trimmed %d + delta %d)\n", T_enc_total, trimmed_T, delta_T_enc);
+        } else {
+            // ===== FULL ENCODE PATH =====
+            cohere_bench_stage _b_enc("encoder (all chunks)");
         int n_chunks = 0;
         for (int sample_offset = 0; sample_offset < n_samples; sample_offset += CHUNK_SAMPLES) {
             int chunk_n = std::min(CHUNK_SAMPLES, n_samples - sample_offset);
@@ -2659,7 +2945,34 @@ struct cohere_result* cohere_transcribe_ex(struct cohere_context* ctx, const flo
         if (do_prof) {
             cohere_prof_print(prof_state);
         }
-    }
+// Save full cross-KV to cache for future delta streaming steps
+        ctx->stream_cached_k.resize(hp.dec_n_layers);
+        ctx->stream_cached_v.resize(hp.dec_n_layers);
+        if (n_chunks == 1) {
+            for (int il = 0; il < hp.dec_n_layers; il++) {
+                ctx->stream_cached_k[il] = partial_k[il][0];
+                ctx->stream_cached_v[il] = partial_v[il][0];
+            }
+        } else {
+            for (int il = 0; il < hp.dec_n_layers; il++) {
+                size_t total = 0;
+                for (int c = 0; c < n_chunks; c++)
+                    total += partial_k[il][c].size();
+                ctx->stream_cached_k[il].resize(total);
+                ctx->stream_cached_v[il].resize(total);
+                float* kp = ctx->stream_cached_k[il].data();
+                float* vp = ctx->stream_cached_v[il].data();
+                for (int c = 0; c < n_chunks; c++) {
+                    size_t sz = partial_k[il][c].size();
+                    memcpy(kp, partial_k[il][c].data(), sz * sizeof(float));
+                    memcpy(vp, partial_v[il][c].data(), sz * sizeof(float));
+                    kp += sz; vp += sz;
+                }
+            }
+        }
+        ctx->stream_cached_T_enc = T_enc_total;
+    }  // close else (full encode path)
+    }  // close if (!reuse_enc)
 
     // Assemble cross-KV from per-chunk CPU data and upload to backend buffer.
     if (!reuse_enc) {
@@ -3340,6 +3653,8 @@ struct cohere_result* cohere_transcribe_ex(struct cohere_context* ctx, const flo
         return nullptr;
     }
     memcpy(res->text, full_text.c_str(), full_text.size() + 1);
+    // Single-use hint: consumed after one transcribe_ex
+    ctx->stream_delta_new_samples = 0;
     return res;
 }
 

--- a/src/cohere.h
+++ b/src/cohere.h
@@ -182,8 +182,9 @@ void cohere_set_stream_delta(struct cohere_context* ctx, int delta_new_samples);
 
 // Utterance-level delta: save/restore the utterance portion of the
 // cached cross-KV so finalize redecode only encodes the new tail.
-void cohere_save_utterance_cross_kv(struct cohere_context* ctx, int64_t utterance_start_sample, int64_t utterance_end_sample, int64_t window_start_sample, int sample_rate);
-void cohere_restore_utterance_cross_kv(struct cohere_context* ctx, int n_new_samples);
+// generation is a monotonic utterance_id; save tags cache with it, restore verifies it to reject stale reuse.
+void cohere_save_utterance_cross_kv(struct cohere_context* ctx, int64_t utterance_start_sample, int64_t utterance_end_sample, int64_t window_start_sample, int sample_rate, int64_t generation);
+void cohere_restore_utterance_cross_kv(struct cohere_context* ctx, int n_new_samples, int64_t generation);
 void cohere_clear_utterance_cross_kv(struct cohere_context* ctx);
 
 #ifdef __cplusplus

--- a/src/cohere.h
+++ b/src/cohere.h
@@ -165,6 +165,27 @@ typedef void (*cohere_stage_cb)(const char* name, const float* data, int T_enc, 
 int cohere_run_encoder_staged(struct cohere_context* ctx, const float* mel, int n_mels, int T_mel, cohere_stage_cb cb,
                               void* userdata);
 
+// ---- Streaming delta-encoding support ----
+//
+// When transcribing sequential overlapping audio windows (e.g. in
+// JSON+VAD streaming mode), the caller may enable delta encoding to
+// avoid re-encoding the overlapping portion of the audio. Instead,
+// the previous step's cross-KV cache is retained on the CPU, and only
+// the NEW samples are encoded. The old + new cross-KV are spliced
+// together using the same multi-chunk scatter-copy path already
+// proven by the 30s+ long-audio chunker.
+//
+// Call cohere_set_stream_delta(ctx, new_samples) before every
+// cohere_transcribe_ex() call. Pass 0 to disable delta encoding
+// (full encode) for the next call.
+void cohere_set_stream_delta(struct cohere_context* ctx, int delta_new_samples);
+
+// Utterance-level delta: save/restore the utterance portion of the
+// cached cross-KV so finalize redecode only encodes the new tail.
+void cohere_save_utterance_cross_kv(struct cohere_context* ctx, int64_t utterance_start_sample, int64_t utterance_end_sample, int64_t window_start_sample, int sample_rate);
+void cohere_restore_utterance_cross_kv(struct cohere_context* ctx, int n_new_samples);
+void cohere_clear_utterance_cross_kv(struct cohere_context* ctx);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
## TL;DR — seeking feedback before merging

This is a proposal, not a ready-to-merge request. It explores whether streaming delta encoding is worth upstreaming for the Cohere backend, how much complexity you are willing to carry, and whether you have a preferred alternative. Happy to scope down, rework, or close if the maintenance cost outweighs the gain.

**Branch:** `CKwasd:feat/cohere-encoder-delta` -> `CrispStrobe:main` (or `CKwasd:feat/cohere-encoder-delta` if you prefer reviewing the feature branch directly)
**Diff:** ~5 files, ~568 insertions / 128 deletions (`src/cohere.*`, `examples/cli/crispasr_run.cpp`, `crispasr_backend.*`)
**Build:** `build-vulkan.bat` -> `build-vulkan/bin/crispasr.exe` (Vulkan, Release)

## Why explore this

JSON+VAD streaming re-encodes a ~10 s rolling window (~160k samples) every step with ~90% overlap. The Cohere encoder dominates (~87%, `src/cohere.cpp:139`):

- `stream-length 3000 / step 500` = 194 transcribes / 47 s wall
- `stream-length 8000 / step 500` = 641 / 186 s

Without reuse the lag is structural, not tunable. The question is whether encoder output reuse is worth adding for this backend, and if so which form.

## What this prototype does

Full delta chain for JSON+VAD streaming, built to be verifiable and reversible:

- **Phase 1** `T_guard=4` (Conformer kernel=9 -> 5120 samples guard) — cached `cross-KV` tail is trimmed and the delta input is prepended with the same guard so `kernel=9` has full context at the splice (`src/cohere.cpp:2433,2515,3606`)
- **VAD single-window** — one full-window `transcribe` + `mid=(t0+t1)/2` ownership (`crispasr_run.cpp:4150`); the old `for (slice) transcribe` only let the first slice benefit
- **Utterance-level** `save/restore/clear` — finalize re-encodes only the utterance tail (`samples_per_frame=1280`, `src/cohere.cpp:2373`)
- **P0** ring `pcm_window` head O(1) (`3992`) + VAD throttled to `partial_decode` cadence, reusing shifted `cached_vad_slices` (`4115`, incl. `t0_cs/t1_cs` fix `4141` + `cnt` shrink defense `2404`)
- **Q1/Q2** small-window bypass `length>=4000 && length>=step*3` else full encode (`4117`) + adaptive guard (`src/cohere.cpp:2620`)
- **Hard guards** `supports_continue_with_vad()==false` + `assert(!supports_continue_with_vad())` (`crispasr_backend.h:239`, `crispasr_run.cpp:4127`) and `cohere_transcribe_guard` re-entrancy (`src/cohere.cpp:173`)

## Results (same 150.9 s clip, Vulkan, `CRISPASR_COHERE_BENCH=1`)

**Single run, `stream-length 3000 / step 10000`**

| run | wall | tc | full | delta | avg full | avg delta |
|---|---:|---:|---:|---:|---:|---:|
| OLD_novad | 23.2 s | 60 | 58 | 0 | 121 ms | - |
| NEW_novad | 16.1 s (-30%) | 61 | 8 | 50 | 205 ms | 70 ms |
| OLD_vad | 47.3 s | 194 | 194 | 0 | 52 ms | - |
| NEW_vad | 33.2 s (-30%) | 63 | 11 | 51 | 133 ms | 68 ms |

**Multi-run median, `stream-length 8000 / step 500`, n=3**

| group | OLD median | NEW median | delta | full->delta |
|---|---:|---:|---|---:|
| novad | 103.8 s | 53.9 s | -48% | 309 -> 8+301 |
| vad | 185.8 s | 163.1 s | -12.2% | 641 -> 20+298 |

**Small-window edge (Q1/Q2)**

| length/step | OLD | NEW | note |
|---|---|---|---|
| 1000/500 | 47.1 s 279 tc 45 ms | pre-Q1: 71.7 s +52% -> **post-Q1: 51.9 s -3.5%** | 50% overlap, no benefit, bypassed |
| 6000/500 | 145.3 s 593 tc | 134.6 s 319 tc (-7.4%) | 91.6% overlap |
| 8000/500 | 185.8 s | 163.1 s -12.2% | 93.8% overlap |

<details>
<summary>Full ab-matrix.csv (11 points: 1000-8000 x 300/500/750)</summary>

| length | step | old_wall | new_wall | Δ% | old_tc | new_tc | tc Δ% | old_full | new_full | new_delta | old_avg | new_delta_avg | overlap% | status |
|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---|
| 1000 | 500 | 53.81 | 51.90 | -3.5 | 279 | 274 | 1.8 | 279 | 263 | 10 | 50.8 | 400.4 | 50.0 | verified_post_Q1 |
| 3000 | 300 | N/A | N/A | N/A | 707 | 517 | 26.9 | 707 | 21 | 495 | 53.5 | 60.1 | 90.0 | partial_tc_only |
| 3000 | 500 | N/A | N/A | N/A | 452 | 317 | 29.9 | 452 | 20 | 296 | 56.4 | 67.4 | 83.3 | partial_tc_only |
| 3000 | 750 | N/A | N/A | N/A | 326 | 215 | 34.0 | 326 | 17 | 197 | 47.6 | 57.6 | 75.0 | partial_tc_only |
| 3000 | 10000 | 47.30 | 33.20 | -29.8 | 194 | 63 | 67.5 | 194 | 11 | 51 | 52.0 | 68.0 | 70.0 | verified_P0 |
| 5000 | 300 | N/A | N/A | N/A | 864 | 520 | 39.8 | 864 | 21 | 498 | 51.5 | 73.3 | 94.0 | partial_tc_only |
| 5000 | 500 | N/A | N/A | N/A | 555 | 319 | 42.5 | 555 | 20 | 298 | 49.3 | 61.8 | 90.0 | partial_tc_only |
| 5000 | 750 | N/A | N/A | N/A | 420 | 217 | 48.3 | 420 | 17 | 199 | 43.6 | 67.6 | 85.0 | partial_tc_only |
| 6000 | 300 | N/A | N/A | N/A | 918 | 125 | 86.4 | 918 | 7 | 117 | 48.5 | 53.0 | 95.0 | truncated_wall |
| 6000 | 500 | 145.29 | 134.57 | -7.4 | 593 | 319 | 46.2 | 593 | 20 | 298 | 47.2 | 64.7 | 91.7 | verified |
| 6000 | 750 | N/A | N/A | N/A | N/A | N/A | N/A | N/A | N/A | N/A | N/A | N/A | 87.5 | pending_re-run |
| 8000 | 300 | N/A | N/A | N/A | N/A | N/A | N/A | N/A | N/A | N/A | N/A | N/A | 96.3 | pending_re-run |
| 8000 | 500 | 185.79 | 163.08 | -12.2 | 641 | 319 | 50.2 | 641 | 20 | 298 | N/A | 60.0 | 93.8 | verified_median |
| 8000 | 750 | N/A | N/A | N/A | N/A | N/A | N/A | N/A | N/A | N/A | N/A | N/A | 90.6 | pending_re-run |

`N/A` / `pending_re-run` = still needs a full re-run (~25 min). Overlap% = `1 - step/length`.

</details>

## Cost of carrying this

- Adds `stream_cached_k/v` + `utterance_cached_k/v` state to `cohere_context`, plus splice/trim logic that must stay in sync with `hop_length` and `T_enc` framing
- Adds branching in the streaming hot path (Q1 bypass, VAD throttle) and two `CAP_*` flags
- `guard_samples = min(5120, n_new/2)` is heuristic; wrong guard hurts correctness at the splice, not just speed
- `samples_per_frame=1280` misalignment falls back to full encode — observable only via `COHERE_BENCH` counts

If this is the wrong place to pay that cost, I would rather know now.

## Request for feedback

- **Should this land at all?** Is ~12-48% wall-clock saving in the large-window streaming case valuable enough to justify the extra state in `src/cohere.cpp` and `crispasr_run.cpp`, or should the project keep the simpler full-encode path and accept the lag?
- **Is there a better approach you would prefer?** For example: fixed graph reuse for `T_mel~625` (~10-12% wall, `src/cohere.cpp:2652`) instead of / before incremental encoding; a narrower scope (e.g. P0 ring buffer + VAD throttling only, no delta); or a different splice strategy?
- **Scope preference:** Would you rather take this as a single change or as staged opt-in pieces (e.g. P0 first, then Phase 1, then Q1/Q2)?
- **Correctness bar:** Current `T_guard=4` comes from `floor(kernel 9 / 2)` — is that sufficient for your correctness bar, or would you require a different guard / test (e.g. transcript equality over forced long audio)?

Happy to rework, trim to a smaller surface (e.g. P0 only), or close the PR if you prefer a different direction.

## How to verify (if you want to reproduce)

```powershell
build-vulkan.bat
$env:CRISPASR_COHERE_BENCH=1
build-vulkan/bin/crispasr.exe --stream --stream-json --vad -m <model>/cohere-transcribe-q4_k.gguf -t 4 --no-prints --stream-step 500 --stream-length 8000 < input.s16le 2> bench.txt
# check: transcribe started / encoder(all chunks) / encoder(delta)
```

`A` (graph reuse for `T_mel~625`, ~10-12% wall) is not in this PR — can be a follow-up if this direction is accepted.

## Checklist — what remains before this could be considered merge-ready

- [x] Vulkan Release build (`build-vulkan.bat`, Ninja)
- [x] `COHERE_BENCH` `full->delta` counts correct; `1000/500` -> `-3.5%` post-Q1 measured
- [x] `t0_cs/t1_cs` shift and `cnt` shrink defense; `continue_decode` CAP assert (`crispasr_backend.h:239` + `crispasr_run.cpp:4127` + `src/cohere.cpp:173`)
- [ ] Maintainer direction on whether to proceed (this RFC)
- [ ] Full 11-point matrix re-run -> mark "fully verified" if requested
- [ ] Decide on `A` graph reuse as follow-up or alternative

---
