### PR TITLE
feat(server): expose transcription progress via GET /progress

### DIFF
--- a/examples/cli/crispasr_server.cpp
+++ b/examples/cli/crispasr_server.cpp
@@ -451,6 +451,18 @@ struct stage_scope {
 
 // Load audio from a multipart file upload, transcribe it, return result.
 // Acquires model_mutex internally.
+
+// Change 150 (polyschnack): per-server progress for the webapp. One job per
+// container today, so a single atomic is honest; with --server-workers
+// concurrency this needs per-request scoping (future work).
+static std::atomic<int>    g_server_progress{-1};   // 0..100, -1 = idle
+static std::atomic<bool>   g_server_busy{false};
+struct progress_scope {
+    explicit progress_scope() { g_server_progress = 0; g_server_busy = true; }
+    ~progress_scope() { g_server_busy = false; g_server_progress = -1; }
+    progress_scope(const progress_scope&) = delete;
+    progress_scope& operator=(const progress_scope&) = delete;
+};
 static transcription_result do_transcribe(const httplib::MultipartFormData& audio_file, CrispasrBackend* backend,
                                           std::mutex& model_mutex, whisper_params rp, bool need_timestamps,
                                           fireredpunc_context* punc_ctx = nullptr, pcs_context* pcs_ctx = nullptr,
@@ -459,6 +471,7 @@ static transcription_result do_transcribe(const httplib::MultipartFormData& audi
                                           truecaser_lstm_context* tc_lstm_ctx = nullptr) {
     transcription_result result;
     result.language = rp.language;
+    progress_scope _progress;  // Change 150: /progress liefert 0..100
 
     if (rp.verbose)
         fprintf(stderr, "crispasr-server: processing '%s' (%zu bytes)\n", log_sanitize(audio_file.filename).c_str(),
@@ -731,6 +744,7 @@ static transcription_result do_transcribe(const httplib::MultipartFormData& audi
 
         for (size_t i = 0; i < slices.size(); ++i) {
             const auto& sl = slices[i];
+            g_server_progress = (int)((i + 1) * 100 / slices.size());  // Change 150
             auto tc0 = std::chrono::steady_clock::now();
             auto segs = backend->transcribe(pcmf32.data() + sl.start, sl.end - sl.start, sl.t0_cs, rp);
             if (rp.return_logits)
@@ -2279,6 +2293,18 @@ int crispasr_run_server(whisper_params& params, const std::string& host, int por
             res.status = 503;
             res.set_content("{\"status\": \"loading\"}", "application/json");
         }
+    });
+
+    // -----------------------------------------------------------------------
+    // GET /progress — Change 150 (polyschnack): 0..100 des aktuellen Jobs.
+    // busy=false → idle; progress=-1 → kein Fortschritt bekannt.
+    // -----------------------------------------------------------------------
+    svr.Get("/progress", [&](const Request&, Response& res) {
+        char buf[96];
+        snprintf(buf, sizeof(buf), "{\"busy\": %s, \"progress\": %d}",
+                 g_server_busy.load() ? "true" : "false",
+                 g_server_progress.load());
+        res.set_content(buf, "application/json");
     });
 
     // -----------------------------------------------------------------------

--- a/examples/cli/crispasr_server.cpp
+++ b/examples/cli/crispasr_server.cpp
@@ -455,11 +455,17 @@ struct stage_scope {
 // Change 150 (polyschnack): per-server progress for the webapp. One job per
 // container today, so a single atomic is honest; with --server-workers
 // concurrency this needs per-request scoping (future work).
-static std::atomic<int>    g_server_progress{-1};   // 0..100, -1 = idle
-static std::atomic<bool>   g_server_busy{false};
+static std::atomic<int> g_server_progress{-1}; // 0..100, -1 = idle
+static std::atomic<bool> g_server_busy{false};
 struct progress_scope {
-    explicit progress_scope() { g_server_progress = 0; g_server_busy = true; }
-    ~progress_scope() { g_server_busy = false; g_server_progress = -1; }
+    explicit progress_scope() {
+        g_server_progress = 0;
+        g_server_busy = true;
+    }
+    ~progress_scope() {
+        g_server_busy = false;
+        g_server_progress = -1;
+    }
     progress_scope(const progress_scope&) = delete;
     progress_scope& operator=(const progress_scope&) = delete;
 };
@@ -471,7 +477,7 @@ static transcription_result do_transcribe(const httplib::MultipartFormData& audi
                                           truecaser_lstm_context* tc_lstm_ctx = nullptr) {
     transcription_result result;
     result.language = rp.language;
-    progress_scope _progress;  // Change 150: /progress liefert 0..100
+    progress_scope _progress; // Change 150: /progress liefert 0..100
 
     if (rp.verbose)
         fprintf(stderr, "crispasr-server: processing '%s' (%zu bytes)\n", log_sanitize(audio_file.filename).c_str(),
@@ -744,7 +750,7 @@ static transcription_result do_transcribe(const httplib::MultipartFormData& audi
 
         for (size_t i = 0; i < slices.size(); ++i) {
             const auto& sl = slices[i];
-            g_server_progress = (int)((i + 1) * 100 / slices.size());  // Change 150
+            g_server_progress = (int)((i + 1) * 100 / slices.size()); // Change 150
             auto tc0 = std::chrono::steady_clock::now();
             auto segs = backend->transcribe(pcmf32.data() + sl.start, sl.end - sl.start, sl.t0_cs, rp);
             if (rp.return_logits)
@@ -2301,8 +2307,7 @@ int crispasr_run_server(whisper_params& params, const std::string& host, int por
     // -----------------------------------------------------------------------
     svr.Get("/progress", [&](const Request&, Response& res) {
         char buf[96];
-        snprintf(buf, sizeof(buf), "{\"busy\": %s, \"progress\": %d}",
-                 g_server_busy.load() ? "true" : "false",
+        snprintf(buf, sizeof(buf), "{\"busy\": %s, \"progress\": %d}", g_server_busy.load() ? "true" : "false",
                  g_server_progress.load());
         res.set_content(buf, "application/json");
     });


### PR DESCRIPTION
### Description

Adds a pollable progress endpoint to the HTTP server. While a job runs, `do_transcribe` updates a server-side progress value (0..100) in its chunk loop; `GET /progress` returns `{"busy": bool, "progress": -1..100}` (`-1` = idle).

### Motivation

Long-running jobs (ASR transcription, speaker diarization, and every other backend that flows through the chunk loop in `do_transcribe`) are submitted as a single synchronous POST. The server previously had no progress channel over HTTP — the whisper progress callback only printed to stderr, so clients could only show a heartbeat. With `/progress`, any client can poll honest 0..100 progress for the active job.

### What it covers

- **ASR transcription** — chunk-loop progress, 0..100.
- **Speaker diarization and other backends** routed through the same server path — the endpoint is backend-agnostic and reports whatever the active job is doing.
- **Idle state** — `{"busy": false, "progress": -1}` when no job is running.

### Design notes

- One job per container today, so a single pair of atomics is honest. With `--server-workers` concurrency this needs per-request scoping — flagged as future work in the code comment.
- A `progress_scope` guard resets `busy`/`progress` on every exit path (including error returns).

### Verification

- Built locally (ggml native, parakeet-tdt backend) — clean build.
- Smoke-tested: `/health` ok, `/progress` idle `{"busy": false, "progress": -1}`, and during a transcription `{"busy": true, "progress": 0..100}`.
- CI on the fork has not been exercised yet; the change is a single-file additive server change.

*Drafted with assistance from an AI agent (Hermes) on behalf of the contributor.*