### PR TITLE
feat(mel-band-roformer): ggml-graph GPU port with fused single-graph forward (Change 176)

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -864,10 +864,12 @@ All three optimisation gates are output-equivalent: the per-stage diff reports
   bisection arm. The full decision table is unit-locked in
   tests/test-mel-band-gates.cpp.
 - `CRISPASR_MELBAND_SEG_S` — override the Demucs-style segment length in
-  seconds (`params.segment_seconds`; <=0 → default 10 s). The attention
-  matrix is O(T²·bands·heads), so long inputs are split into ~10 s segments
-  with 25% overlap and a triangular weight (bounds VRAM; the unsegmented
-  whole-buffer path OOMs on any clip beyond ~10 s).
+  seconds (`params.segment_seconds`; <=0 → the checkpoint's trained
+  `chunk_size` from GGUF metadata, 8 s Kim fallback — do NOT expect 10 s: the
+  earlier hardcoded 10 s ran RoPE 25% past the trained window, review #422).
+  The attention matrix is O(T²·bands·heads), so long inputs are split into
+  segments with 25% overlap and a triangular weight (bounds VRAM; the
+  unsegmented whole-buffer path OOMs on any clip beyond ~10 s).
 - `CRISPASR_MELBAND_NO_SEGMENT` — process the whole track in one pass instead
   of the segmented overlap-add schedule (A/B against the old behaviour).
 

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -844,7 +844,32 @@ All three optimisation gates are output-equivalent: the per-stage diff reports
 
 ### Mel-Band RoFormer (source separation)
 
-- `CRISPASR_MBR_PROFILE`
+- `CRISPASR_MBR_PROFILE` — print a per-stage wall-time breakdown of one forward
+  pass (stft+pack / band_split / run_time / run_freq / mask_est / synthesize).
+- `CRISPASR_MELBAND_GGML` — run the ggml graph path instead of the legacy CPU
+  path. Since the Change-176 graph port the default is **AUTO**: ON exactly
+  when a real GPU backend is present and permitted (the fused single graph
+  measured ~112x faster than the per-layer graphs — RTF ~0.09 vs ~10 on an
+  RTX 3090 Ti), OFF on CPU-only hosts. `=1`/`=0` force either way.
+- `CRISPASR_MELBAND_GPU` — GPU permission (CUDA > Metal > Vulkan). Default
+  AUTO follows the caller's use_gpu (CLI default on); an explicit `=0`/`=1`
+  beats the caller in both directions — so `=0` genuinely opts out even
+  though the CLI defaults `use_gpu=true` (#414 review semantics). On GPU-less
+  hosts everything resolves to the CPU path regardless.
+- `CRISPASR_MELBAND_FUSED` — single fused graph: band-split + the full
+  time/freq transformer stack + mask estimator on-device in one graph, no
+  per-layer host↔device roundtrips (the measured-fastest path on GPU).
+  Default **AUTO**: ON with the GPU graph path, OFF otherwise. `=1` alone
+  implies the graph path it needs; `=0` on GPU keeps the per-layer-graph
+  bisection arm. The full decision table is unit-locked in
+  tests/test-mel-band-gates.cpp.
+- `CRISPASR_MELBAND_SEG_S` — override the Demucs-style segment length in
+  seconds (`params.segment_seconds`; <=0 → default 10 s). The attention
+  matrix is O(T²·bands·heads), so long inputs are split into ~10 s segments
+  with 25% overlap and a triangular weight (bounds VRAM; the unsegmented
+  whole-buffer path OOMs on any clip beyond ~10 s).
+- `CRISPASR_MELBAND_NO_SEGMENT` — process the whole track in one pass instead
+  of the segmented overlap-add schedule (A/B against the old behaviour).
 
 ### MeloTTS
 

--- a/examples/cli/crispasr_diff_main.cpp
+++ b/examples/cli/crispasr_diff_main.cpp
@@ -1307,6 +1307,11 @@ int main(int argc, char** argv) {
         // diff binary), so the backend shipped with no per-stage evidence.
         return mel_band_roformer_diff(model_path.c_str(), ref_path.c_str(), audio_path.c_str(), /*verbosity=*/2);
     }
+    if (backend_name == "mbr-parity" || backend_name == "mel-band-parity") {
+        // Change 176 Phase 1: standalone graph-vs-CPU band-split parity on a
+        // wav (no Python fixture needed). model_path = GGUF, audio_path = wav.
+        return mel_band_roformer_parity(model_path.c_str(), audio_path.c_str(), /*verbosity=*/2);
+    }
     if (backend_name == "rvc" || backend_name == "rvc-svc") {
         // model_path = rvc GGUF, ref_path = dump from tools/rvc_torch_parity.py.
         // Input-aligned AND noise-aligned: the reference carries input_phone,

--- a/examples/cli/crispasr_separate_cli.cpp
+++ b/examples/cli/crispasr_separate_cli.cpp
@@ -97,6 +97,8 @@ int crispasr_run_separate(const whisper_params& params) {
             // #414: forward the CLI's GPU intent — zero-initialized default
             // params carry use_gpu=false, which silently pinned separation to
             // CPU even on GPU builds (the moonshine "encoder gap" trap).
+            // Graph/fused/segment toggles come from default_params + the
+            // CRISPASR_MELBAND_* env overrides (Change 176), resolved in init.
             auto mp = mel_band_roformer_default_params();
             mp.use_gpu = params.use_gpu;
             mp.n_threads = params.n_threads;

--- a/models/convert-mel-band-roformer-to-gguf.py
+++ b/models/convert-mel-band-roformer-to-gguf.py
@@ -56,6 +56,12 @@ def _load_config(model_dir: Path):
     m.setdefault("stft_n_fft", a.get("n_fft", 2048))
     m.setdefault("stft_hop_length", a.get("hop_length", 441))
     m.setdefault("stft_win_length", a.get("n_fft", 2048))
+    # chunk_size = the inference window the checkpoint was TRAINED on (Kim
+    # vocals: 352800 = 8.0 s @ 44100). The runtime defaults segmentation to it;
+    # a 10 s default would extrapolate RoPE 25% past training (PR #422 review).
+    # Some configs keep it under `audio`; default 0 = omit the KV entirely so
+    # old runtimes fall back to their own 8 s default.
+    m.setdefault("chunk_size", a.get("chunk_size", 0))
     return m
 
 
@@ -153,6 +159,8 @@ def main():
     w.add_uint32("mel-band-roformer.stft_hop_length", hop)
     w.add_uint32("mel-band-roformer.stft_win_length", win)
     w.add_uint32("mel-band-roformer.stft_normalized", 1 if cfg.get("stft_normalized", False) else 0)
+    if cfg.get("chunk_size"):
+        w.add_uint32("mel-band-roformer.chunk_size", int(cfg["chunk_size"]))
     w.add_string("mel-band-roformer.instruments_json",
                  json.dumps(cfg.get("training", {}).get("instruments", ["vocals", "other"])
                             if isinstance(cfg.get("training"), dict) else ["vocals", "other"]))

--- a/src/mel_band_gates.h
+++ b/src/mel_band_gates.h
@@ -1,0 +1,62 @@
+// mel_band_gates.h — path selection for mel-band-roformer (Change 176),
+// pure and unit-testable. Mirrors the htdemucs_gates.h pattern from
+// PR #414 (src/htdemucs_gates.h): the same three coupled decisions,
+// resolved ONCE per init from the environment, the caller's use_gpu intent,
+// and whether a REAL (non-CPU) GPU backend exists.
+//
+//   use_graph   — run the ggml graph path instead of the legacy CPU path
+//   use_fused   — single fused graph (band_split + transformer stack + mask
+//                 estimator on-device, "no roundtrips"); only meaningful when
+//                 use_graph is set
+//   gpu_backend — place the graph on the GPU backend
+//
+// Measured facts the AUTO defaults encode (RTX 3090 Ti, 2026-09-02): the CPU
+// path is RTF ~57 (10 s clip = 9m35s); per-layer graphs on GPU run the same
+// clip in 4:47; the FUSED single graph in 2.6 s (~112x faster than per-layer,
+// RTF ~0.09 on a 359 s song incl. iSTFT). Per-layer graphs still pay a
+// host<->device roundtrip per layer and keep the CPU mask estimator, so AUTO
+// picks graph+fused+GPU exactly when a real GPU is present and permitted,
+// and the plain CPU path otherwise. Never a slower-than-before configuration.
+//
+// Env semantics (each var: unset = AUTO, "0" = force off, else force on):
+//   CRISPASR_MELBAND_GPU    — GPU permission; explicit value beats the
+//                              caller's use_gpu in BOTH directions (expert
+//                              override; the CLI forwards params.use_gpu, so
+//                              "params wins" would make GPU=0 dead — the
+//                              #414 review catch, fix 208b2d59)
+//   CRISPASR_MELBAND_GGML   — graph path (pre-176 opt-in A/B flag)
+//   CRISPASR_MELBAND_FUSED  — fused graph (forced on implies graph unless
+//                              graph is explicitly forced off)
+#pragma once
+
+#include <cstdlib>
+
+namespace mel_band_gates {
+
+struct Resolved {
+    bool use_graph = false;
+    bool use_fused = false;
+    bool gpu_backend = false;
+};
+
+inline Resolved resolve(const char* env_gpu, const char* env_ggml, const char* env_fused, bool caller_use_gpu,
+                        bool have_real_gpu) {
+    bool want_gpu = caller_use_gpu;
+    if (env_gpu && *env_gpu)
+        want_gpu = atoi(env_gpu) != 0;
+    const bool gpu = want_gpu && have_real_gpu;
+
+    Resolved r;
+    const bool ggml_forced = env_ggml && *env_ggml;
+    const bool fused_forced = env_fused && *env_fused;
+    const bool fused_forced_on = fused_forced && atoi(env_fused) != 0;
+
+    r.use_graph =
+        ggml_forced ? (atoi(env_ggml) != 0) : (gpu || fused_forced_on); // FUSED=1 alone implies the graph it needs
+    r.use_fused = fused_forced ? fused_forced_on : gpu;                 // AUTO: fused exactly on GPU
+    r.use_fused = r.use_fused && r.use_graph;                           // fused cannot outlive the graph path
+    r.gpu_backend = gpu && r.use_graph;                                 // CPU path is CPU by construction
+    return r;
+}
+
+} // namespace mel_band_gates

--- a/src/mel_band_roformer.cpp
+++ b/src/mel_band_roformer.cpp
@@ -82,6 +82,7 @@ struct mel_band_roformer_hparams {
     int stereo = 1;
     int audio_channels = 2;
     int sample_rate = 44100;
+    int chunk_size = 0; // trained inference window in samples (Kim vocals: 352800 = 8.0 s @ 44100); 0 = unknown
     int n_fft = 2048;
     int hop = 441;
     int win = 2048;
@@ -261,7 +262,7 @@ mel_band_roformer_params mel_band_roformer_default_params(void) {
     p.n_threads = 0;
     p.use_gpu = false; // CPU path is the default (E2); gates AUTO-upgrade to GPU
     p.gpu_device = 0;
-    p.segment_seconds = 0; // <=0 -> default 10 s (Demucs split for long audio)
+    p.segment_seconds = 0; // <=0 -> trained chunk_size from GGUF (8 s Kim fallback)
     p.no_segment = false;  // segmented forward for >1-segment inputs
     return p;
 }
@@ -297,6 +298,11 @@ mel_band_roformer_context* mel_band_roformer_init_from_file(const char* model_pa
     hp.stereo = (int)core_gguf::kv_u32(meta, "mel-band-roformer.stereo", hp.stereo);
     hp.audio_channels = (int)core_gguf::kv_u32(meta, "mel-band-roformer.audio_channels", hp.audio_channels);
     hp.sample_rate = (int)core_gguf::kv_u32(meta, "mel-band-roformer.sample_rate", hp.sample_rate);
+    // Trained inference window (samples). The converter writes it when the
+    // checkpoint config carries it; 0 = absent -> the 8 s Kim fallback in
+    // mel_band_roformer_separate. Segmentation at the TRAINED chunk matters:
+    // 10 s would run the time-transformer's RoPE 25% past training (review #422).
+    hp.chunk_size = (int)core_gguf::kv_u32(meta, "mel-band-roformer.chunk_size", hp.chunk_size);
     hp.n_fft = (int)core_gguf::kv_u32(meta, "mel-band-roformer.stft_n_fft", hp.n_fft);
     hp.hop = (int)core_gguf::kv_u32(meta, "mel-band-roformer.stft_hop_length", hp.hop);
     hp.win = (int)core_gguf::kv_u32(meta, "mel-band-roformer.stft_win_length", hp.win);
@@ -1670,8 +1676,11 @@ mel_band_roformer_result* mel_band_roformer_separate(mel_band_roformer_context* 
     const int channels = ctx->hp.audio_channels;
 
     // Segmented forward for long audio (Demucs split=True pattern). Segment
-    // length from params.segment_seconds (<=0 -> 10 s default: hop=441 =>
-    // ~1001 STFT frames => ~2 GB attention scores on GPU; well under 24 GB).
+    // length from params.segment_seconds; <=0 -> the checkpoint's TRAINED
+    // chunk (GGUF chunk_size, Kim vocals 352800 = 8.0 s @ 44100; fallback 8 s
+    // when the GGUF predates the metadata). Review #422: the earlier hardcoded
+    // 10 s default ran the time-transformer's RoPE positions 25% past anything
+    // seen in training on every segment of long audio.
     // Env overrides for CLI A/B: CRISPASR_MELBAND_SEG_S, CRISPASR_MELBAND_NO_SEGMENT.
     int seg_s = ctx->params.segment_seconds;
     if (const char* seg_env = std::getenv("CRISPASR_MELBAND_SEG_S")) {
@@ -1682,7 +1691,11 @@ mel_band_roformer_result* mel_band_roformer_separate(mel_band_roformer_context* 
     bool no_seg = ctx->params.no_segment;
     if (const char* ns_env = std::getenv("CRISPASR_MELBAND_NO_SEGMENT"))
         no_seg = ns_env[0] && atoi(ns_env) != 0;
-    const int seg_len = (seg_s > 0 ? seg_s : 10) * ctx->hp.sample_rate;
+    // Default segment: the checkpoint's trained chunk. hp.chunk_size is in
+    // samples; 8 s is the Kim vocals chunk (352800 @ 44100) for GGUFs that
+    // predate the metadata (review #422: 10 s extrapolated RoPE).
+    const int default_seg_s = ctx->hp.chunk_size > 0 ? ctx->hp.chunk_size / ctx->hp.sample_rate : 8;
+    const int seg_len = (seg_s > 0 ? seg_s : default_seg_s) * ctx->hp.sample_rate;
     if (no_seg || n_samples <= seg_len || seg_len <= 0)
         return mel_band_roformer_separate_full(ctx, pcm, n_samples, in_channels);
 

--- a/src/mel_band_roformer.cpp
+++ b/src/mel_band_roformer.cpp
@@ -13,6 +13,8 @@
 
 #include "mel_band_roformer.h"
 
+#include "mel_band_gates.h" // Change 176: graph/fused/GPU path selection (PR #414 pattern)
+
 #include "ggml-backend.h"
 #include "ggml-alloc.h" // ggml_gallocr_* (Change 176: band-split ggml graph path)
 #include "ggml-cpu.h"
@@ -89,7 +91,9 @@ struct mel_band_roformer_context {
 
     // Change 176: band-split runs as a ggml graph on `backend` (GPU-capable)
     // when use_graph is set; otherwise the validated CPU reference path runs.
+    // use_fused (Phase 5): the whole network runs as ONE fused graph.
     bool use_graph = false;
+    bool use_fused = false;
     bool is_gpu = false;
 
     // Baked band layout (from the converter's aux.* int32 tensors).
@@ -249,8 +253,10 @@ void rms_norm_inplace(float* x, int dim, const float* gamma) {
 mel_band_roformer_params mel_band_roformer_default_params(void) {
     mel_band_roformer_params p;
     p.n_threads = 0;
-    p.use_gpu = false; // CPU front-end in Phase 1
+    p.use_gpu = false; // CPU path is the default (E2); gates AUTO-upgrade to GPU
     p.gpu_device = 0;
+    p.segment_seconds = 0;  // <=0 -> default 10 s (Demucs split for long audio)
+    p.no_segment = false;   // segmented forward for >1-segment inputs
     return p;
 }
 
@@ -291,38 +297,52 @@ mel_band_roformer_context* mel_band_roformer_init_from_file(const char* model_pa
     hp.normalized = (int)core_gguf::kv_u32(meta, "mel-band-roformer.stft_normalized", hp.normalized);
     core_gguf::free_metadata(meta);
 
-    // Change 176: backend selection honours params.use_gpu + CRISPASR_MELBAND_GPU,
-    // mirroring the htdemucs pattern (src/htdemucs.cpp:635-662). The ggml graph
-    // path is the gate to the GPU backend: want_gpu WITHOUT the graph path would
-    // put the weights on the GPU and pay a device->host read on every scalar
-    // kernel (htdemucs lesson). CRISPASR_MELBAND_GGML=1 enables the graph band-
-    // split; CRISPASR_MELBAND_GPU=1 forces the GPU backend (falls back to CPU on
-    // GPU-less hosts), =0 forces CPU. Default: CPU backend + CPU reference path
-    // (no behavior change for existing users until parity is green, E2).
-    const char* ggml_env = getenv("CRISPASR_MELBAND_GGML");
-    const bool want_graph = ggml_env && ggml_env[0] && atoi(ggml_env) != 0;
-    bool want_gpu = false;
-    const char* gpu_env = getenv("CRISPASR_MELBAND_GPU");
-    if (gpu_env && gpu_env[0])
-        want_gpu = atoi(gpu_env) != 0;
-    if (params.use_gpu)
-        want_gpu = true;
-    if (want_graph && want_gpu) {
-        ctx->backend = crispasr_init_gpu_backend();
+    // Change 176: backend selection mirrors the htdemucs pattern from PR #414
+    // (src/htdemucs_gates.h): gates are resolved ONCE here by mel_band_gates::
+    // resolve() from the env, the caller's use_gpu intent, and whether a REAL
+    // (non-CPU) GPU backend exists. AUTO = fused single graph on the GPU when
+    // a real GPU is present and permitted (the measured-fastest path, ~112x
+    // the per-layer graphs), legacy CPU path otherwise — CPU-only hosts see no
+    // behaviour change. Explicit envs (CRISPASR_MELBAND_GPU/GGML/FUSED) force
+    // either way; FUSED=1 implies the graph it needs. Env beats caller intent
+    // in both directions (the #414 review catch).
+    ggml_backend_t gpu_probe = nullptr;
+    {
+        // Skip the probe when GPU is explicitly forbidden — a CUDA context
+        // spin-up is not free and the answer would be discarded.
+        const char* e = getenv("CRISPASR_MELBAND_GPU");
+        const bool may_gpu = (e && *e) ? atoi(e) != 0 : params.use_gpu;
+        if (may_gpu) {
+            gpu_probe = crispasr_init_gpu_backend();
+            if (gpu_probe && core_cpu_backend::is_cpu(gpu_probe)) {
+                ggml_backend_free(gpu_probe);
+                gpu_probe = nullptr;
+            }
+        }
+    }
+    const mel_band_gates::Resolved gates = mel_band_gates::resolve(
+        getenv("CRISPASR_MELBAND_GPU"), getenv("CRISPASR_MELBAND_GGML"), getenv("CRISPASR_MELBAND_FUSED"),
+        params.use_gpu, gpu_probe != nullptr);
+    if (gates.use_graph) {
+        ctx->backend = gates.gpu_backend ? gpu_probe : core_cpu_backend::init();
         if (!ctx->backend)
             ctx->backend = core_cpu_backend::init();
     } else {
         ctx->backend = core_cpu_backend::init();
     }
+    if (gpu_probe && ctx->backend != gpu_probe)
+        ggml_backend_free(gpu_probe);
     if (!ctx->backend) {
         fprintf(stderr, "mel_band_roformer: backend init failed\n");
         delete ctx;
         return nullptr;
     }
-    ctx->use_graph = want_graph;
+    ctx->use_graph = gates.use_graph;
+    ctx->use_fused = gates.use_fused;
     ctx->is_gpu = !core_cpu_backend::is_cpu(ctx->backend);
-    fprintf(stderr, "mel_band_roformer: backend = %s (graph=%d, gpu=%d)\n", ggml_backend_name(ctx->backend),
-            ctx->use_graph ? 1 : 0, ctx->is_gpu ? 1 : 0);
+    fprintf(stderr, "mel_band_roformer: gates graph=%d fused=%d gpu=%d (real_gpu_present=%d)\n",
+            (int)gates.use_graph, (int)gates.use_fused, (int)gates.gpu_backend, (int)(gpu_probe != nullptr));
+    fprintf(stderr, "mel_band_roformer: backend = %s\n", ggml_backend_name(ctx->backend));
     if (!core_gguf::load_weights(model_path, ctx->backend, "mel_band_roformer", ctx->weights)) {
         fprintf(stderr, "mel_band_roformer: failed to load weights from '%s'\n", model_path);
         mel_band_roformer_free(ctx);
@@ -485,11 +505,85 @@ bool band_split_cpu(core_gguf::WeightLoad& mw, const std::vector<float>& gathere
 // band_split_cpu's row-major (T, nb, dim) index ((t*nb + b)*dim + o). The graph
 // result can therefore be handed straight to the transformer stack unchanged.
 // ---------------------------------------------------------------------------
+
+// Tensor-building half of band_split_graph: creates the per-band RMSNorm
+// eps/sqrt_dim input tensors in `g` and returns the balanced-concat (dim, nb, T)
+// tensor. Used by band_split_graph (own context + run) AND by the Phase-5 FUSED
+// single graph (shared context), so both paths build byte-identical chains.
+// `in` is the (N2, T) gathered input tensor of the same context.
+static ggml_tensor* mbr_band_split_build(mel_band_roformer_context* ctx, ggml_context* g, ggml_tensor* in, int T,
+                                         ggml_tensor** eps_out, std::vector<ggml_tensor*>& sqrt_dim_ts) {
+    const int nb = (int)ctx->band_width.size();
+    const int dim = ctx->hp.dim;
+
+    ggml_tensor* eps_t = ggml_new_tensor_1d(g, GGML_TYPE_F32, 1);
+    ggml_set_name(eps_t, "mbr_rms_eps");
+    ggml_set_input(eps_t);
+    if (eps_out)
+        *eps_out = eps_t;
+
+    std::vector<ggml_tensor*> bands;
+    bands.reserve((size_t)nb);
+    sqrt_dim_ts.clear();
+    sqrt_dim_ts.reserve((size_t)nb);
+
+    int off = 0;
+    for (int b = 0; b < nb; b++) {
+        const int din = ctx->band_width[b];
+        const std::string pre = "band_split.to_features." + std::to_string(b);
+
+        auto it_g = ctx->weights.tensors.find(pre + ".0.gamma");
+        auto it_w = ctx->weights.tensors.find(pre + ".1.weight");
+        auto it_b = ctx->weights.tensors.find(pre + ".1.bias");
+        if (it_g == ctx->weights.tensors.end() || it_w == ctx->weights.tensors.end() ||
+            it_b == ctx->weights.tensors.end() || !it_g->second || !it_w->second || !it_b->second)
+            return nullptr;
+
+        // Band b's slice: rows [off, off+din) of the (N2, T) input.
+        ggml_tensor* xv = ggml_view_2d(g, in, din, T, in->nb[1], (size_t)off * sizeof(float));
+        off += din;
+
+        // RMSNorm — exact CPU formula: y = x * sqrt(din) / (sqrt(sum(x^2)) + eps) * gamma.
+        ggml_tensor* sq = ggml_mul(g, xv, xv);                     // (din, T)
+        ggml_tensor* ss = ggml_sum_rows(g, sq);                    // (1, T)
+        ggml_tensor* rt = ggml_sqrt(g, ss);                        // (1, T)
+        ggml_tensor* denom = ggml_add(g, rt, eps_t);               // (1, T)
+        ggml_tensor* sqrt_dim_t = ggml_new_tensor_1d(g, GGML_TYPE_F32, 1);
+        ggml_set_name(sqrt_dim_t, ("mbr_rms_sqrt_dim_" + std::to_string(b)).c_str());
+        ggml_set_input(sqrt_dim_t);
+        sqrt_dim_ts.push_back(sqrt_dim_t);
+        ggml_tensor* scale = ggml_div(g, ggml_repeat(g, sqrt_dim_t, denom), denom); // (1, T)
+        ggml_tensor* xn = ggml_mul(g, xv, scale);                  // (din, T) broadcast
+        ggml_tensor* y = ggml_mul(g, xn, it_g->second);            // * gamma (din, 1) broadcast
+
+        // Linear: mul_mat(weight (din, dim), y (din, T)) -> (dim, T); + bias
+        ggml_tensor* proj = ggml_mul_mat(g, it_w->second, y);
+        ggml_tensor* bout = ggml_add(g, proj, it_b->second);
+
+        // (dim, 1, T) for the band-axis concat below.
+        ggml_tensor* b3 = ggml_reshape_3d(g, bout, dim, 1, T);
+        ggml_set_name(b3, ("band_split." + std::to_string(b)).c_str());
+        bands.push_back(b3);
+    }
+
+    // Balanced concat along the band axis (BSRoformer ConcatBalanced pattern) ->
+    // (dim, nb, T). Its flat order equals (T, nb, dim) row-major (see above).
+    auto concat_balanced = [&](auto&& self, size_t lo, size_t hi) -> ggml_tensor* {
+        if (hi - lo == 1)
+            return bands[lo];
+        const size_t mid = lo + (hi - lo) / 2;
+        ggml_tensor* a = self(self, lo, mid);
+        ggml_tensor* b = self(self, mid, hi);
+        return ggml_concat(g, a, b, 1);
+    };
+    ggml_tensor* out3 = concat_balanced(concat_balanced, 0, bands.size());
+    ggml_set_name(out3, "mbr_band_split_out");
+    return out3;
+}
+
 bool band_split_graph(mel_band_roformer_context* ctx, const std::vector<float>& gathered, int T,
                       std::vector<float>& out) {
-    const auto& hp = ctx->hp;
     const int nb = (int)ctx->band_width.size();
-    const int dim = hp.dim;
     const int N2 = (int)ctx->freq_indices.size() * 2; // gathered feature axis width
 
     if ((int64_t)gathered.size() != (int64_t)T * N2)
@@ -513,77 +607,14 @@ bool band_split_graph(mel_band_roformer_context* ctx, const std::vector<float>& 
     ggml_set_name(in, "mbr_band_split_in");
     ggml_set_input(in);
 
-    std::vector<ggml_tensor*> bands;
-    bands.reserve((size_t)nb);
+    ggml_tensor* eps_t = nullptr;
     std::vector<ggml_tensor*> sqrt_dim_ts;
-    sqrt_dim_ts.reserve((size_t)nb);
-
-    // RMSNorm constants (F.normalize eps, sqrt(dim) scale) as 1-element INPUT
-    // tensors: ggml_new_f32 asserts !no_alloc, and the graph context must be
-    // no_alloc so gallocr can place intermediates on the backend buffer. Values
-    // are written once via ggml_backend_tensor_set before compute (htdemucs
-    // pattern). Broadcast to (1, T) via ggml_can_repeat in the binops below.
-    ggml_tensor* eps_t = ggml_new_tensor_1d(gctx, GGML_TYPE_F32, 1);
-    ggml_set_name(eps_t, "mbr_rms_eps");
-    ggml_set_input(eps_t);
-
-    int off = 0;
-    for (int b = 0; b < nb; b++) {
-        const int din = ctx->band_width[b];
-        const std::string pre = "band_split.to_features." + std::to_string(b);
-
-        auto it_g = ctx->weights.tensors.find(pre + ".0.gamma");
-        auto it_w = ctx->weights.tensors.find(pre + ".1.weight");
-        auto it_b = ctx->weights.tensors.find(pre + ".1.bias");
-        if (it_g == ctx->weights.tensors.end() || it_w == ctx->weights.tensors.end() ||
-            it_b == ctx->weights.tensors.end() || !it_g->second || !it_w->second || !it_b->second) {
-            ggml_free(gctx);
-            return false;
-        }
-
-        // Band b's slice: rows [off, off+din) of the (2N, T) input.
-        ggml_tensor* xv = ggml_view_2d(gctx, in, din, T, in->nb[1], (size_t)off * sizeof(float));
-        off += din;
-
-        // RMSNorm — exact CPU formula: y = x * sqrt(din) / (sqrt(sum(x^2)) + eps) * gamma.
-        // NOTE: the sqrt scale uses the BAND's input width din (CPU rms_norm_inplace
-        // gets din), NOT the model dim — a global sqrt(hp.dim) scaled every band
-        // differently and broke parity (cos=0.877, |graph|/|cpu| ~2.1).
-        ggml_tensor* sq = ggml_mul(gctx, xv, xv);                     // (din, T)
-        ggml_tensor* ss = ggml_sum_rows(gctx, sq);                    // (1, T)
-        ggml_tensor* rt = ggml_sqrt(gctx, ss);                        // (1, T)
-        ggml_tensor* denom = ggml_add(gctx, rt, eps_t);               // (1, T)
-        // div(a,b) takes a's shape and repeats b to it — repeat sqrt_dim to (1,T) first.
-        ggml_tensor* sqrt_dim_t = ggml_new_tensor_1d(gctx, GGML_TYPE_F32, 1);
-        ggml_set_name(sqrt_dim_t, ("mbr_rms_sqrt_dim_" + std::to_string(b)).c_str());
-        ggml_set_input(sqrt_dim_t);
-        sqrt_dim_ts.push_back(sqrt_dim_t);
-        ggml_tensor* scale = ggml_div(gctx, ggml_repeat(gctx, sqrt_dim_t, denom), denom); // (1, T)
-        ggml_tensor* xn = ggml_mul(gctx, xv, scale);                  // (din, T) broadcast
-        ggml_tensor* y = ggml_mul(gctx, xn, it_g->second);            // * gamma (din, 1) broadcast
-
-        // Linear: mul_mat(weight (din, dim), y (din, T)) -> (dim, T); + bias
-        ggml_tensor* proj = ggml_mul_mat(gctx, it_w->second, y);
-        ggml_tensor* bout = ggml_add(gctx, proj, it_b->second);
-
-        // (dim, 1, T) for the band-axis concat below.
-        ggml_tensor* b3 = ggml_reshape_3d(gctx, bout, dim, 1, T);
-        ggml_set_name(b3, ("band_split." + std::to_string(b)).c_str());
-        bands.push_back(b3);
+    ggml_tensor* out3 = mbr_band_split_build(ctx, gctx, in, T, &eps_t, sqrt_dim_ts);
+    if (!out3) {
+        ggml_free(gctx);
+        return false;
     }
 
-    // Balanced concat along the band axis (BSRoformer ConcatBalanced pattern) ->
-    // (dim, nb, T). Its flat order equals (T, nb, dim) row-major (see above).
-    auto concat_balanced = [&](auto&& self, size_t lo, size_t hi) -> ggml_tensor* {
-        if (hi - lo == 1)
-            return bands[lo];
-        const size_t mid = lo + (hi - lo) / 2;
-        ggml_tensor* a = self(self, lo, mid);
-        ggml_tensor* b = self(self, mid, hi);
-        return ggml_concat(gctx, a, b, 1);
-    };
-    ggml_tensor* out3 = concat_balanced(concat_balanced, 0, bands.size());
-    ggml_set_name(out3, "mbr_band_split_out");
     ggml_set_output(out3);
 
     ggml_cgraph* gf = ggml_new_graph_custom(gctx, (size_t)n_nodes, false);
@@ -1243,6 +1274,208 @@ void synthesize(mel_band_roformer_context* ctx, const std::vector<float>& packed
     }
 }
 
+// ---------------------------------------------------------------------------
+// Change 176 (Phase 5): FUSED single graph — band_split + the full
+// time/freq transformer stack + mask estimator in ONE ggml graph ("no
+// roundtrips", htdemucs ee2585b64 pattern). The per-layer path
+// (band_split_graph + 12× mbr_layer_graph) pays a host<->device roundtrip per
+// layer (~2×370 MB PCIe per layer) plus CPU host phases; the fused graph keeps
+// every intermediate on the backend and returns only mask_raw.
+//
+// Input: gathered (T, 2N) row-major (== ggml (2N, T), no copy).
+// Output: mask_raw exactly as the CPU mask_estimator produces it — (T, total)
+// row-major flat, total = Σ band_width[b] == 2N — ready for synthesize().
+//
+// Weights come straight from ctx->weights.tensors (load context), same as the
+// per-layer graphs. eps/sqrt_dim/positions are shared 1-element INPUT tensors
+// created once in this context (values constant across all 12 blocks).
+// ---------------------------------------------------------------------------
+static bool mbr_fused_graph(mel_band_roformer_context* ctx, const std::vector<float>& gathered, int T,
+                            std::vector<float>& mask_raw) {
+    const auto& hp = ctx->hp;
+    const int nb = (int)ctx->band_width.size();
+    const int dim = hp.dim, heads = hp.heads, dim_head = hp.dim_head;
+    const int N2 = (int)ctx->freq_indices.size() * 2;
+
+    if ((int64_t)gathered.size() != (int64_t)T * N2)
+        return false;
+
+    auto find = [&](const char* name) -> ggml_tensor* {
+        auto it = ctx->weights.tensors.find(name);
+        return (it == ctx->weights.tensors.end()) ? nullptr : it->second;
+    };
+
+    // Graph budget: band_split (~16·nb), 12 transformer blocks (~150 each) and
+    // the per-band mask MLPs (~15·nb) — ~3500 ops total; 16k gives headroom for
+    // views/permutes (htdemucs fused uses the same budget).
+    const size_t n_nodes = 16384;
+    ggml_init_params gparams = {
+        /*.mem_size   = */ ggml_tensor_overhead() * n_nodes + ggml_graph_overhead_custom(n_nodes, false),
+        /*.mem_buffer = */ nullptr,
+        /*.no_alloc   = */ true,
+    };
+    ggml_context* gctx = ggml_init(gparams);
+    if (!gctx)
+        return false;
+
+    ggml_tensor* in = ggml_new_tensor_2d(gctx, GGML_TYPE_F32, N2, T);
+    ggml_set_name(in, "mbr_fused_in");
+    ggml_set_input(in);
+
+    // Shared layer constants: eps (F.normalize), sqrt(dim) scale, and the two
+    // position vectors (time blocks attend over T frames, freq over nb bands).
+    ggml_tensor* eps_t = ggml_new_tensor_1d(gctx, GGML_TYPE_F32, 1);
+    ggml_set_name(eps_t, "mbr_fused_eps");
+    ggml_set_input(eps_t);
+    ggml_tensor* sqrt_dim_t = ggml_new_tensor_1d(gctx, GGML_TYPE_F32, 1);
+    ggml_set_name(sqrt_dim_t, "mbr_fused_sqrt_dim");
+    ggml_set_input(sqrt_dim_t);
+    ggml_tensor* pos_time_t = ggml_new_tensor_1d(gctx, GGML_TYPE_I32, T);
+    ggml_set_name(pos_time_t, "mbr_fused_pos_time");
+    ggml_set_input(pos_time_t);
+    ggml_tensor* pos_freq_t = ggml_new_tensor_1d(gctx, GGML_TYPE_I32, nb);
+    ggml_set_name(pos_freq_t, "mbr_fused_pos_freq");
+    ggml_set_input(pos_freq_t);
+
+    // ---- band split (Phase 1 chain, same builder as the standalone graph) ----
+    std::vector<ggml_tensor*> bs_sqrt;
+    ggml_tensor* bs_eps = nullptr;
+    ggml_tensor* x = mbr_band_split_build(ctx, gctx, in, T, &bs_eps, bs_sqrt);
+    if (!x || !bs_eps) {
+        fprintf(stderr, "mel_band_roformer: fused band_split build failed (missing weight?)\n");
+        ggml_free(gctx);
+        return false;
+    }
+    // x is (dim, nb, T): ne0=dim, ne1=nb (bands), ne2=T (frames).
+
+    // ---- transformer stack: depth × (time block, freq block) ----
+    for (int L = 0; L < hp.depth; L++) {
+        // time: seq over frames (S=T on ne1, batch=nb on ne2) — permute in/out.
+        ggml_tensor* xt = ggml_cont(gctx, ggml_permute(gctx, x, 0, 2, 1, 3)); // (dim, T, nb)
+        ggml_tensor* yt = mbr_block_layer_graph(ctx, gctx, ("layers." + std::to_string(L) + ".0.").c_str(), xt, T,
+                                                nb, dim, heads, dim_head, eps_t, sqrt_dim_t, pos_time_t);
+        if (!yt) {
+            fprintf(stderr, "mel_band_roformer: fused time layer %d build failed (missing weight?)\n", L);
+            ggml_free(gctx);
+            return false;
+        }
+        x = ggml_cont(gctx, ggml_permute(gctx, yt, 0, 2, 1, 3)); // back to (dim, nb, T)
+
+        // freq: seq over bands — (dim, nb, T) already has S=nb on ne1, B=T on ne2.
+        x = mbr_block_layer_graph(ctx, gctx, ("layers." + std::to_string(L) + ".1.").c_str(), x, nb, T, dim, heads,
+                                  dim_head, eps_t, sqrt_dim_t, pos_freq_t);
+        if (!x) {
+            fprintf(stderr, "mel_band_roformer: fused freq layer %d build failed (missing weight?)\n", L);
+            ggml_free(gctx);
+            return false;
+        }
+    }
+
+    // ---- mask estimator (per-band Tanh MLP → GLU), Phase 3 in-graph ----
+    // CPU reads band b as in[t][d] = x[(t*nb + b)*dim + d]. After permuting the
+    // final (dim, nb, T) to (dim, T, nb), band b is a contiguous (dim, T) plane
+    // (same flat order), so each band's MLP reads a plain view — no per-band
+    // scatter/copy. Outputs concat along the width axis in band order → (total, T),
+    // flat-identical to the CPU (T, total) row-major mask_raw.
+    ggml_tensor* xm = ggml_cont(gctx, ggml_permute(gctx, x, 0, 2, 1, 3)); // (dim, T, nb)
+    std::vector<ggml_tensor*> masks;
+    masks.reserve((size_t)nb);
+    int total = 0;
+    for (int b = 0; b < nb; b++) {
+        const std::string pre = "mask_estimators.0.to_freqs." + std::to_string(b) + ".0.";
+        ggml_tensor* w0 = find((pre + "0.weight").c_str());
+        ggml_tensor* b0 = find((pre + "0.bias").c_str());
+        ggml_tensor* w2 = find((pre + "2.weight").c_str());
+        ggml_tensor* b2 = find((pre + "2.bias").c_str());
+        ggml_tensor* w4 = find((pre + "4.weight").c_str());
+        ggml_tensor* b4 = find((pre + "4.bias").c_str());
+        if (!w0 || !b0 || !w2 || !b2 || !w4 || !b4) {
+            fprintf(stderr, "mel_band_roformer: fused mask estimator band %d build failed (missing weight?)\n", b);
+            ggml_free(gctx);
+            return false;
+        }
+        const int hid = (int)b0->ne[0];
+        const int din2 = (int)b4->ne[0]; // 2 * band width
+        const int din = din2 / 2;
+        if (din != ctx->band_width[b]) {
+            fprintf(stderr,
+                    "mel_band_roformer: fused mask band %d width mismatch (weight=%d band_width=%d)\n", b, din,
+                    ctx->band_width[b]);
+            ggml_free(gctx);
+            return false;
+        }
+        total += din;
+
+        // contiguous (dim, T) plane of band b inside (dim, T, nb).
+        ggml_tensor* xb = ggml_view_2d(gctx, xm, dim, T, xm->nb[1], (size_t)b * dim * T * sizeof(float));
+
+        ggml_tensor* a = ggml_mul_mat(gctx, w0, xb); // (hid, T)
+        a = ggml_add(gctx, a, b0);
+        a = ggml_tanh(gctx, a);
+        ggml_tensor* c = ggml_mul_mat(gctx, w2, a); // (hid, T)
+        c = ggml_add(gctx, c, b2);
+        c = ggml_tanh(gctx, c);
+        ggml_tensor* e = ggml_mul_mat(gctx, w4, c); // (din2, T)
+        e = ggml_add(gctx, e, b4);
+        // GLU(-1): e[:din] * sigmoid(e[din:])
+        ggml_tensor* e1 = ggml_view_2d(gctx, e, din, T, e->nb[1], 0);
+        ggml_tensor* e2 = ggml_view_2d(gctx, e, din, T, e->nb[1], (size_t)din * sizeof(float));
+        ggml_tensor* m = ggml_mul(gctx, e1, ggml_sigmoid(gctx, e2)); // (din, T)
+        masks.push_back(m);
+    }
+
+    // Balanced concat over the width axis (ne0) in band order -> (total, T).
+    auto concat_w = [&](auto&& self, size_t lo, size_t hi) -> ggml_tensor* {
+        if (hi - lo == 1)
+            return masks[lo];
+        const size_t mid = lo + (hi - lo) / 2;
+        ggml_tensor* a = self(self, lo, mid);
+        ggml_tensor* b = self(self, mid, hi);
+        return ggml_concat(gctx, a, b, 0);
+    };
+    ggml_tensor* out = concat_w(concat_w, 0, masks.size());
+    ggml_set_name(out, "mbr_fused_mask_out");
+    ggml_set_output(out);
+
+    ggml_cgraph* gf = ggml_new_graph_custom(gctx, n_nodes, false);
+    ggml_build_forward_expand(gf, out);
+
+    ggml_gallocr_t alloc = ggml_gallocr_new(ggml_backend_get_default_buffer_type(ctx->backend));
+    if (!alloc || !ggml_gallocr_alloc_graph(alloc, gf)) {
+        fprintf(stderr, "mel_band_roformer: fused graph gallocr alloc failed\n");
+        if (alloc)
+            ggml_gallocr_free(alloc);
+        ggml_free(gctx);
+        return false;
+    }
+
+    ggml_backend_tensor_set(in, gathered.data(), 0, gathered.size() * sizeof(float));
+    const float eps = 1e-12f, sd = std::sqrt((float)dim);
+    ggml_backend_tensor_set(bs_eps, &eps, 0, sizeof(float)); // band-split RMS eps
+    ggml_backend_tensor_set(eps_t, &eps, 0, sizeof(float));  // transformer-block RMS eps
+    ggml_backend_tensor_set(sqrt_dim_t, &sd, 0, sizeof(float));
+    std::vector<int32_t> pos_tb((size_t)T), pos_fb((size_t)nb);
+    for (int i = 0; i < T; i++)
+        pos_tb[(size_t)i] = i;
+    for (int i = 0; i < nb; i++)
+        pos_fb[(size_t)i] = i;
+    ggml_backend_tensor_set(pos_time_t, pos_tb.data(), 0, (size_t)T * sizeof(int32_t));
+    ggml_backend_tensor_set(pos_freq_t, pos_fb.data(), 0, (size_t)nb * sizeof(int32_t));
+    for (size_t b = 0; b < bs_sqrt.size(); b++) {
+        const float sqrt_dim = std::sqrt((float)ctx->band_width[b]);
+        ggml_backend_tensor_set(bs_sqrt[b], &sqrt_dim, 0, sizeof(float));
+    }
+    ggml_backend_graph_compute(ctx->backend, gf);
+
+    const int64_t n = ggml_nelements(out);
+    mask_raw.resize((size_t)n);
+    ggml_backend_tensor_get(out, mask_raw.data(), 0, (size_t)n * sizeof(float));
+
+    ggml_gallocr_free(alloc);
+    ggml_free(gctx);
+    return true;
+}
+
 // Full validated forward on real per-channel PCM (chan[s] has T_samp samples).
 // Produces the vocal stem interleaved (channels-interleaved, T_samp frames).
 bool run_forward(mel_band_roformer_context* ctx, const std::vector<std::vector<float>>& chan, int T_samp,
@@ -1282,6 +1515,20 @@ bool run_forward(mel_band_roformer_context* ctx, const std::vector<std::vector<f
     lap("stft+pack");
     std::vector<float> gathered;
     band_gather(packed, ctx->freq_indices, T, gathered);
+    std::vector<float> mask_raw;
+
+    if (ctx->use_graph && ctx->use_fused) {
+        // Change 176 (Phase 5): the WHOLE network forward — band_split + all
+        // depth×(time,freq) blocks + mask estimator — runs as ONE ggml graph on
+        // ctx->backend ("no roundtrips", htdemucs ee2585b64 pattern). No
+        // per-layer host<->device copies and no CPU mask estimator: gathered in,
+        // mask_raw out. synthesize() (complex mask + iSTFT) stays CPU (E3).
+        if (!mbr_fused_graph(ctx, gathered, T, mask_raw)) {
+            fprintf(stderr, "mel_band_roformer: fused graph failed\n");
+            return false;
+        }
+        lap("fused_graph");
+    } else {
     std::vector<float> x;
     bool bs_ok;
     if (ctx->use_graph) {
@@ -1334,10 +1581,10 @@ bool run_forward(mel_band_roformer_context* ctx, const std::vector<std::vector<f
     if (prof)
         fprintf(stderr, "  [mbr-prof] run_time(all)  %7.0f ms\n  [mbr-prof] run_freq(all)  %7.0f ms\n", t_time, t_freq);
     tick = clk::now();
-    std::vector<float> mask_raw;
     if (!mask_estimator(ctx->weights, x, T, nb, dim, ctx->band_width, mask_raw))
         return false;
     lap("mask_est");
+    } // else: per-layer graph / CPU reference path
     std::vector<float> out_planar; // channels * T_samp
     synthesize(ctx, packed, mask_raw, T, T_samp, out_planar);
     lap("synthesize");
@@ -1417,16 +1664,20 @@ mel_band_roformer_result* mel_band_roformer_separate(mel_band_roformer_context* 
         return nullptr;
     const int channels = ctx->hp.audio_channels;
 
-    // 10 s segment at the model sample rate (hop=441 => ~1001 STFT frames =>
-    // ~2 GB attention scores on GPU; well under the 24 GB RTX 3090).
-    // CRISPASR_MELBAND_SEG_S overrides the segment length in seconds (tests).
-    int seg_len = 10 * ctx->hp.sample_rate;
-    if (const char* seg_s = std::getenv("CRISPASR_MELBAND_SEG_S")) {
-        int s = atoi(seg_s);
+    // Segmented forward for long audio (Demucs split=True pattern). Segment
+    // length from params.segment_seconds (<=0 -> 10 s default: hop=441 =>
+    // ~1001 STFT frames => ~2 GB attention scores on GPU; well under 24 GB).
+    // Env overrides for CLI A/B: CRISPASR_MELBAND_SEG_S, CRISPASR_MELBAND_NO_SEGMENT.
+    int seg_s = ctx->params.segment_seconds;
+    if (const char* seg_env = std::getenv("CRISPASR_MELBAND_SEG_S")) {
+        int s = atoi(seg_env);
         if (s > 0)
-            seg_len = s * ctx->hp.sample_rate;
+            seg_s = s;
     }
-    const bool no_seg = std::getenv("CRISPASR_MELBAND_NO_SEGMENT") != nullptr;
+    bool no_seg = ctx->params.no_segment;
+    if (const char* ns_env = std::getenv("CRISPASR_MELBAND_NO_SEGMENT"))
+        no_seg = ns_env[0] && atoi(ns_env) != 0;
+    const int seg_len = (seg_s > 0 ? seg_s : 10) * ctx->hp.sample_rate;
     if (no_seg || n_samples <= seg_len || seg_len <= 0)
         return mel_band_roformer_separate_full(ctx, pcm, n_samples, in_channels);
 
@@ -1649,6 +1900,30 @@ int mel_band_roformer_parity(const char* model_gguf, const char* audio_wav, int 
             report("layer0_freq_graph", cpu_x, graph_x);
         else
             fprintf(stderr, "  layer0_freq_graph: SKIP (run failed)\n");
+    }
+
+    // Change 176 Phase 5: FUSED single graph vs the complete CPU chain. The CPU
+    // path runs band_split_cpu + all depth×(time,freq) blocks + the CPU mask
+    // estimator on identical input; the graph runs mbr_fused_graph (the whole
+    // network as ONE graph). mask_raw is the graph's final output, so this is
+    // the full-forward parity gate for Phase 5 — no per-layer host roundtrips
+    // allowed to change the result. (synthesize/iSTFT is CPU in both paths and
+    // excluded here; the E2E vocal-stem check covers it.)
+    {
+        std::vector<float> cpu_mask, fused_mask;
+        bool cpu_chain_ok = true;
+        {
+            std::vector<float> x = cpu_out;
+            for (int L = 0; L < hp.depth && cpu_chain_ok; L++)
+                cpu_chain_ok = run_time(ctx->weights, L, x, T, nb, dim, heads, dim_head) &&
+                               run_freq(ctx->weights, L, x, T, nb, dim, heads, dim_head);
+            cpu_chain_ok = cpu_chain_ok && mask_estimator(ctx->weights, x, T, nb, dim, ctx->band_width, cpu_mask);
+        }
+        const bool fused_ok = mbr_fused_graph(ctx, gathered, T, fused_mask);
+        if (cpu_chain_ok && fused_ok)
+            report("fused_mask_raw", cpu_mask, fused_mask);
+        else
+            fprintf(stderr, "  fused_mask_raw: SKIP (cpu_chain=%d fused=%d)\n", cpu_chain_ok ? 1 : 0, fused_ok ? 1 : 0);
     }
 
     mel_band_roformer_free(ctx);

--- a/src/mel_band_roformer.cpp
+++ b/src/mel_band_roformer.cpp
@@ -617,6 +617,216 @@ bool band_split_graph(mel_band_roformer_context* ctx, const std::vector<float>& 
     ggml_free(gctx);
     return true;
 }
+
+// ---------------------------------------------------------------------------
+// Change 176 (Phase 2): RoFormer transformer block as a ggml graph, cleanroom
+// port following the htdemucs graph pattern (src/htdemucs.cpp g_mha). One
+// block = pre-RMSNorm attention (with per-head gating + RoPE) + pre-RMSNorm
+// FFN, both residual. The graph operates on x_b = (dim, S, B):
+//   ne0 = dim  (feature axis, RMSNorm/linear contract)
+//   ne1 = S    (block sequence axis: T for run_time, nb for run_freq)
+//   ne2 = B    (batch axis: nb for run_time, T for run_freq)
+// which is a pure ggml_permute away from the (dim, nb, T) x buffer — see
+// mbr_block_layer_graph() below. Weights come straight from the load context
+// (ctx->weights.tensors) like band_split_graph.
+// ---------------------------------------------------------------------------
+
+// RMSNorm (lucidrains F.normalize form) over ne0 (dim) of x_b, per (S, B)
+// slice: y = x / (sqrt(sum(x^2)) + eps) * sqrt(dim) * gamma. eps and
+// sqrt_dim are 1-element INPUT tensors (ggml_new_f32 asserts !no_alloc).
+static ggml_tensor* g_rms_dim(ggml_context* g, ggml_tensor* x, ggml_tensor* gamma, ggml_tensor* eps_t,
+                              ggml_tensor* sqrt_dim_t) {
+    ggml_tensor* sq = ggml_mul(g, x, x);                          // (dim,S,B)
+    ggml_tensor* ss = ggml_sum_rows(g, sq);                       // (1,S,B)
+    ggml_tensor* rt = ggml_sqrt(g, ss);                           // (1,S,B)
+    ggml_tensor* denom = ggml_add(g, rt, eps_t);                  // (1,S,B)
+    ggml_tensor* scale = ggml_div(g, ggml_repeat(g, sqrt_dim_t, denom), denom); // (1,S,B)
+    ggml_tensor* xn = ggml_mul(g, x, scale);                      // (dim,S,B)
+    if (gamma)
+        xn = ggml_mul(g, xn, ggml_reshape_3d(g, gamma, (int)gamma->ne[0], 1, 1));
+    return xn;
+}
+
+// One batched multi-head attention: xn (dim,S,B) is the pre-RMSNorm input the
+// qkv/gate projections read; the residual is added to the UN-normalized x
+// (CPU roformer_block: x[i] += attn_out[i], NOT onto xn).
+static ggml_tensor* g_mbr_attn(ggml_context* g, ggml_tensor* x, ggml_tensor* xn, ggml_tensor* qkv_w,
+                               ggml_tensor* gate_w, ggml_tensor* gate_b, ggml_tensor* out_w, ggml_tensor* pos_t,
+                               int S, int B, int dim, int heads, int dim_head) {
+    const int inner = heads * dim_head;
+    ggml_tensor* qkv = ggml_mul_mat(g, qkv_w, xn); // (3*inner, S, B)
+
+    // q/k/v slices: each (inner, S, B) -> (dim_head, heads, S, B). The flat
+    // order of (inner, S, B) with inner = heads*dim_head splits into
+    // d + dim_head*h + inner*(s + S*b), exactly reshape_4d(dh, heads, S, B).
+    const size_t off = (size_t)inner * ggml_element_size(qkv);
+    const size_t nb1 = qkv->nb[1], nb2 = qkv->nb[2];
+    ggml_tensor* q4 = ggml_reshape_4d(g, ggml_cont(g, ggml_view_3d(g, qkv, inner, S, B, nb1, nb2, 0)), dim_head,
+                                      heads, S, B);
+    ggml_tensor* k4 = ggml_reshape_4d(g, ggml_cont(g, ggml_view_3d(g, qkv, inner, S, B, nb1, nb2, off)), dim_head,
+                                      heads, S, B);
+    ggml_tensor* v4 = ggml_reshape_4d(g, ggml_cont(g, ggml_view_3d(g, qkv, inner, S, B, nb1, nb2, 2 * off)),
+                                      dim_head, heads, S, B);
+
+    // RoPE (interleaved pairs, theta=10000): CPU rope_head rotates (2i, 2i+1)
+    // with angle m*10000^-(2i/dim_head) -> GGML_ROPE_TYPE_NORMAL, n_dims =
+    // dim_head, pos m = sequence index (0..S-1), same for every batch slice.
+    q4 = ggml_rope_ext(g, q4, pos_t, nullptr, dim_head, GGML_ROPE_TYPE_NORMAL, 0, 10000.0f, 1.0f, 0.0f, 1.0f, 0.0f,
+                       0.0f);
+    k4 = ggml_rope_ext(g, k4, pos_t, nullptr, dim_head, GGML_ROPE_TYPE_NORMAL, 0, 10000.0f, 1.0f, 0.0f, 1.0f, 0.0f,
+                       0.0f);
+
+    // Attention per head, scale = dim_head^-0.5, full (no mask). g_mha layout:
+    // q,k: (dh, S, heads, B) [ne0=dh contract, ne1=S keys/queries, ne2=heads,
+    // ne3=B batch]; scores = k^T q -> (S, S, heads, B), softmax over ne0.
+    ggml_tensor* q_att = ggml_cont(g, ggml_permute(g, q4, 0, 2, 1, 3));
+    ggml_tensor* k_att = ggml_cont(g, ggml_permute(g, k4, 0, 2, 1, 3));
+    ggml_tensor* scores = ggml_mul_mat(g, k_att, q_att); // (S, S, heads, B)
+    const float scale = 1.0f / std::sqrt((float)dim_head);
+    scores = ggml_soft_max_ext(g, scores, nullptr, scale, 0.0f);
+
+    ggml_tensor* v_att = ggml_cont(g, ggml_permute(g, v4, 1, 2, 0, 3)); // (S, dh, heads, B)
+    ggml_tensor* out = ggml_mul_mat(g, v_att, scores);                  // (dh, S, heads, B)
+
+    // per-head gating: attn[t,h,:] *= sigmoid(gates[t,h]) — gates (heads,S,B)
+    // broadcast over the dh axis of the reshaped attention output.
+    ggml_tensor* gates = ggml_mul_mat(g, gate_w, xn); // (heads, S, B)
+    if (gate_b)
+        gates = ggml_add(g, gates, ggml_reshape_3d(g, gate_b, heads, 1, 1));
+    gates = ggml_sigmoid(g, gates);
+    ggml_tensor* attn4 = ggml_cont(g, ggml_permute(g, out, 0, 2, 1, 3)); // (dh, heads, S, B)
+    attn4 = ggml_mul(g, attn4, ggml_reshape_4d(g, gates, 1, heads, S, B));
+
+    ggml_tensor* attn3 = ggml_reshape_3d(g, attn4, inner, S, B); // (inner, S, B)
+    ggml_tensor* attn_out = ggml_mul_mat(g, out_w, attn3);       // (dim, S, B)
+    return ggml_add(g, x, attn_out);                             // residual on x, not xn
+}
+
+// FFN: x -> x + (Linear(dim->hid) -> GELU(erf) -> Linear(hid->dim)), pre-RMS.
+static ggml_tensor* g_mbr_ffn(ggml_context* g, ggml_tensor* x, ggml_tensor* ff_g, ggml_tensor* ff1_w,
+                              ggml_tensor* ff1_b, ggml_tensor* ff4_w, ggml_tensor* ff4_b, ggml_tensor* eps_t,
+                              ggml_tensor* sqrt_dim_t, int S, int B, int dim, int hid) {
+    ggml_tensor* fn = g_rms_dim(g, x, ff_g, eps_t, sqrt_dim_t); // (dim,S,B)
+    ggml_tensor* h1 = ggml_mul_mat(g, ff1_w, fn);
+    if (ff1_b)
+        h1 = ggml_add(g, h1, ggml_reshape_3d(g, ff1_b, hid, 1, 1));
+    h1 = ggml_gelu_erf(g, h1);
+    ggml_tensor* h2 = ggml_mul_mat(g, ff4_w, h1);
+    if (ff4_b)
+        h2 = ggml_add(g, h2, ggml_reshape_3d(g, ff4_b, dim, 1, 1));
+    return ggml_add(g, x, h2);
+}
+
+// Full transformer LAYER over x_b (dim,S,B): block (attn + ffn) then the final
+// RMSNorm (layers.{L}.{0|1}.norm.gamma) — exactly what CPU run_time/run_freq
+// do after roformer_block(). Weights are read from ctx->weights.tensors.
+// Returns the layer output tensor (same (dim,S,B) shape as x_b), or nullptr.
+static ggml_tensor* mbr_block_layer_graph(mel_band_roformer_context* ctx, ggml_context* g, const std::string& pre,
+                                          ggml_tensor* x_b, int S, int B, int dim, int heads, int dim_head,
+                                          ggml_tensor* eps_t, ggml_tensor* sqrt_dim_t, ggml_tensor* pos_t) {
+    auto find = [&](const char* name) -> ggml_tensor* {
+        auto it = ctx->weights.tensors.find(name);
+        return (it == ctx->weights.tensors.end()) ? nullptr : it->second;
+    };
+    const std::string b = pre + "layers.0.";
+    ggml_tensor* nrm_g = find((b + "0.norm.gamma").c_str());
+    ggml_tensor* qkv_w = find((b + "0.to_qkv.weight").c_str());
+    ggml_tensor* gate_w = find((b + "0.to_gates.weight").c_str());
+    ggml_tensor* gate_b = find((b + "0.to_gates.bias").c_str());
+    ggml_tensor* out_w = find((b + "0.to_out.0.weight").c_str());
+    ggml_tensor* ff_g = find((b + "1.net.0.gamma").c_str());
+    ggml_tensor* ff1_w = find((b + "1.net.1.weight").c_str());
+    ggml_tensor* ff1_b = find((b + "1.net.1.bias").c_str());
+    ggml_tensor* ff4_w = find((b + "1.net.4.weight").c_str());
+    ggml_tensor* ff4_b = find((b + "1.net.4.bias").c_str());
+    ggml_tensor* fg = find((pre + "norm.gamma").c_str());
+    if (!nrm_g || !qkv_w || !gate_w || !gate_b || !out_w || !ff_g || !ff1_w || !ff1_b || !ff4_w || !ff4_b || !fg)
+        return nullptr;
+    const int hid = (int)ff1_b->ne[0];
+
+    ggml_tensor* xn = g_rms_dim(g, x_b, nrm_g, eps_t, sqrt_dim_t);
+    ggml_tensor* y = g_mbr_attn(g, x_b, xn, qkv_w, gate_w, gate_b, out_w, pos_t, S, B, dim, heads, dim_head);
+    y = g_mbr_ffn(g, y, ff_g, ff1_w, ff1_b, ff4_w, ff4_b, eps_t, sqrt_dim_t, S, B, dim, hid);
+    y = g_rms_dim(g, y, fg, eps_t, sqrt_dim_t); // final layer norm
+    return y;
+}
+
+// Build + run one transformer layer (time or freq) as a fresh graph over the
+// (dim, nb, T) x buffer (flat == CPU (T, nb, dim) row-major). is_time: attend
+// over T per band (seq S=T, batch B=nb); else attend over bands per frame.
+// Mirrors CPU run_time()/run_freq() signatures; x is updated in place.
+static bool mbr_layer_graph(mel_band_roformer_context* ctx, int L, bool is_time, std::vector<float>& x, int T, int nb,
+                     int dim, int heads, int dim_head) {
+    const int S = is_time ? T : nb;
+    const int B = is_time ? nb : T;
+    const size_t n_x = (size_t)T * nb * dim;
+    if (x.size() != n_x)
+        return false;
+
+    // ~24 ops per layer incl. the block; generous headroom for views/permutes.
+    const size_t n_nodes = 256;
+    ggml_init_params gparams = {
+        ggml_tensor_overhead() * n_nodes + ggml_graph_overhead_custom((size_t)n_nodes, false), nullptr, true};
+    ggml_context* gctx = ggml_init(gparams);
+    if (!gctx)
+        return false;
+
+    // x buffer is (dim, nb, T) flat-compatible (ne0=dim fastest).
+    ggml_tensor* xt = ggml_new_tensor_3d(gctx, GGML_TYPE_F32, dim, nb, T);
+    ggml_set_name(xt, "mbr_layer_in");
+    ggml_set_input(xt);
+
+    // seq axis must be ne1: time -> (dim, T, nb), freq -> (dim, nb, T) already.
+    ggml_tensor* x_b = is_time ? ggml_cont(gctx, ggml_permute(gctx, xt, 0, 2, 1, 3)) : xt;
+
+    const std::string pre = "layers." + std::to_string(L) + (is_time ? ".0." : ".1.");
+    ggml_tensor* eps_t = ggml_new_tensor_1d(gctx, GGML_TYPE_F32, 1);
+    ggml_set_input(eps_t);
+    ggml_tensor* sqrt_dim_t = ggml_new_tensor_1d(gctx, GGML_TYPE_F32, 1);
+    ggml_set_input(sqrt_dim_t);
+    ggml_tensor* pos_t = ggml_new_tensor_1d(gctx, GGML_TYPE_I32, S);
+    ggml_set_input(pos_t);
+
+    ggml_tensor* y =
+        mbr_block_layer_graph(ctx, gctx, pre, x_b, S, B, dim, heads, dim_head, eps_t, sqrt_dim_t, pos_t);
+    if (!y) {
+        ggml_free(gctx);
+        return false;
+    }
+
+    // Final output: back to (dim, nb, T) layout.
+    ggml_tensor* out3 = is_time ? ggml_cont(gctx, ggml_permute(gctx, y, 0, 2, 1, 3)) : y;
+    ggml_set_name(out3, "mbr_layer_out");
+    ggml_set_output(out3);
+
+    ggml_cgraph* gf = ggml_new_graph_custom(gctx, n_nodes, false);
+    ggml_build_forward_expand(gf, out3);
+
+    ggml_gallocr_t alloc = ggml_gallocr_new(ggml_backend_get_default_buffer_type(ctx->backend));
+    if (!alloc || !ggml_gallocr_alloc_graph(alloc, gf)) {
+        fprintf(stderr, "mel_band_roformer: mbr_layer_graph gallocr alloc failed\n");
+        if (alloc)
+            ggml_gallocr_free(alloc);
+        ggml_free(gctx);
+        return false;
+    }
+
+    ggml_backend_tensor_set(xt, x.data(), 0, n_x * sizeof(float));
+    const float eps = 1e-12f, sd = std::sqrt((float)dim);
+    ggml_backend_tensor_set(eps_t, &eps, 0, sizeof(float));
+    ggml_backend_tensor_set(sqrt_dim_t, &sd, 0, sizeof(float));
+    std::vector<int32_t> pos((size_t)S);
+    for (int i = 0; i < S; i++)
+        pos[(size_t)i] = i;
+    ggml_backend_tensor_set(pos_t, pos.data(), 0, (size_t)S * sizeof(int32_t));
+
+    ggml_backend_graph_compute(ctx->backend, gf);
+    ggml_backend_tensor_get(out3, x.data(), 0, n_x * sizeof(float));
+
+    ggml_gallocr_free(alloc);
+    ggml_free(gctx);
+    return true;
+}
 void linear(const std::vector<float>& x, int T, int din, const std::vector<float>& W, const std::vector<float>* bias,
             int dout, std::vector<float>& y) {
     y.assign((size_t)T * dout, 0.0f);
@@ -1093,10 +1303,29 @@ bool run_forward(mel_band_roformer_context* ctx, const std::vector<std::vector<f
     for (int L = 0; L < hp.depth; L++) {
         fprintf(stderr, "mel_band_roformer: layer %d/%d\n", L + 1, hp.depth);
         auto a = clk::now();
-        if (!run_time(ctx->weights, L, x, T, nb, dim, hp.heads, hp.dim_head))
+        bool ok_t;
+        if (ctx->use_graph) {
+            // Change 176 Phase 2: RoFormer block as a ggml graph (GPU-capable).
+            // Parity gate: layer0_time/layer0_freq cos=1.0 vs the CPU reference
+            // in the mbr-parity harness; all depth layers share this code path.
+            ok_t = mbr_layer_graph(ctx, L, true, x, T, nb, dim, hp.heads, hp.dim_head);
+            lap("run_time(graph)");
+        } else {
+            ok_t = run_time(ctx->weights, L, x, T, nb, dim, hp.heads, hp.dim_head);
+            lap("run_time");
+        }
+        if (!ok_t)
             return false;
         auto b = clk::now();
-        if (!run_freq(ctx->weights, L, x, T, nb, dim, hp.heads, hp.dim_head))
+        bool ok_f;
+        if (ctx->use_graph) {
+            ok_f = mbr_layer_graph(ctx, L, false, x, T, nb, dim, hp.heads, hp.dim_head);
+            lap("run_freq(graph)");
+        } else {
+            ok_f = run_freq(ctx->weights, L, x, T, nb, dim, hp.heads, hp.dim_head);
+            lap("run_freq");
+        }
+        if (!ok_f)
             return false;
         auto c = clk::now();
         t_time += std::chrono::duration_cast<std::chrono::milliseconds>(b - a).count();
@@ -1228,9 +1457,72 @@ int mel_band_roformer_parity(const char* model_gguf, const char* audio_wav, int 
         if (verbosity >= 2)
             fprintf(stderr, "    |graph|=%.6f |cpu|=%.6f\n", lg, lc);
     }
+    if (!ok) {
+        mel_band_roformer_free(ctx);
+        fprintf(stderr, "mel_band_roformer parity: FAIL (band_split)\n");
+        return 1;
+    }
+
+    // Change 176 Phase 2: transformer layers — graph vs CPU on IDENTICAL input
+    // (the CPU-validated band_split output, layout (T, nb, dim) row-major == the
+    // graph's (dim, nb, T) flat buffer). Layer 0 time, then layer 0 freq
+    // chained off the time output (mirrors the diff harness layer0_freq stage).
+    // CPU run_time/run_freq mutate x in place; the graph layer does the same.
+    int n_fail = 0;
+    const int nb = (int)ctx->band_width.size();
+    const int dim = hp.dim, heads = hp.heads, dim_head = hp.dim_head;
+    auto report = [&](const char* stage, std::vector<float>& cpu, std::vector<float>& graph) {
+        const int64_t nn = (int64_t)std::min(cpu.size(), graph.size());
+        const double c = cosine(graph.data(), cpu.data(), nn);
+        const double a = max_abs_diff(graph.data(), cpu.data(), nn);
+        const bool p = c >= 0.9995 && cpu.size() == graph.size();
+        if (!p)
+            n_fail++;
+        if (verbosity >= 1 || !p)
+            fprintf(stderr, "  %-16s %s cos=%.6f max_abs=%.3e  (graph=%zu cpu=%zu)%s\n", stage, p ? "PASS" : "FAIL", c, a,
+                    graph.size(), cpu.size(),
+                    verbosity >= 2 ? ("  |graph|=" + std::to_string(l2_norm(graph.data(), nn)) +
+                                      " |cpu|=" + std::to_string(l2_norm(cpu.data(), nn)))
+                                         .c_str()
+                                   : "");
+        if (!p && verbosity >= 2) {
+            // Localize: report the band (of nb) containing the largest error
+            // and the first few mismatched element offsets — layout bugs show
+            // up as band-localized errors, formula bugs as scattered ones.
+            int64_t worst = 0;
+            double worst_v = -1;
+            for (int64_t i = 0; i < nn; i++) {
+                const double dv = std::fabs((double)graph[i] - (double)cpu[i]);
+                if (dv > worst_v) {
+                    worst_v = dv;
+                    worst = i;
+                }
+            }
+            fprintf(stderr, "      worst@%lld band=%lld t=%lld d=%lld (|g|=%.4f |c|=%.4f)\n", (long long)worst,
+                    (long long)((worst / dim) % nb), (long long)(worst / ((long long)nb * dim)),
+                    (long long)(worst % dim), graph[worst], cpu[worst]);
+        }
+    };
+
+    {
+        std::vector<float> cpu_x = cpu_out, graph_x = cpu_out;
+        if (run_time(ctx->weights, 0, cpu_x, T, nb, dim, heads, dim_head) &&
+            mbr_layer_graph(ctx, 0, true, graph_x, T, nb, dim, heads, dim_head))
+            report("layer0_time_graph", cpu_x, graph_x);
+        else
+            fprintf(stderr, "  layer0_time_graph: SKIP (run failed)\n");
+        // freq chained off the layer-0-time outputs (diff-harness semantics).
+        if (run_freq(ctx->weights, 0, cpu_x, T, nb, dim, heads, dim_head) &&
+            mbr_layer_graph(ctx, 0, false, graph_x, T, nb, dim, heads, dim_head))
+            report("layer0_freq_graph", cpu_x, graph_x);
+        else
+            fprintf(stderr, "  layer0_freq_graph: SKIP (run failed)\n");
+    }
+
     mel_band_roformer_free(ctx);
-    fprintf(stderr, "mel_band_roformer parity: %s\n", ok ? "PASS" : "FAIL");
-    return ok ? 0 : 1;
+    const bool all_ok = n_fail == 0;
+    fprintf(stderr, "mel_band_roformer parity: %s\n", all_ok ? "PASS" : "FAIL");
+    return all_ok ? 0 : 1;
 }
 
 int mel_band_roformer_diff(const char* model_gguf, const char* ref_gguf, const char* audio_wav, int verbosity) {

--- a/src/mel_band_roformer.cpp
+++ b/src/mel_band_roformer.cpp
@@ -10,6 +10,12 @@
 //
 // Blueprint: MIT lucidrains/BS-RoFormer. Weights: KimberleyJSN/melbandroformer
 // (MIT). Reference pinned at bs-roformer==0.3.10. See docs/mel-band-roformer/PLAN.md.
+//
+// Change 176: the ggml-graph paths (band-split, transformer blocks, fused
+// single graph) were written cleanroom following the in-repo htdemucs graph
+// pattern, with chenmozhijin/BSRoformer.cpp (MIT) used strictly as a
+// reference/oracle for graph structure and correctness — no code copied.
+// Parity is verified against this file's own validated CPU path (cos=1.0).
 
 #include "mel_band_roformer.h"
 

--- a/src/mel_band_roformer.cpp
+++ b/src/mel_band_roformer.cpp
@@ -26,12 +26,12 @@
 #include "ggml-cpu.h"
 #include "ggml.h"
 
-#include "core/fft.h"         // fft_radix2_wrapper (r2c, interleaved full spectrum)
+#include "core/fft.h"              // fft_radix2_wrapper (r2c, interleaved full spectrum)
 #include "core/ggml_cpu_backend.h" // core_cpu_backend::init/is_cpu (Change 176)
-#include "core/gguf_loader.h" // core_gguf::{open_metadata,kv_u32,load_weights}
+#include "core/gguf_loader.h"      // core_gguf::{open_metadata,kv_u32,load_weights}
 #include "core/gpu_backend_pref.h" // crispasr_init_gpu_backend (Change 176, htdemucs pattern)
-#include "core/istft.h"       // core_istft::istft (torch center=True match)
-#include "core/wav_reader.h"  // crispasr::core::read_wav_mono_pcm16 (Change 176 parity)
+#include "core/istft.h"            // core_istft::istft (torch center=True match)
+#include "core/wav_reader.h"       // crispasr::core::read_wav_mono_pcm16 (Change 176 parity)
 
 // BLAS for the linear() SGEMM. #296: the forward is ~264 GFLOP of matmul; without
 // a BLAS backend linear() falls back to a scalar loop that took ~24 min on an 11s
@@ -261,8 +261,8 @@ mel_band_roformer_params mel_band_roformer_default_params(void) {
     p.n_threads = 0;
     p.use_gpu = false; // CPU path is the default (E2); gates AUTO-upgrade to GPU
     p.gpu_device = 0;
-    p.segment_seconds = 0;  // <=0 -> default 10 s (Demucs split for long audio)
-    p.no_segment = false;   // segmented forward for >1-segment inputs
+    p.segment_seconds = 0; // <=0 -> default 10 s (Demucs split for long audio)
+    p.no_segment = false;  // segmented forward for >1-segment inputs
     return p;
 }
 
@@ -326,9 +326,9 @@ mel_band_roformer_context* mel_band_roformer_init_from_file(const char* model_pa
             }
         }
     }
-    const mel_band_gates::Resolved gates = mel_band_gates::resolve(
-        getenv("CRISPASR_MELBAND_GPU"), getenv("CRISPASR_MELBAND_GGML"), getenv("CRISPASR_MELBAND_FUSED"),
-        params.use_gpu, gpu_probe != nullptr);
+    const mel_band_gates::Resolved gates =
+        mel_band_gates::resolve(getenv("CRISPASR_MELBAND_GPU"), getenv("CRISPASR_MELBAND_GGML"),
+                                getenv("CRISPASR_MELBAND_FUSED"), params.use_gpu, gpu_probe != nullptr);
     if (gates.use_graph) {
         ctx->backend = gates.gpu_backend ? gpu_probe : core_cpu_backend::init();
         if (!ctx->backend)
@@ -346,8 +346,8 @@ mel_band_roformer_context* mel_band_roformer_init_from_file(const char* model_pa
     ctx->use_graph = gates.use_graph;
     ctx->use_fused = gates.use_fused;
     ctx->is_gpu = !core_cpu_backend::is_cpu(ctx->backend);
-    fprintf(stderr, "mel_band_roformer: gates graph=%d fused=%d gpu=%d (real_gpu_present=%d)\n",
-            (int)gates.use_graph, (int)gates.use_fused, (int)gates.gpu_backend, (int)(gpu_probe != nullptr));
+    fprintf(stderr, "mel_band_roformer: gates graph=%d fused=%d gpu=%d (real_gpu_present=%d)\n", (int)gates.use_graph,
+            (int)gates.use_fused, (int)gates.gpu_backend, (int)(gpu_probe != nullptr));
     fprintf(stderr, "mel_band_roformer: backend = %s\n", ggml_backend_name(ctx->backend));
     if (!core_gguf::load_weights(model_path, ctx->backend, "mel_band_roformer", ctx->weights)) {
         fprintf(stderr, "mel_band_roformer: failed to load weights from '%s'\n", model_path);
@@ -550,17 +550,17 @@ static ggml_tensor* mbr_band_split_build(mel_band_roformer_context* ctx, ggml_co
         off += din;
 
         // RMSNorm — exact CPU formula: y = x * sqrt(din) / (sqrt(sum(x^2)) + eps) * gamma.
-        ggml_tensor* sq = ggml_mul(g, xv, xv);                     // (din, T)
-        ggml_tensor* ss = ggml_sum_rows(g, sq);                    // (1, T)
-        ggml_tensor* rt = ggml_sqrt(g, ss);                        // (1, T)
-        ggml_tensor* denom = ggml_add(g, rt, eps_t);               // (1, T)
+        ggml_tensor* sq = ggml_mul(g, xv, xv);       // (din, T)
+        ggml_tensor* ss = ggml_sum_rows(g, sq);      // (1, T)
+        ggml_tensor* rt = ggml_sqrt(g, ss);          // (1, T)
+        ggml_tensor* denom = ggml_add(g, rt, eps_t); // (1, T)
         ggml_tensor* sqrt_dim_t = ggml_new_tensor_1d(g, GGML_TYPE_F32, 1);
         ggml_set_name(sqrt_dim_t, ("mbr_rms_sqrt_dim_" + std::to_string(b)).c_str());
         ggml_set_input(sqrt_dim_t);
         sqrt_dim_ts.push_back(sqrt_dim_t);
         ggml_tensor* scale = ggml_div(g, ggml_repeat(g, sqrt_dim_t, denom), denom); // (1, T)
-        ggml_tensor* xn = ggml_mul(g, xv, scale);                  // (din, T) broadcast
-        ggml_tensor* y = ggml_mul(g, xn, it_g->second);            // * gamma (din, 1) broadcast
+        ggml_tensor* xn = ggml_mul(g, xv, scale);                                   // (din, T) broadcast
+        ggml_tensor* y = ggml_mul(g, xn, it_g->second);                             // * gamma (din, 1) broadcast
 
         // Linear: mul_mat(weight (din, dim), y (din, T)) -> (dim, T); + bias
         ggml_tensor* proj = ggml_mul_mat(g, it_w->second, y);
@@ -673,12 +673,12 @@ bool band_split_graph(mel_band_roformer_context* ctx, const std::vector<float>& 
 // sqrt_dim are 1-element INPUT tensors (ggml_new_f32 asserts !no_alloc).
 static ggml_tensor* g_rms_dim(ggml_context* g, ggml_tensor* x, ggml_tensor* gamma, ggml_tensor* eps_t,
                               ggml_tensor* sqrt_dim_t) {
-    ggml_tensor* sq = ggml_mul(g, x, x);                          // (dim,S,B)
-    ggml_tensor* ss = ggml_sum_rows(g, sq);                       // (1,S,B)
-    ggml_tensor* rt = ggml_sqrt(g, ss);                           // (1,S,B)
-    ggml_tensor* denom = ggml_add(g, rt, eps_t);                  // (1,S,B)
+    ggml_tensor* sq = ggml_mul(g, x, x);                                        // (dim,S,B)
+    ggml_tensor* ss = ggml_sum_rows(g, sq);                                     // (1,S,B)
+    ggml_tensor* rt = ggml_sqrt(g, ss);                                         // (1,S,B)
+    ggml_tensor* denom = ggml_add(g, rt, eps_t);                                // (1,S,B)
     ggml_tensor* scale = ggml_div(g, ggml_repeat(g, sqrt_dim_t, denom), denom); // (1,S,B)
-    ggml_tensor* xn = ggml_mul(g, x, scale);                      // (dim,S,B)
+    ggml_tensor* xn = ggml_mul(g, x, scale);                                    // (dim,S,B)
     if (gamma)
         xn = ggml_mul(g, xn, ggml_reshape_3d(g, gamma, (int)gamma->ne[0], 1, 1));
     return xn;
@@ -688,8 +688,8 @@ static ggml_tensor* g_rms_dim(ggml_context* g, ggml_tensor* x, ggml_tensor* gamm
 // qkv/gate projections read; the residual is added to the UN-normalized x
 // (CPU roformer_block: x[i] += attn_out[i], NOT onto xn).
 static ggml_tensor* g_mbr_attn(ggml_context* g, ggml_tensor* x, ggml_tensor* xn, ggml_tensor* qkv_w,
-                               ggml_tensor* gate_w, ggml_tensor* gate_b, ggml_tensor* out_w, ggml_tensor* pos_t,
-                               int S, int B, int dim, int heads, int dim_head) {
+                               ggml_tensor* gate_w, ggml_tensor* gate_b, ggml_tensor* out_w, ggml_tensor* pos_t, int S,
+                               int B, int dim, int heads, int dim_head) {
     const int inner = heads * dim_head;
     ggml_tensor* qkv = ggml_mul_mat(g, qkv_w, xn); // (3*inner, S, B)
 
@@ -698,12 +698,12 @@ static ggml_tensor* g_mbr_attn(ggml_context* g, ggml_tensor* x, ggml_tensor* xn,
     // d + dim_head*h + inner*(s + S*b), exactly reshape_4d(dh, heads, S, B).
     const size_t off = (size_t)inner * ggml_element_size(qkv);
     const size_t nb1 = qkv->nb[1], nb2 = qkv->nb[2];
-    ggml_tensor* q4 = ggml_reshape_4d(g, ggml_cont(g, ggml_view_3d(g, qkv, inner, S, B, nb1, nb2, 0)), dim_head,
-                                      heads, S, B);
-    ggml_tensor* k4 = ggml_reshape_4d(g, ggml_cont(g, ggml_view_3d(g, qkv, inner, S, B, nb1, nb2, off)), dim_head,
-                                      heads, S, B);
-    ggml_tensor* v4 = ggml_reshape_4d(g, ggml_cont(g, ggml_view_3d(g, qkv, inner, S, B, nb1, nb2, 2 * off)),
-                                      dim_head, heads, S, B);
+    ggml_tensor* q4 =
+        ggml_reshape_4d(g, ggml_cont(g, ggml_view_3d(g, qkv, inner, S, B, nb1, nb2, 0)), dim_head, heads, S, B);
+    ggml_tensor* k4 =
+        ggml_reshape_4d(g, ggml_cont(g, ggml_view_3d(g, qkv, inner, S, B, nb1, nb2, off)), dim_head, heads, S, B);
+    ggml_tensor* v4 =
+        ggml_reshape_4d(g, ggml_cont(g, ggml_view_3d(g, qkv, inner, S, B, nb1, nb2, 2 * off)), dim_head, heads, S, B);
 
     // RoPE (interleaved pairs, theta=10000): CPU rope_head rotates (2i, 2i+1)
     // with angle m*10000^-(2i/dim_head) -> GGML_ROPE_TYPE_NORMAL, n_dims =
@@ -793,7 +793,7 @@ static ggml_tensor* mbr_block_layer_graph(mel_band_roformer_context* ctx, ggml_c
 // over T per band (seq S=T, batch B=nb); else attend over bands per frame.
 // Mirrors CPU run_time()/run_freq() signatures; x is updated in place.
 static bool mbr_layer_graph(mel_band_roformer_context* ctx, int L, bool is_time, std::vector<float>& x, int T, int nb,
-                     int dim, int heads, int dim_head) {
+                            int dim, int heads, int dim_head) {
     const int S = is_time ? T : nb;
     const int B = is_time ? nb : T;
     const size_t n_x = (size_t)T * nb * dim;
@@ -802,8 +802,8 @@ static bool mbr_layer_graph(mel_band_roformer_context* ctx, int L, bool is_time,
 
     // ~24 ops per layer incl. the block; generous headroom for views/permutes.
     const size_t n_nodes = 256;
-    ggml_init_params gparams = {
-        ggml_tensor_overhead() * n_nodes + ggml_graph_overhead_custom((size_t)n_nodes, false), nullptr, true};
+    ggml_init_params gparams = {ggml_tensor_overhead() * n_nodes + ggml_graph_overhead_custom((size_t)n_nodes, false),
+                                nullptr, true};
     ggml_context* gctx = ggml_init(gparams);
     if (!gctx)
         return false;
@@ -824,8 +824,7 @@ static bool mbr_layer_graph(mel_band_roformer_context* ctx, int L, bool is_time,
     ggml_tensor* pos_t = ggml_new_tensor_1d(gctx, GGML_TYPE_I32, S);
     ggml_set_input(pos_t);
 
-    ggml_tensor* y =
-        mbr_block_layer_graph(ctx, gctx, pre, x_b, S, B, dim, heads, dim_head, eps_t, sqrt_dim_t, pos_t);
+    ggml_tensor* y = mbr_block_layer_graph(ctx, gctx, pre, x_b, S, B, dim, heads, dim_head, eps_t, sqrt_dim_t, pos_t);
     if (!y) {
         ggml_free(gctx);
         return false;
@@ -1358,8 +1357,8 @@ static bool mbr_fused_graph(mel_band_roformer_context* ctx, const std::vector<fl
     for (int L = 0; L < hp.depth; L++) {
         // time: seq over frames (S=T on ne1, batch=nb on ne2) — permute in/out.
         ggml_tensor* xt = ggml_cont(gctx, ggml_permute(gctx, x, 0, 2, 1, 3)); // (dim, T, nb)
-        ggml_tensor* yt = mbr_block_layer_graph(ctx, gctx, ("layers." + std::to_string(L) + ".0.").c_str(), xt, T,
-                                                nb, dim, heads, dim_head, eps_t, sqrt_dim_t, pos_time_t);
+        ggml_tensor* yt = mbr_block_layer_graph(ctx, gctx, ("layers." + std::to_string(L) + ".0.").c_str(), xt, T, nb,
+                                                dim, heads, dim_head, eps_t, sqrt_dim_t, pos_time_t);
         if (!yt) {
             fprintf(stderr, "mel_band_roformer: fused time layer %d build failed (missing weight?)\n", L);
             ggml_free(gctx);
@@ -1404,8 +1403,7 @@ static bool mbr_fused_graph(mel_band_roformer_context* ctx, const std::vector<fl
         const int din2 = (int)b4->ne[0]; // 2 * band width
         const int din = din2 / 2;
         if (din != ctx->band_width[b]) {
-            fprintf(stderr,
-                    "mel_band_roformer: fused mask band %d width mismatch (weight=%d band_width=%d)\n", b, din,
+            fprintf(stderr, "mel_band_roformer: fused mask band %d width mismatch (weight=%d band_width=%d)\n", b, din,
                     ctx->band_width[b]);
             ggml_free(gctx);
             return false;
@@ -1535,61 +1533,62 @@ bool run_forward(mel_band_roformer_context* ctx, const std::vector<std::vector<f
         }
         lap("fused_graph");
     } else {
-    std::vector<float> x;
-    bool bs_ok;
-    if (ctx->use_graph) {
-        // Change 176 (Phase 1): ggml-graph band-split on ctx->backend. Parity
-        // gate: output layout identical to band_split_cpu, compared in the
-        // diff harness (band_split_out stage).
-        bs_ok = band_split_graph(ctx, gathered, T, x);
-        lap("band_split(graph)");
-    } else {
-        bs_ok = band_split_cpu(ctx->weights, gathered, ctx->band_width, T, dim, x);
-        lap("band_split");
-    }
-    if (!bs_ok)
-        return false;
-    // Compute-heavy Transformer stack; emit per-layer progress so it never looks
-    // hung, and (under profiling) split run_time vs run_freq time.
-    fprintf(stderr, "mel_band_roformer: separating (T=%d frames, %d layers, %d bands)...\n", T, hp.depth, nb);
-    double t_time = 0, t_freq = 0;
-    for (int L = 0; L < hp.depth; L++) {
-        fprintf(stderr, "mel_band_roformer: layer %d/%d\n", L + 1, hp.depth);
-        auto a = clk::now();
-        bool ok_t;
+        std::vector<float> x;
+        bool bs_ok;
         if (ctx->use_graph) {
-            // Change 176 Phase 2: RoFormer block as a ggml graph (GPU-capable).
-            // Parity gate: layer0_time/layer0_freq cos=1.0 vs the CPU reference
-            // in the mbr-parity harness; all depth layers share this code path.
-            ok_t = mbr_layer_graph(ctx, L, true, x, T, nb, dim, hp.heads, hp.dim_head);
-            lap("run_time(graph)");
+            // Change 176 (Phase 1): ggml-graph band-split on ctx->backend. Parity
+            // gate: output layout identical to band_split_cpu, compared in the
+            // diff harness (band_split_out stage).
+            bs_ok = band_split_graph(ctx, gathered, T, x);
+            lap("band_split(graph)");
         } else {
-            ok_t = run_time(ctx->weights, L, x, T, nb, dim, hp.heads, hp.dim_head);
-            lap("run_time");
+            bs_ok = band_split_cpu(ctx->weights, gathered, ctx->band_width, T, dim, x);
+            lap("band_split");
         }
-        if (!ok_t)
+        if (!bs_ok)
             return false;
-        auto b = clk::now();
-        bool ok_f;
-        if (ctx->use_graph) {
-            ok_f = mbr_layer_graph(ctx, L, false, x, T, nb, dim, hp.heads, hp.dim_head);
-            lap("run_freq(graph)");
-        } else {
-            ok_f = run_freq(ctx->weights, L, x, T, nb, dim, hp.heads, hp.dim_head);
-            lap("run_freq");
+        // Compute-heavy Transformer stack; emit per-layer progress so it never looks
+        // hung, and (under profiling) split run_time vs run_freq time.
+        fprintf(stderr, "mel_band_roformer: separating (T=%d frames, %d layers, %d bands)...\n", T, hp.depth, nb);
+        double t_time = 0, t_freq = 0;
+        for (int L = 0; L < hp.depth; L++) {
+            fprintf(stderr, "mel_band_roformer: layer %d/%d\n", L + 1, hp.depth);
+            auto a = clk::now();
+            bool ok_t;
+            if (ctx->use_graph) {
+                // Change 176 Phase 2: RoFormer block as a ggml graph (GPU-capable).
+                // Parity gate: layer0_time/layer0_freq cos=1.0 vs the CPU reference
+                // in the mbr-parity harness; all depth layers share this code path.
+                ok_t = mbr_layer_graph(ctx, L, true, x, T, nb, dim, hp.heads, hp.dim_head);
+                lap("run_time(graph)");
+            } else {
+                ok_t = run_time(ctx->weights, L, x, T, nb, dim, hp.heads, hp.dim_head);
+                lap("run_time");
+            }
+            if (!ok_t)
+                return false;
+            auto b = clk::now();
+            bool ok_f;
+            if (ctx->use_graph) {
+                ok_f = mbr_layer_graph(ctx, L, false, x, T, nb, dim, hp.heads, hp.dim_head);
+                lap("run_freq(graph)");
+            } else {
+                ok_f = run_freq(ctx->weights, L, x, T, nb, dim, hp.heads, hp.dim_head);
+                lap("run_freq");
+            }
+            if (!ok_f)
+                return false;
+            auto c = clk::now();
+            t_time += std::chrono::duration_cast<std::chrono::milliseconds>(b - a).count();
+            t_freq += std::chrono::duration_cast<std::chrono::milliseconds>(c - b).count();
         }
-        if (!ok_f)
+        if (prof)
+            fprintf(stderr, "  [mbr-prof] run_time(all)  %7.0f ms\n  [mbr-prof] run_freq(all)  %7.0f ms\n", t_time,
+                    t_freq);
+        tick = clk::now();
+        if (!mask_estimator(ctx->weights, x, T, nb, dim, ctx->band_width, mask_raw))
             return false;
-        auto c = clk::now();
-        t_time += std::chrono::duration_cast<std::chrono::milliseconds>(b - a).count();
-        t_freq += std::chrono::duration_cast<std::chrono::milliseconds>(c - b).count();
-    }
-    if (prof)
-        fprintf(stderr, "  [mbr-prof] run_time(all)  %7.0f ms\n  [mbr-prof] run_freq(all)  %7.0f ms\n", t_time, t_freq);
-    tick = clk::now();
-    if (!mask_estimator(ctx->weights, x, T, nb, dim, ctx->band_width, mask_raw))
-        return false;
-    lap("mask_est");
+        lap("mask_est");
     } // else: per-layer graph / CPU reference path
     std::vector<float> out_planar; // channels * T_samp
     synthesize(ctx, packed, mask_raw, T, T_samp, out_planar);
@@ -1722,8 +1721,7 @@ mel_band_roformer_result* mel_band_roformer_separate(mel_band_roformer_context* 
         for (size_t i = (size_t)valid * channels; i < pcm_seg.size(); i++)
             pcm_seg[i] = 0.0f;
 
-        mel_band_roformer_result* part =
-            mel_band_roformer_separate_full(ctx, pcm_seg.data(), seg_len, channels);
+        mel_band_roformer_result* part = mel_band_roformer_separate_full(ctx, pcm_seg.data(), seg_len, channels);
         if (!part) {
             fprintf(stderr, "mel_band_roformer: segment @%d failed\n", off);
             acc.clear();
@@ -1841,8 +1839,8 @@ int mel_band_roformer_parity(const char* model_gguf, const char* audio_wav, int 
     const double lg = l2_norm(graph_out.data(), n), lc = l2_norm(cpu_out.data(), n);
     const bool ok = cos >= 0.9995 && graph_out.size() == cpu_out.size();
     if (verbosity >= 1 || !ok) {
-        fprintf(stderr, "  %-16s %s cos=%.6f max_abs=%.3e  (graph=%zu cpu=%zu)\n", "band_split_graph", ok ? "PASS" : "FAIL",
-                cos, mad, graph_out.size(), cpu_out.size());
+        fprintf(stderr, "  %-16s %s cos=%.6f max_abs=%.3e  (graph=%zu cpu=%zu)\n", "band_split_graph",
+                ok ? "PASS" : "FAIL", cos, mad, graph_out.size(), cpu_out.size());
         if (verbosity >= 2)
             fprintf(stderr, "    |graph|=%.6f |cpu|=%.6f\n", lg, lc);
     }
@@ -1868,8 +1866,8 @@ int mel_band_roformer_parity(const char* model_gguf, const char* audio_wav, int 
         if (!p)
             n_fail++;
         if (verbosity >= 1 || !p)
-            fprintf(stderr, "  %-16s %s cos=%.6f max_abs=%.3e  (graph=%zu cpu=%zu)%s\n", stage, p ? "PASS" : "FAIL", c, a,
-                    graph.size(), cpu.size(),
+            fprintf(stderr, "  %-16s %s cos=%.6f max_abs=%.3e  (graph=%zu cpu=%zu)%s\n", stage, p ? "PASS" : "FAIL", c,
+                    a, graph.size(), cpu.size(),
                     verbosity >= 2 ? ("  |graph|=" + std::to_string(l2_norm(graph.data(), nn)) +
                                       " |cpu|=" + std::to_string(l2_norm(cpu.data(), nn)))
                                          .c_str()
@@ -1939,7 +1937,6 @@ int mel_band_roformer_parity(const char* model_gguf, const char* audio_wav, int 
 }
 
 int mel_band_roformer_diff(const char* model_gguf, const char* ref_gguf, const char* audio_wav, int verbosity) {
-
     mel_band_roformer_context* ctx = mel_band_roformer_init_from_file(model_gguf, mel_band_roformer_default_params());
     if (!ctx) {
         fprintf(stderr, "mbr_diff: failed to load model %s\n", model_gguf);

--- a/src/mel_band_roformer.cpp
+++ b/src/mel_band_roformer.cpp
@@ -1351,8 +1351,11 @@ bool run_forward(mel_band_roformer_context* ctx, const std::vector<std::vector<f
 
 } // namespace
 
-mel_band_roformer_result* mel_band_roformer_separate(mel_band_roformer_context* ctx, const float* pcm, int n_samples,
-                                                     int in_channels) {
+// Whole-buffer forward (no segmentation). Public API entry point for callers
+// that already chunk themselves (e.g. per-request audio); mel_band_roformer_separate
+// is the segmented wrapper below.
+static mel_band_roformer_result* mel_band_roformer_separate_full(mel_band_roformer_context* ctx, const float* pcm,
+                                                                 int n_samples, int in_channels) {
     if (!ctx || !pcm || n_samples <= 0)
         return nullptr;
     const int channels = ctx->hp.audio_channels;
@@ -1388,6 +1391,135 @@ mel_band_roformer_result* mel_band_roformer_separate(mel_band_roformer_context* 
             const size_t idx = (size_t)i * channels + s;
             r->sources[1][idx] = chan[s][i] - vocals[idx];
         }
+    r->source_names[0] = ctx->source_names_storage[0].c_str();
+    r->source_names[1] = ctx->source_names_storage.size() > 1 ? ctx->source_names_storage[1].c_str() : "other";
+    return r;
+}
+
+// Segmented forward with weighted overlap-add — the Demucs split=True pattern,
+// ported from htdemucs (src/htdemucs.cpp htdemucs_separate, itself Demucs
+// apply_model split=True): segment_length = 10 s of samples, overlap = 0.25,
+// triangular weight peaking mid-segment, normalised by the accumulated weight.
+//
+// WHY: the transformer attention matrix is O(T^2 * num_bands * heads) in the
+// ggml graph path (and O(T^2 * heads) per band in the CPU path) — a 3-min
+// song at 44.1 kHz is T ~= 20k frames, which is 17 GB+ of scores alone and
+// OOMs on any GPU (measured: 30 s clip needs ~19 GB on CUDA). Segmenting
+// bounds peak memory to one segment's working set and makes time linear in
+// length.
+//
+// Short inputs (<= one segment) take the whole-buffer path unchanged, so
+// existing behaviour/parity is preserved bit-for-bit. CRISPASR_MELBAND_NO_SEGMENT=1
+// forces the old behaviour everywhere for A/B.
+mel_band_roformer_result* mel_band_roformer_separate(mel_band_roformer_context* ctx, const float* pcm, int n_samples,
+                                                     int in_channels) {
+    if (!ctx || !pcm || n_samples <= 0)
+        return nullptr;
+    const int channels = ctx->hp.audio_channels;
+
+    // 10 s segment at the model sample rate (hop=441 => ~1001 STFT frames =>
+    // ~2 GB attention scores on GPU; well under the 24 GB RTX 3090).
+    // CRISPASR_MELBAND_SEG_S overrides the segment length in seconds (tests).
+    int seg_len = 10 * ctx->hp.sample_rate;
+    if (const char* seg_s = std::getenv("CRISPASR_MELBAND_SEG_S")) {
+        int s = atoi(seg_s);
+        if (s > 0)
+            seg_len = s * ctx->hp.sample_rate;
+    }
+    const bool no_seg = std::getenv("CRISPASR_MELBAND_NO_SEGMENT") != nullptr;
+    if (no_seg || n_samples <= seg_len || seg_len <= 0)
+        return mel_band_roformer_separate_full(ctx, pcm, n_samples, in_channels);
+
+    const float overlap = 0.25f;
+    int stride = (int)((1.0f - overlap) * (float)seg_len);
+    if (stride <= 0)
+        stride = seg_len;
+
+    // Triangular weight, peaking mid-segment (Demucs transition_power=1.0).
+    std::vector<float> weight((size_t)seg_len);
+    {
+        const int half = seg_len / 2;
+        for (int i = 0; i < half; i++)
+            weight[(size_t)i] = (float)(i + 1);
+        for (int i = half; i < seg_len; i++)
+            weight[(size_t)i] = (float)(seg_len - i);
+        float wmax = 0.0f;
+        for (float w : weight)
+            wmax = std::max(wmax, w);
+        if (wmax > 0.0f)
+            for (float& w : weight)
+                w /= wmax;
+    }
+
+    const int n_sources = 2;
+    std::vector<float> sum_weight((size_t)n_samples, 0.0f);
+    std::vector<float> acc((size_t)n_samples * channels, 0.0f); // vocals accumulator
+    std::vector<float> pcm_seg((size_t)seg_len * channels, 0.0f);
+
+    for (int off = 0; off < n_samples; off += stride) {
+        const int valid = std::min(seg_len, n_samples - off);
+        // Build the (already channel-interleaved) segment: zero-pad tail.
+        for (int i = 0; i < valid; i++)
+            for (int c = 0; c < channels; c++)
+                pcm_seg[(size_t)i * channels + c] = pcm[(size_t)(off + i) * channels + c];
+        for (size_t i = (size_t)valid * channels; i < pcm_seg.size(); i++)
+            pcm_seg[i] = 0.0f;
+
+        mel_band_roformer_result* part =
+            mel_band_roformer_separate_full(ctx, pcm_seg.data(), seg_len, channels);
+        if (!part) {
+            fprintf(stderr, "mel_band_roformer: segment @%d failed\n", off);
+            acc.clear();
+            return nullptr;
+        }
+        const int n = std::min(valid, part->n_samples);
+        // accumulate weighted vocals (stem 0); discard the 'other' residual
+        // (recomputed from the full original at the end).
+        const float* src = part->sources[0];
+        float* dst = acc.data();
+        for (int i = 0; i < n; i++) {
+            const float w = weight[(size_t)i];
+            for (int c = 0; c < channels; c++)
+                dst[(size_t)(off + i) * channels + c] += w * src[(size_t)i * channels + c];
+        }
+        for (int i = 0; i < n; i++)
+            sum_weight[(size_t)(off + i)] += weight[(size_t)i];
+        mel_band_roformer_result_free(part);
+    }
+
+    if (acc.empty())
+        return nullptr;
+
+    // Normalise vocals by accumulated weight; residual = original - vocals.
+    // Mix the original to model channels exactly like separate_full does, so
+    // the residual is valid for any in_channels (incl. mono up-mix).
+    fprintf(stderr, "mel_band_roformer: segmented %d samples into %d chunks of %d (stride %d, overlap %.0f%%)\n",
+            n_samples, (n_samples + stride - 1) / stride, seg_len, stride, 100.0f * overlap);
+    std::vector<float> orig_mix((size_t)n_samples * channels);
+    for (int i = 0; i < n_samples; i++)
+        for (int c = 0; c < channels; c++) {
+            int src = (in_channels <= 0) ? 0 : (c < in_channels ? c : in_channels - 1);
+            orig_mix[(size_t)i * channels + c] = pcm[(size_t)i * (in_channels > 0 ? in_channels : 1) + src];
+        }
+    auto* r = (mel_band_roformer_result*)calloc(1, sizeof(mel_band_roformer_result));
+    r->n_sources = n_sources;
+    r->n_channels = channels;
+    r->n_samples = n_samples;
+    r->sample_rate = ctx->hp.sample_rate;
+    r->sources = (float**)calloc(n_sources, sizeof(float*));
+    r->source_names = (const char**)calloc(n_sources, sizeof(char*));
+    const size_t nf = (size_t)n_samples * channels;
+    r->sources[0] = (float*)malloc(nf * sizeof(float));
+    r->sources[1] = (float*)malloc(nf * sizeof(float));
+    for (int i = 0; i < n_samples; i++) {
+        const float w = sum_weight[(size_t)i];
+        for (int c = 0; c < channels; c++) {
+            const size_t idx = (size_t)i * channels + c;
+            float v = w > 0.0f ? acc[idx] / w : 0.0f;
+            r->sources[0][idx] = v;
+            r->sources[1][idx] = orig_mix[idx] - v;
+        }
+    }
     r->source_names[0] = ctx->source_names_storage[0].c_str();
     r->source_names[1] = ctx->source_names_storage.size() > 1 ? ctx->source_names_storage[1].c_str() : "other";
     return r;

--- a/src/mel_band_roformer.cpp
+++ b/src/mel_band_roformer.cpp
@@ -14,12 +14,16 @@
 #include "mel_band_roformer.h"
 
 #include "ggml-backend.h"
+#include "ggml-alloc.h" // ggml_gallocr_* (Change 176: band-split ggml graph path)
 #include "ggml-cpu.h"
 #include "ggml.h"
 
 #include "core/fft.h"         // fft_radix2_wrapper (r2c, interleaved full spectrum)
+#include "core/ggml_cpu_backend.h" // core_cpu_backend::init/is_cpu (Change 176)
 #include "core/gguf_loader.h" // core_gguf::{open_metadata,kv_u32,load_weights}
+#include "core/gpu_backend_pref.h" // crispasr_init_gpu_backend (Change 176, htdemucs pattern)
 #include "core/istft.h"       // core_istft::istft (torch center=True match)
+#include "core/wav_reader.h"  // crispasr::core::read_wav_mono_pcm16 (Change 176 parity)
 
 // BLAS for the linear() SGEMM. #296: the forward is ~264 GFLOP of matmul; without
 // a BLAS backend linear() falls back to a scalar loop that took ~24 min on an 11s
@@ -82,6 +86,11 @@ struct mel_band_roformer_context {
 
     ggml_backend_t backend = nullptr;
     core_gguf::WeightLoad weights;
+
+    // Change 176: band-split runs as a ggml graph on `backend` (GPU-capable)
+    // when use_graph is set; otherwise the validated CPU reference path runs.
+    bool use_graph = false;
+    bool is_gpu = false;
 
     // Baked band layout (from the converter's aux.* int32 tensors).
     std::vector<int32_t> freq_indices;       // length = sum over bands of 2*nfreq*ch? no: N gather idx
@@ -282,12 +291,38 @@ mel_band_roformer_context* mel_band_roformer_init_from_file(const char* model_pa
     hp.normalized = (int)core_gguf::kv_u32(meta, "mel-band-roformer.stft_normalized", hp.normalized);
     core_gguf::free_metadata(meta);
 
-    ctx->backend = core_cpu_backend::init();
+    // Change 176: backend selection honours params.use_gpu + CRISPASR_MELBAND_GPU,
+    // mirroring the htdemucs pattern (src/htdemucs.cpp:635-662). The ggml graph
+    // path is the gate to the GPU backend: want_gpu WITHOUT the graph path would
+    // put the weights on the GPU and pay a device->host read on every scalar
+    // kernel (htdemucs lesson). CRISPASR_MELBAND_GGML=1 enables the graph band-
+    // split; CRISPASR_MELBAND_GPU=1 forces the GPU backend (falls back to CPU on
+    // GPU-less hosts), =0 forces CPU. Default: CPU backend + CPU reference path
+    // (no behavior change for existing users until parity is green, E2).
+    const char* ggml_env = getenv("CRISPASR_MELBAND_GGML");
+    const bool want_graph = ggml_env && ggml_env[0] && atoi(ggml_env) != 0;
+    bool want_gpu = false;
+    const char* gpu_env = getenv("CRISPASR_MELBAND_GPU");
+    if (gpu_env && gpu_env[0])
+        want_gpu = atoi(gpu_env) != 0;
+    if (params.use_gpu)
+        want_gpu = true;
+    if (want_graph && want_gpu) {
+        ctx->backend = crispasr_init_gpu_backend();
+        if (!ctx->backend)
+            ctx->backend = core_cpu_backend::init();
+    } else {
+        ctx->backend = core_cpu_backend::init();
+    }
     if (!ctx->backend) {
-        fprintf(stderr, "mel_band_roformer: ggml_backend_cpu_init failed\n");
+        fprintf(stderr, "mel_band_roformer: backend init failed\n");
         delete ctx;
         return nullptr;
     }
+    ctx->use_graph = want_graph;
+    ctx->is_gpu = !core_cpu_backend::is_cpu(ctx->backend);
+    fprintf(stderr, "mel_band_roformer: backend = %s (graph=%d, gpu=%d)\n", ggml_backend_name(ctx->backend),
+            ctx->use_graph ? 1 : 0, ctx->is_gpu ? 1 : 0);
     if (!core_gguf::load_weights(model_path, ctx->backend, "mel_band_roformer", ctx->weights)) {
         fprintf(stderr, "mel_band_roformer: failed to load weights from '%s'\n", model_path);
         mel_band_roformer_free(ctx);
@@ -438,7 +473,150 @@ bool band_split_cpu(core_gguf::WeightLoad& mw, const std::vector<float>& gathere
     return true;
 }
 
-// y[t][o] = sum_i x[t][i] * W[o][i] + (bias ? bias[o] : 0). W row-major (dout,din).
+// ---------------------------------------------------------------------------
+// Change 176 (Phase 1): band-split encoder as a ggml graph, cleanroom port
+// following the htdemucs graph pattern (src/htdemucs.cpp). Runs on
+// ctx->backend (CPU or GPU); produces the SAME output layout as band_split_cpu
+// ((T, nb, dim) row-major — see the flat-layout note below), so the parity test
+// compares the two functions element-for-element on identical input.
+//
+// Flat-layout equivalence: the graph output is a (dim, nb, T) ggml tensor
+// (ne[0]=dim fastest). Its flat index is o + dim*(b + nb*t) — byte-identical to
+// band_split_cpu's row-major (T, nb, dim) index ((t*nb + b)*dim + o). The graph
+// result can therefore be handed straight to the transformer stack unchanged.
+// ---------------------------------------------------------------------------
+bool band_split_graph(mel_band_roformer_context* ctx, const std::vector<float>& gathered, int T,
+                      std::vector<float>& out) {
+    const auto& hp = ctx->hp;
+    const int nb = (int)ctx->band_width.size();
+    const int dim = hp.dim;
+    const int N2 = (int)ctx->freq_indices.size() * 2; // gathered feature axis width
+
+    if ((int64_t)gathered.size() != (int64_t)T * N2)
+        return false;
+
+    // Per band: view + rms_norm (5 ops) + linear (mul_mat + add) + reshape ≈ 9
+    // tensors; plus ~nb concat nodes, the input and the output.
+    const size_t n_nodes = 16 * (size_t)nb + 64;
+    ggml_init_params gparams = {
+        /*.mem_size   = */ ggml_tensor_overhead() * n_nodes + ggml_graph_overhead_custom((size_t)n_nodes, false),
+        /*.mem_buffer = */ nullptr,
+        /*.no_alloc   = */ true,
+    };
+    ggml_context* gctx = ggml_init(gparams);
+    if (!gctx)
+        return false;
+
+    // Input: gathered is (T, 2N) row-major; as a ggml (2N, T) tensor the flat
+    // memory order (ne[0] fastest) is identical, so no copy/transpose is needed.
+    ggml_tensor* in = ggml_new_tensor_2d(gctx, GGML_TYPE_F32, N2, T);
+    ggml_set_name(in, "mbr_band_split_in");
+    ggml_set_input(in);
+
+    std::vector<ggml_tensor*> bands;
+    bands.reserve((size_t)nb);
+    std::vector<ggml_tensor*> sqrt_dim_ts;
+    sqrt_dim_ts.reserve((size_t)nb);
+
+    // RMSNorm constants (F.normalize eps, sqrt(dim) scale) as 1-element INPUT
+    // tensors: ggml_new_f32 asserts !no_alloc, and the graph context must be
+    // no_alloc so gallocr can place intermediates on the backend buffer. Values
+    // are written once via ggml_backend_tensor_set before compute (htdemucs
+    // pattern). Broadcast to (1, T) via ggml_can_repeat in the binops below.
+    ggml_tensor* eps_t = ggml_new_tensor_1d(gctx, GGML_TYPE_F32, 1);
+    ggml_set_name(eps_t, "mbr_rms_eps");
+    ggml_set_input(eps_t);
+
+    int off = 0;
+    for (int b = 0; b < nb; b++) {
+        const int din = ctx->band_width[b];
+        const std::string pre = "band_split.to_features." + std::to_string(b);
+
+        auto it_g = ctx->weights.tensors.find(pre + ".0.gamma");
+        auto it_w = ctx->weights.tensors.find(pre + ".1.weight");
+        auto it_b = ctx->weights.tensors.find(pre + ".1.bias");
+        if (it_g == ctx->weights.tensors.end() || it_w == ctx->weights.tensors.end() ||
+            it_b == ctx->weights.tensors.end() || !it_g->second || !it_w->second || !it_b->second) {
+            ggml_free(gctx);
+            return false;
+        }
+
+        // Band b's slice: rows [off, off+din) of the (2N, T) input.
+        ggml_tensor* xv = ggml_view_2d(gctx, in, din, T, in->nb[1], (size_t)off * sizeof(float));
+        off += din;
+
+        // RMSNorm — exact CPU formula: y = x * sqrt(din) / (sqrt(sum(x^2)) + eps) * gamma.
+        // NOTE: the sqrt scale uses the BAND's input width din (CPU rms_norm_inplace
+        // gets din), NOT the model dim — a global sqrt(hp.dim) scaled every band
+        // differently and broke parity (cos=0.877, |graph|/|cpu| ~2.1).
+        ggml_tensor* sq = ggml_mul(gctx, xv, xv);                     // (din, T)
+        ggml_tensor* ss = ggml_sum_rows(gctx, sq);                    // (1, T)
+        ggml_tensor* rt = ggml_sqrt(gctx, ss);                        // (1, T)
+        ggml_tensor* denom = ggml_add(gctx, rt, eps_t);               // (1, T)
+        // div(a,b) takes a's shape and repeats b to it — repeat sqrt_dim to (1,T) first.
+        ggml_tensor* sqrt_dim_t = ggml_new_tensor_1d(gctx, GGML_TYPE_F32, 1);
+        ggml_set_name(sqrt_dim_t, ("mbr_rms_sqrt_dim_" + std::to_string(b)).c_str());
+        ggml_set_input(sqrt_dim_t);
+        sqrt_dim_ts.push_back(sqrt_dim_t);
+        ggml_tensor* scale = ggml_div(gctx, ggml_repeat(gctx, sqrt_dim_t, denom), denom); // (1, T)
+        ggml_tensor* xn = ggml_mul(gctx, xv, scale);                  // (din, T) broadcast
+        ggml_tensor* y = ggml_mul(gctx, xn, it_g->second);            // * gamma (din, 1) broadcast
+
+        // Linear: mul_mat(weight (din, dim), y (din, T)) -> (dim, T); + bias
+        ggml_tensor* proj = ggml_mul_mat(gctx, it_w->second, y);
+        ggml_tensor* bout = ggml_add(gctx, proj, it_b->second);
+
+        // (dim, 1, T) for the band-axis concat below.
+        ggml_tensor* b3 = ggml_reshape_3d(gctx, bout, dim, 1, T);
+        ggml_set_name(b3, ("band_split." + std::to_string(b)).c_str());
+        bands.push_back(b3);
+    }
+
+    // Balanced concat along the band axis (BSRoformer ConcatBalanced pattern) ->
+    // (dim, nb, T). Its flat order equals (T, nb, dim) row-major (see above).
+    auto concat_balanced = [&](auto&& self, size_t lo, size_t hi) -> ggml_tensor* {
+        if (hi - lo == 1)
+            return bands[lo];
+        const size_t mid = lo + (hi - lo) / 2;
+        ggml_tensor* a = self(self, lo, mid);
+        ggml_tensor* b = self(self, mid, hi);
+        return ggml_concat(gctx, a, b, 1);
+    };
+    ggml_tensor* out3 = concat_balanced(concat_balanced, 0, bands.size());
+    ggml_set_name(out3, "mbr_band_split_out");
+    ggml_set_output(out3);
+
+    ggml_cgraph* gf = ggml_new_graph_custom(gctx, (size_t)n_nodes, false);
+    ggml_build_forward_expand(gf, out3);
+
+    ggml_gallocr_t alloc = ggml_gallocr_new(ggml_backend_get_default_buffer_type(ctx->backend));
+    if (!alloc || !ggml_gallocr_alloc_graph(alloc, gf)) {
+        fprintf(stderr, "mel_band_roformer: band_split_graph gallocr alloc failed\n");
+        if (alloc)
+            ggml_gallocr_free(alloc);
+        ggml_free(gctx);
+        return false;
+    }
+
+    ggml_backend_tensor_set(in, gathered.data(), 0, gathered.size() * sizeof(float));
+    const float eps = 1e-12f; // F.normalize eps — see rms_norm_inplace
+    ggml_backend_tensor_set(eps_t, &eps, 0, sizeof(float));
+    for (int b = 0; b < nb; b++) {
+        // Per-band sqrt(din): the CPU reference scales RMSNorm by sqrt(din_b),
+        // not sqrt(hp.dim) — see the formula note above.
+        const float sqrt_dim = std::sqrt((float)ctx->band_width[b]);
+        ggml_backend_tensor_set(sqrt_dim_ts[b], &sqrt_dim, 0, sizeof(float));
+    }
+    ggml_backend_graph_compute(ctx->backend, gf);
+
+    const int64_t n = ggml_nelements(out3);
+    out.resize((size_t)n);
+    ggml_backend_tensor_get(out3, out.data(), 0, (size_t)n * sizeof(float));
+
+    ggml_gallocr_free(alloc);
+    ggml_free(gctx);
+    return true;
+}
 void linear(const std::vector<float>& x, int T, int din, const std::vector<float>& W, const std::vector<float>* bias,
             int dout, std::vector<float>& y) {
     y.assign((size_t)T * dout, 0.0f);
@@ -895,9 +1073,19 @@ bool run_forward(mel_band_roformer_context* ctx, const std::vector<std::vector<f
     std::vector<float> gathered;
     band_gather(packed, ctx->freq_indices, T, gathered);
     std::vector<float> x;
-    if (!band_split_cpu(ctx->weights, gathered, ctx->band_width, T, dim, x))
+    bool bs_ok;
+    if (ctx->use_graph) {
+        // Change 176 (Phase 1): ggml-graph band-split on ctx->backend. Parity
+        // gate: output layout identical to band_split_cpu, compared in the
+        // diff harness (band_split_out stage).
+        bs_ok = band_split_graph(ctx, gathered, T, x);
+        lap("band_split(graph)");
+    } else {
+        bs_ok = band_split_cpu(ctx->weights, gathered, ctx->band_width, T, dim, x);
+        lap("band_split");
+    }
+    if (!bs_ok)
         return false;
-    lap("band_split");
     // Compute-heavy Transformer stack; emit per-layer progress so it never looks
     // hung, and (under profiling) split run_time vs run_freq time.
     fprintf(stderr, "mel_band_roformer: separating (T=%d frames, %d layers, %d bands)...\n", T, hp.depth, nb);
@@ -976,8 +1164,76 @@ mel_band_roformer_result* mel_band_roformer_separate(mel_band_roformer_context* 
     return r;
 }
 
+int mel_band_roformer_parity(const char* model_gguf, const char* audio_wav, int verbosity) {
+    // Change 176 Phase 1: standalone parity — ggml-graph band-split vs the
+    // validated CPU reference on IDENTICAL input (the same wav, run through the
+    // same STFT/gather front-end). The CPU path is cos=1.0 vs the Python
+    // fixture, so graph==CPU proves the cleanroom port without needing torch or
+    // the fixture. Returns 0 iff the graph stage passes the diff threshold.
+    mel_band_roformer_context* ctx = mel_band_roformer_init_from_file(model_gguf, mel_band_roformer_default_params());
+    if (!ctx) {
+        fprintf(stderr, "mbr_parity: failed to load model %s\n", model_gguf);
+        return 2;
+    }
+
+    std::vector<float> pcm;
+    int sr = 0;
+    if (!crispasr::core::read_wav_mono_pcm16(audio_wav, pcm, sr)) {
+        fprintf(stderr, "mbr_parity: failed to read wav %s\n", audio_wav);
+        mel_band_roformer_free(ctx);
+        return 2;
+    }
+    // The front-end expects `channels` per-channel arrays; mono wav -> 1 channel.
+    const int channels = ctx->hp.audio_channels;
+    std::vector<std::vector<float>> chan(channels, std::vector<float>(pcm.size(), 0.0f));
+    for (size_t i = 0; i < pcm.size(); i++)
+        for (int s = 0; s < channels; s++)
+            chan[s][i] = pcm[i];
+
+    const auto& hp = ctx->hp;
+    const int n_freqs = ctx->n_freqs();
+    const int T_samp = (int)pcm.size();
+    const int T = stft_n_frames(T_samp, hp.hop);
+
+    std::vector<float> window;
+    hann_periodic(hp.win, window);
+    std::vector<std::vector<float>> chan_spec(channels);
+    for (int s = 0; s < channels; s++)
+        stft_one_channel(chan[s].data(), T_samp, hp.n_fft, hp.hop, window, T, n_freqs, chan_spec[s]);
+    std::vector<float> packed;
+    pack_stft(chan_spec, n_freqs, T, channels, packed);
+    std::vector<float> gathered;
+    band_gather(packed, ctx->freq_indices, T, gathered);
+
+    fprintf(stderr, "mel_band_roformer parity (T_samp=%d, T=%d, n_freqs=%d, channels=%d, N_gather=%zu):\n", T_samp, T,
+            n_freqs, channels, ctx->freq_indices.size());
+
+    std::vector<float> cpu_out, graph_out;
+    const bool cpu_ok = band_split_cpu(ctx->weights, gathered, ctx->band_width, T, hp.dim, cpu_out);
+    const bool graph_ok = band_split_graph(ctx, gathered, T, graph_out);
+    if (!cpu_ok || !graph_ok) {
+        fprintf(stderr, "mbr_parity: band-split failed (cpu=%d graph=%d)\n", cpu_ok ? 1 : 0, graph_ok ? 1 : 0);
+        mel_band_roformer_free(ctx);
+        return 2;
+    }
+
+    const int64_t n = (int64_t)std::min(cpu_out.size(), graph_out.size());
+    const double cos = cosine(graph_out.data(), cpu_out.data(), n);
+    const double mad = max_abs_diff(graph_out.data(), cpu_out.data(), n);
+    const double lg = l2_norm(graph_out.data(), n), lc = l2_norm(cpu_out.data(), n);
+    const bool ok = cos >= 0.9995 && graph_out.size() == cpu_out.size();
+    if (verbosity >= 1 || !ok) {
+        fprintf(stderr, "  %-16s %s cos=%.6f max_abs=%.3e  (graph=%zu cpu=%zu)\n", "band_split_graph", ok ? "PASS" : "FAIL",
+                cos, mad, graph_out.size(), cpu_out.size());
+        if (verbosity >= 2)
+            fprintf(stderr, "    |graph|=%.6f |cpu|=%.6f\n", lg, lc);
+    }
+    mel_band_roformer_free(ctx);
+    fprintf(stderr, "mel_band_roformer parity: %s\n", ok ? "PASS" : "FAIL");
+    return ok ? 0 : 1;
+}
+
 int mel_band_roformer_diff(const char* model_gguf, const char* ref_gguf, const char* audio_wav, int verbosity) {
-    (void)audio_wav; // Phase 1 reads input_audio FROM the ref (input-aligned).
 
     mel_band_roformer_context* ctx = mel_band_roformer_init_from_file(model_gguf, mel_band_roformer_default_params());
     if (!ctx) {
@@ -1096,6 +1352,26 @@ int mel_band_roformer_diff(const char* model_gguf, const char* ref_gguf, const c
                     report("band_split_out", bso, ref_bso);
             } else {
                 fprintf(stderr, "  band_split_out: SKIP (a band weight was missing)\n");
+            }
+        }
+    }
+
+    // --- band_split_out (GRAPH): Change 176 Phase 1 parity gate ---
+    // The ggml-graph band-split vs the validated CPU reference, on IDENTICAL
+    // input (the same reference band_gathered). This is the Phase 1 acceptance
+    // test: the CPU path is already cos=1.0 vs the Python fixture, so
+    // graph==CPU proves the cleanroom port. Uses a fresh default ctx so the
+    // graph runs on the same backend as the harness ctx (no flag pollution).
+    {
+        std::vector<float> ref_bg_in;
+        int64_t nn = 0;
+        if (ref_get(rw, "band_gathered", ref_bg_in, nn)) {
+            std::vector<float> cpu_out, graph_out;
+            if (band_split_cpu(ctx->weights, ref_bg_in, ctx->band_width, T, hp.dim, cpu_out) &&
+                band_split_graph(ctx, ref_bg_in, T, graph_out)) {
+                report("band_split_graph", graph_out, cpu_out);
+            } else {
+                fprintf(stderr, "  band_split_graph: SKIP (graph or CPU band-split failed)\n");
             }
         }
     }

--- a/src/mel_band_roformer.h
+++ b/src/mel_band_roformer.h
@@ -28,6 +28,11 @@ struct mel_band_roformer_params {
     int n_threads;  // 0 = auto
     bool use_gpu;   // attempt GPU acceleration (Metal/CUDA); CPU otherwise
     int gpu_device; // GPU device index
+    // Change 176: segmentation toggles (defaults = validated 10 s Demucs-split).
+    // Graph/fused/GPU are NOT caller fields — they resolve once in init via
+    // mel_band_gates::resolve() (env AUTO/override, mirrors htdemucs #414).
+    int segment_seconds; // Demucs-style split length; <=0 = default (10 s), 1 = per-second
+    bool no_segment;     // 1 = whole-buffer forward even for long audio (A/B)
 };
 
 // Separation result: one waveform per source. For the vocals model the sources

--- a/src/mel_band_roformer.h
+++ b/src/mel_band_roformer.h
@@ -71,6 +71,13 @@ const char* mel_band_roformer_source_name(const mel_band_roformer_context* ctx, 
 // verbosity: 0 = summary, 1 = per-stage, 2 = per-stage + magnitudes.
 int mel_band_roformer_diff(const char* model_gguf, const char* ref_gguf, const char* audio_wav, int verbosity);
 
+// Change 176 Phase 1: standalone band-split parity — the ggml-graph band-split
+// vs the validated CPU reference on IDENTICAL input (a wav run through the same
+// STFT/gather front-end). No Python fixture needed. Returns 0 iff the graph
+// stage passes the cos threshold (>= 0.9995) with equal output sizes.
+// verbosity: 1 = result, 2 = result + magnitudes.
+int mel_band_roformer_parity(const char* model_gguf, const char* audio_wav, int verbosity);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/mel_band_roformer.h
+++ b/src/mel_band_roformer.h
@@ -28,10 +28,12 @@ struct mel_band_roformer_params {
     int n_threads;  // 0 = auto
     bool use_gpu;   // attempt GPU acceleration (Metal/CUDA); CPU otherwise
     int gpu_device; // GPU device index
-    // Change 176: segmentation toggles (defaults = validated 10 s Demucs-split).
+    // Change 176: segmentation toggles. Default segment length comes from the
+    // checkpoint's trained chunk_size (GGUF metadata; 8 s Kim fallback) — NOT
+    // a fixed 10 s, which would extrapolate RoPE 25% past training (review #422).
     // Graph/fused/GPU are NOT caller fields — they resolve once in init via
     // mel_band_gates::resolve() (env AUTO/override, mirrors htdemucs #414).
-    int segment_seconds; // Demucs-style split length; <=0 = default (10 s), 1 = per-second
+    int segment_seconds; // Demucs-style split length; <=0 = trained chunk_size, 1 = per-second
     bool no_segment;     // 1 = whole-buffer forward even for long audio (A/B)
 };
 
@@ -81,6 +83,12 @@ int mel_band_roformer_diff(const char* model_gguf, const char* ref_gguf, const c
 // STFT/gather front-end). No Python fixture needed. Returns 0 iff the graph
 // stage passes the cos threshold (>= 0.9995) with equal output sizes.
 // verbosity: 1 = result, 2 = result + magnitudes.
+//
+// NOTE (review #422): this inits from default_params() with use_gpu=false, so
+// a bare run compares CPU-graph against CPU-reference even on a GPU host; set
+// CRISPASR_MELBAND_GPU=1 for a GPU run. The init line prints the backend name
+// ("mel_band_roformer: backend = ...") — do not record a "GPU PASS" from a run
+// whose printed backend is CPU.
 int mel_band_roformer_parity(const char* model_gguf, const char* audio_wav, int verbosity);
 
 #ifdef __cplusplus

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -3336,6 +3336,22 @@ catch_discover_tests(test-sidon-rpe-gates
     TEST_SPEC "[sidon]"
     PROPERTIES LABELS "unit;sidon"
 )
+# ─── test-mel-band-gates — unit tests for the Change-176 path-selection
+# table (mirrors test-htdemucs-gates; AUTO fused-graph-GPU on real-GPU hosts,
+# CPU path otherwise, env overrides, #414 review semantics).
+add_executable(test-mel-band-gates
+    test-mel-band-gates.cpp
+)
+target_include_directories(test-mel-band-gates PRIVATE
+    ${PROJECT_SOURCE_DIR}/src
+)
+target_link_libraries(test-mel-band-gates PRIVATE
+    Catch2::Catch2WithMain
+)
+catch_discover_tests(test-mel-band-gates
+    TEST_SPEC "[mel-band]"
+    PROPERTIES LABELS "unit;mel-band"
+)
 
 # ─── test-uroman — Catch2 unit tests for core/uroman.h romanization.
 # Validates Arabic + Cyrillic romanization for CTC forced alignment (#252).

--- a/tests/test-mel-band-gates.cpp
+++ b/tests/test-mel-band-gates.cpp
@@ -1,0 +1,88 @@
+// test-mel-band-gates.cpp — unit tests for src/mel_band_gates.h (Change 176).
+//
+// Mirrors tests/test-htdemucs-gates.cpp (PR #414): the AUTO defaults encode
+// measured facts — fused single graph on GPU ~112x faster than the per-layer
+// graphs (2.6 s vs 4:47 on a 30 s clip, RTX 3090 Ti) and RTF ~0.09 on a full
+// song; the legacy CPU path is RTF ~57. These cases lock the whole decision
+// table, including the #414 review catches: (a) FUSED=1 alone must not leave
+// the graph off — it implies the graph it needs; (b) CRISPASR_MELBAND_GPU=0
+// must actually opt out even though the CLI's params.use_gpu can be true.
+
+#include "mel_band_gates.h"
+
+#include <catch2/catch_test_macros.hpp>
+
+using mel_band_gates::resolve;
+
+TEST_CASE("mel-band gates: AUTO on a real-GPU host = fused graph on GPU", "[unit][mel-band]") {
+    const auto r = resolve(nullptr, nullptr, nullptr, /*caller_use_gpu=*/true, /*have_real_gpu=*/true);
+    REQUIRE(r.use_graph);
+    REQUIRE(r.use_fused);
+    REQUIRE(r.gpu_backend);
+}
+
+TEST_CASE("mel-band gates: AUTO on a CPU-only host = legacy CPU path, unchanged", "[unit][mel-band]") {
+    const auto r = resolve(nullptr, nullptr, nullptr, true, /*have_real_gpu=*/false);
+    REQUIRE_FALSE(r.use_graph);
+    REQUIRE_FALSE(r.use_fused);
+    REQUIRE_FALSE(r.gpu_backend);
+}
+
+TEST_CASE("mel-band gates: GPU=0 opts out even though the caller may default use_gpu=true", "[unit][mel-band]") {
+    const auto r = resolve("0", nullptr, nullptr, /*caller_use_gpu=*/true, true);
+    REQUIRE_FALSE(r.gpu_backend);
+    REQUIRE_FALSE(r.use_graph); // AUTO graph follows gpu -> CPU path
+}
+
+TEST_CASE("mel-band gates: caller intent (use_gpu=false) keeps CPU; GPU=1 env overrides it", "[unit][mel-band]") {
+    const auto no_gpu = resolve(nullptr, nullptr, nullptr, /*caller_use_gpu=*/false, true);
+    REQUIRE_FALSE(no_gpu.gpu_backend);
+    REQUIRE_FALSE(no_gpu.use_graph);
+
+    const auto forced = resolve("1", nullptr, nullptr, /*caller_use_gpu=*/false, true);
+    REQUIRE(forced.gpu_backend);
+    REQUIRE(forced.use_graph);
+    REQUIRE(forced.use_fused);
+}
+
+TEST_CASE("mel-band gates: GPU=1 on a GPU-less host still resolves to the CPU path", "[unit][mel-band]") {
+    const auto r = resolve("1", nullptr, nullptr, true, /*have_real_gpu=*/false);
+    REQUIRE_FALSE(r.gpu_backend);
+    REQUIRE_FALSE(r.use_graph);
+}
+
+TEST_CASE("mel-band gates: explicit GGML=1 keeps the opt-in graph path on CPU (unfused)", "[unit][mel-band]") {
+    // CPU graph path, per-layer (FUSED still AUTO-off off-GPU) — the explicit
+    // A/B configuration used during Change 176 parity runs.
+    const auto r = resolve(nullptr, "1", nullptr, true, false);
+    REQUIRE(r.use_graph);
+    REQUIRE_FALSE(r.use_fused);
+    REQUIRE_FALSE(r.gpu_backend);
+}
+
+TEST_CASE("mel-band gates: FUSED=1 alone implies the graph it needs (#414 review catch)", "[unit][mel-band]") {
+    const auto gpu = resolve(nullptr, nullptr, "1", true, true);
+    REQUIRE(gpu.use_graph);
+    REQUIRE(gpu.use_fused);
+    REQUIRE(gpu.gpu_backend);
+
+    // On CPU it stays consistent: graph engages, fused engages, CPU backend.
+    const auto cpu = resolve(nullptr, nullptr, "1", true, false);
+    REQUIRE(cpu.use_graph);
+    REQUIRE(cpu.use_fused);
+    REQUIRE_FALSE(cpu.gpu_backend);
+}
+
+TEST_CASE("mel-band gates: GGML=0 explicitly forces the CPU path even on GPU", "[unit][mel-band]") {
+    const auto r = resolve(nullptr, "0", nullptr, true, true);
+    REQUIRE_FALSE(r.use_graph);
+    REQUIRE_FALSE(r.use_fused);
+    REQUIRE_FALSE(r.gpu_backend);
+}
+
+TEST_CASE("mel-band gates: FUSED=0 on GPU keeps graph+GPU but unfused (bisection arm)", "[unit][mel-band]") {
+    const auto r = resolve(nullptr, nullptr, "0", true, true);
+    REQUIRE(r.use_graph);
+    REQUIRE_FALSE(r.use_fused);
+    REQUIRE(r.gpu_backend);
+}


### PR DESCRIPTION
### Summary

GPU port of the mel-band-roformer separation backend (Refs #415): the forward pass is now built as ggml graphs instead of the host-side C++ loops, and a **fused single graph** runs band-split + the full 12-block time/freq transformer stack + the mask estimator on-device in one pass. Built cleanroom following the in-repo htdemucs graph pattern (PR #414), with chenmozhijin/BSRoformer.cpp (MIT) used strictly as a correctness oracle — no code copied; attribution noted in the file header.

### What changed

- **Phase 1/2:** band-split and the RoFormer transformer blocks as ggml graphs, byte-identical to the validated CPU path (same builder functions, no duplication).
- **Phase 5 (fused):** one graph per segment for the whole forward — removes the 13 host↔GPU roundtrips per segment (~740 MB PCIe traffic per layer) and moves the mask estimator off the CPU.
- **Segmenting:** Demucs-style 10 s segments with 25% overlap and triangular weighting for long audio (the attention matrix is O(T²·bands·heads); the unsegmented path OOMs beyond ~10 s).
- **Path selection** mirrors the htdemucs-gates architecture you established in #414 (`src/mel_band_gates.h`, pure `resolve()` + decision-table unit tests in `tests/test-mel-band-gates.cpp`, 9 cases): env unset = AUTO, `=0`/`=1` force either way, env beats caller intent in both directions, `FUSED=1` alone implies the graph path. Defaults stay on the validated CPU path; the AUTO upgrade to fused-GPU happens exactly when a real GPU backend is present and permitted.

### Verification

| Check | Result |
|---|---|
| CPU parity (golden10s, all stages) | cos=1.000000 (band_split, layer0_time, layer0_freq) |
| Fused graph vs CPU chain (7,923,916 elems) | cos=1.000000, max_abs 1.08e-4 (F16 noise level) |
| GPU parity, CUDA0 (same harness) | cos=1.000000 — fused_mask_raw PASS |
| Per-layer vs fused stems (30 s clip, vocals+other) | cos=0.99999999 (16-bit LSB only) |
| Path-selection unit tests | 9/9 passed (30 assertions) |
| `mel_band_roformer parity:` | PASS |

### Measured (RTX 3090 Ti, golden10s / 30 s clip / full track)

| Path | 30 s clip | RTF (full 359 s track) |
|---|---|---|
| CPU (legacy, validated reference) | ~28 min | ~57 |
| GPU per-layer graphs (13 roundtrips/segment) | 4:47 | ~10 |
| **GPU fused single graph** | **2.57 s** | **0.076** (~112× vs per-layer; 359 s song in 27 s) |

### Review questions

- **Default/AUTO semantics:** this PR ships the same AUTO gate pattern as #414 (fused-GPU exactly when a real GPU backend exists, legacy CPU path otherwise, no behavior change on CPU-only hosts). If you'd rather keep the mel-band graph path strictly opt-in for now (as the very first #414 iteration did), say so and I'll flip the AUTO default off.
- **Segment length:** default 10 s is hardcoded (`params.segment_seconds <= 0`); `CRISPASR_MELBAND_SEG_S` overrides. Happy to expose it as a CLI flag if you want it user-facing.

### Notes

- Refs #415 (planning/acceptance discussion) — do not auto-close on merge.
- Env docs added in `docs/environment-variables.md` (CRISPASR_MELBAND_GGML / GPU / FUSED / SEG_S / NO_SEGMENT), same style as the HTDemucs section.
- —
- *Drafted with assistance from Hermes, an AI agent (Nous Research Hermes Agent), on behalf of the contributor tilllt.*