### PR TITLE
Add generic ASR env parity tool

### DIFF
--- a/tools/asr-env-parity.sh
+++ b/tools/asr-env-parity.sh
@@ -1,0 +1,387 @@
+#!/usr/bin/env bash
+# asr-env-parity.sh
+#
+# Generic byte-parity harness for CrispASR environment-gated code paths.
+#
+# For every matching audio file, run:
+#   baseline -> each test env individually -> all test envs together (when 2+ test envs)
+# and compare stdout byte-for-byte against that file's baseline.
+#
+# The harness is intentionally backend-agnostic. It knows nothing about
+# Nemotron, CUDA/Vulkan/Metal, or individual optimization activation logs.
+# Everything after "--" is passed unchanged to the CrispASR command; the
+# harness only appends "-f <audio>" for each input file.
+
+set -u
+set -o pipefail
+
+SAMPLES="samples"
+PATTERN="*.wav"
+OUT=""
+FAIL_FAST=0
+RUN_LABEL="default"
+TEST_ENVS=()
+BASE_ENVS=()
+UNSET_ENVS=()
+CMD=()
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  tools/asr-env-parity.sh [harness options] -- CRISPASR [crispasr args ...]
+
+For each matching audio file, runs:
+  baseline
+  each -e/--env setting individually
+  all -e/--env settings together (only when two or more -e settings are given)
+
+stdout is compared byte-for-byte against the per-file baseline. stderr and
+stdout from every run are retained for diagnosis.
+
+Harness options (before --):
+  -s, --samples DIR      Input directory (default: samples)
+  -p, --pattern GLOB     File-name glob (default: *.wav)
+  -o, --out DIR          Results directory (default: /tmp/asr-env-parity-$$)
+  -n, --name NAME        Run/profile label shown in output (default: default)
+
+  -e, --env SPEC         Test env. Repeatable.
+                         SPEC may be NAME or NAME=VALUE.
+                         NAME means NAME=1.
+
+  -E, --base-env SPEC    Env applied to baseline and every variant. Repeatable.
+                         SPEC may be NAME or NAME=VALUE.
+                         NAME means NAME=1.
+
+  -u, --unset NAME       Unset env in every run before applying -E/-e.
+                         Repeatable. Test env names from -e are always unset
+                         automatically before each run, preventing shell leakage.
+
+      --fail-fast        Stop on first command error or parity mismatch
+  -h, --help             Show this help
+
+Everything after -- is passed unchanged to CrispASR. Do not pass -f/--file;
+the harness appends -f <audio> itself.
+
+Examples:
+  # Generic single-gate test
+  tools/asr-env-parity.sh \
+    -e CRISPASR_SOME_OPT \
+    -- ./build/bin/crispasr -m /path/model.gguf --lid-backend off
+
+  # Several gates + a common execution mode
+  tools/asr-env-parity.sh \
+    -n streaming \
+    -E CRISPASR_NEMOTRON_STREAMING=1 \
+    -u CRISPASR_NEMOTRON_GPU_FASTPATH \
+    -e CRISPASR_NEMOTRON_GPU_JOINT \
+    -e CRISPASR_NEMOTRON_GPU_DIRECT_CONV \
+    -e CRISPASR_NEMOTRON_GPU_STREAM_CACHE \
+    -e CRISPASR_NEMOTRON_GPU_PROMPT \
+    -- ./build-vulkan/bin/crispasr \
+       --gpu-backend vulkan -dev 0 --lid-backend off -m /path/model.gguf
+
+  # Same harness with another ASR backend (Parakeet example):
+  # compare its default streamed path against forced single-pass encoding.
+  tools/asr-env-parity.sh \
+    -e CRISPASR_PARAKEET_STREAM_THRESHOLD=999 \
+    -- ./build-vulkan/bin/crispasr \
+       --backend parakeet -m /path/parakeet.gguf -l en
+USAGE
+}
+
+die() {
+  printf 'ERROR: %s\n' "$*" >&2
+  exit 2
+}
+
+valid_name() {
+  [[ "$1" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]
+}
+
+# Normalize NAME -> NAME=1; preserve NAME=VALUE exactly.
+normalize_spec() {
+  local spec=$1 name
+  if [[ "$spec" == *=* ]]; then
+    name=${spec%%=*}
+  else
+    name=$spec
+    spec="$spec=1"
+  fi
+  valid_name "$name" || die "invalid environment variable name in spec: $1"
+  NORMALIZED_SPEC=$spec
+}
+
+spec_name() {
+  printf '%s' "${1%%=*}"
+}
+
+safe_name() {
+  printf '%s' "$1" | sed 's/[^A-Za-z0-9._-]/_/g'
+}
+
+variant_label() {
+  local spec=$1 name value
+  name=$(spec_name "$spec")
+  value=${spec#*=}
+  if [[ "$value" == "1" ]]; then
+    printf '%s' "$name"
+  else
+    printf '%s=%s' "$name" "$value"
+  fi
+}
+
+transcribe_seconds() {
+  local log=$1
+  sed -n 's/.*transcribed .* audio in \([0-9][0-9.]*\)s.*/\1/p' "$log" | tail -n 1
+}
+
+shell_join() {
+  local out=() x
+  for x in "$@"; do
+    printf -v x '%q' "$x"
+    out+=("$x")
+  done
+  local IFS=' '
+  printf '%s' "${out[*]}"
+}
+
+while (($#)); do
+  case "$1" in
+    -s|--samples)
+      (($# >= 2)) || die "$1 needs a value"
+      SAMPLES=$2; shift 2 ;;
+    -p|--pattern)
+      (($# >= 2)) || die "$1 needs a value"
+      PATTERN=$2; shift 2 ;;
+    -o|--out)
+      (($# >= 2)) || die "$1 needs a value"
+      OUT=$2; shift 2 ;;
+    -n|--name)
+      (($# >= 2)) || die "$1 needs a value"
+      RUN_LABEL=$2; shift 2 ;;
+    -e|--env)
+      (($# >= 2)) || die "$1 needs a value"
+      normalize_spec "$2"
+      TEST_ENVS+=("$NORMALIZED_SPEC"); shift 2 ;;
+    -E|--base-env)
+      (($# >= 2)) || die "$1 needs a value"
+      normalize_spec "$2"
+      BASE_ENVS+=("$NORMALIZED_SPEC"); shift 2 ;;
+    -u|--unset)
+      (($# >= 2)) || die "$1 needs a value"
+      valid_name "$2" || die "invalid environment variable name: $2"
+      UNSET_ENVS+=("$2"); shift 2 ;;
+    --fail-fast)
+      FAIL_FAST=1; shift ;;
+    -h|--help)
+      usage; exit 0 ;;
+    --)
+      shift
+      CMD=("$@")
+      break ;;
+    -*)
+      die "unknown harness option: $1 (CrispASR args belong after --)" ;;
+    *)
+      die "unexpected argument before --: $1" ;;
+  esac
+done
+
+[[ -d "$SAMPLES" ]] || die "samples directory not found: $SAMPLES"
+((${#TEST_ENVS[@]} > 0)) || die "at least one -e/--env is required"
+((${#CMD[@]} > 0)) || die "missing CrispASR command after --"
+[[ -x "${CMD[0]}" ]] || die "CrispASR command is not executable: ${CMD[0]}"
+
+# A test variable must represent one baseline-vs-variant dimension. Repeating
+# the same name (possibly with different values) makes the aggregate "all"
+# variant order-dependent, and using the same name as a base env means it is
+# already enabled in the baseline. Reject both cases.
+declare -A TEST_NAMES=()
+for spec in "${TEST_ENVS[@]}"; do
+  name=$(spec_name "$spec")
+  [[ -z ${TEST_NAMES[$name]+x} ]] || die "duplicate test env name: $name"
+  TEST_NAMES[$name]=1
+done
+for spec in "${BASE_ENVS[@]}"; do
+  name=$(spec_name "$spec")
+  [[ -z ${TEST_NAMES[$name]+x} ]] || die "env cannot be both --base-env and --env: $name"
+done
+
+# Avoid ambiguous double input selection. Exact parsing of every CrispASR alias
+# is deliberately out of scope; catch the common forms.
+for arg in "${CMD[@]:1}"; do
+  case "$arg" in
+    -f|--file|--file=*) die "do not pass $arg after --; the harness supplies -f <audio>" ;;
+  esac
+done
+
+if [[ -z "$OUT" ]]; then
+  OUT="/tmp/asr-env-parity-$$"
+fi
+mkdir -p "$OUT"
+
+FILES=()
+while IFS= read -r -d '' f; do
+  FILES+=("$f")
+done < <(find "$SAMPLES" -maxdepth 1 -type f -name "$PATTERN" -print0 | sort -z)
+((${#FILES[@]} > 0)) || die "no files matching '$PATTERN' in $SAMPLES"
+
+# Width for human-readable per-file output. Compute it from the actual variant
+# labels so long ENV=VALUE names never run into the status column.
+LABEL_WIDTH=${#RUN_LABEL}
+(( LABEL_WIDTH < 8 )) && LABEL_WIDTH=8
+for spec in "${TEST_ENVS[@]}"; do
+  label=$(variant_label "$spec")
+  ((${#label} > LABEL_WIDTH)) && LABEL_WIDTH=${#label}
+done
+if ((${#TEST_ENVS[@]} > 1)) && (( LABEL_WIDTH < 3 )); then
+  LABEL_WIDTH=3
+fi
+
+# Build a deduplicated unset list. Every tested gate is scrubbed from the
+# caller environment before baseline and each variant. Explicit -u entries are
+# for aggregate/related controls that the generic harness cannot know about.
+ALL_UNSETS=()
+declare -A SEEN_UNSET=()
+for spec in "${TEST_ENVS[@]}"; do
+  name=$(spec_name "$spec")
+  if [[ -z ${SEEN_UNSET[$name]+x} ]]; then
+    ALL_UNSETS+=("$name")
+    SEEN_UNSET[$name]=1
+  fi
+done
+for name in "${UNSET_ENVS[@]}"; do
+  if [[ -z ${SEEN_UNSET[$name]+x} ]]; then
+    ALL_UNSETS+=("$name")
+    SEEN_UNSET[$name]=1
+  fi
+done
+
+{
+  printf 'profile=%s\n' "$RUN_LABEL"
+  printf 'samples=%s\n' "$SAMPLES"
+  printf 'pattern=%s\n' "$PATTERN"
+  printf 'file_count=%d\n' "${#FILES[@]}"
+  printf 'command='; shell_join "${CMD[@]}"; printf '\n'
+  printf 'test_envs='; shell_join "${TEST_ENVS[@]}"; printf '\n'
+  printf 'base_envs='; shell_join "${BASE_ENVS[@]}"; printf '\n'
+  printf 'unset_envs='; shell_join "${ALL_UNSETS[@]}"; printf '\n'
+  printf 'cli_version='; "${CMD[0]}" --version 2>&1 | head -n 1 || true
+} > "$OUT/meta.txt"
+
+pass_count=0
+fail_count=0
+error_count=0
+
+RUN_RC=0
+RUN_STDOUT=""
+RUN_STDERR=""
+RUN_TSEC="-"
+
+run_one() {
+  local audio=$1 variant=$2
+  shift 2
+  local variant_envs=("$@")
+  local sample_name variant_safe dir stdout stderr rc tsec
+
+  sample_name=$(safe_name "$(basename "$audio")")
+  variant_safe=$(safe_name "$variant")
+  dir="$OUT/$sample_name"
+  mkdir -p "$dir"
+  stdout="$dir/$variant_safe.stdout"
+  stderr="$dir/$variant_safe.stderr"
+
+  local env_cmd=(env)
+  local name
+  for name in "${ALL_UNSETS[@]}"; do
+    env_cmd+=(-u "$name")
+  done
+  env_cmd+=("${BASE_ENVS[@]}")
+  env_cmd+=("${variant_envs[@]}")
+
+  if "${env_cmd[@]}" "${CMD[@]}" -f "$audio" >"$stdout" 2>"$stderr"; then
+    rc=0
+  else
+    rc=$?
+  fi
+
+  tsec=$(transcribe_seconds "$stderr")
+
+  RUN_RC=$rc
+  RUN_STDOUT=$stdout
+  RUN_STDERR=$stderr
+  RUN_TSEC=${tsec:--}
+}
+
+for audio in "${FILES[@]}"; do
+  sample=$(basename "$audio")
+  printf '\n[%s] %s\n' "$RUN_LABEL" "$sample"
+
+  run_one "$audio" baseline
+  if ((RUN_RC != 0)); then
+    printf '  %-*s  %-5s  rc=%d  log=%s\n' "$LABEL_WIDTH" baseline ERROR "$RUN_RC" "$RUN_STDERR"
+    ((error_count++))
+    if ((FAIL_FAST)); then exit 1; fi
+    continue
+  fi
+
+  baseline_stdout=$RUN_STDOUT
+  printf '  %-*s  %-5s  transcribe=%ss\n' "$LABEL_WIDTH" baseline REF "$RUN_TSEC"
+
+  for spec in "${TEST_ENVS[@]}"; do
+    label=$(variant_label "$spec")
+    run_one "$audio" "$label" "$spec"
+
+    if ((RUN_RC != 0)); then
+      status=ERROR
+      diff_path=-
+      ((error_count++))
+      printf '  %-*s  %-5s  rc=%d  log=%s\n' "$LABEL_WIDTH" "$label" ERROR "$RUN_RC" "$RUN_STDERR"
+    elif cmp -s "$baseline_stdout" "$RUN_STDOUT"; then
+      status=PASS
+      diff_path=-
+      ((pass_count++))
+      printf '  %-*s  %-5s  transcribe=%ss\n' "$LABEL_WIDTH" "$label" PASS "$RUN_TSEC"
+    else
+      status=FAIL
+      diff_path="${RUN_STDOUT%.stdout}.diff"
+      ((fail_count++))
+      diff -u "$baseline_stdout" "$RUN_STDOUT" > "$diff_path" || true
+      printf '  %-*s  %-5s  transcribe=%ss  diff=%s\n' "$LABEL_WIDTH" "$label" FAIL "$RUN_TSEC" "$diff_path"
+    fi
+
+    if ((FAIL_FAST)) && [[ "$status" != PASS ]]; then exit 1; fi
+  done
+
+  # The aggregate "all" case is meaningful only when there are multiple
+  # independent test dimensions. With a single -e it would duplicate that
+  # variant exactly and waste time.
+  if ((${#TEST_ENVS[@]} > 1)); then
+    run_one "$audio" all "${TEST_ENVS[@]}"
+    if ((RUN_RC != 0)); then
+      status=ERROR
+      diff_path=-
+      ((error_count++))
+      printf '  %-*s  %-5s  rc=%d  log=%s\n' "$LABEL_WIDTH" all ERROR "$RUN_RC" "$RUN_STDERR"
+    elif cmp -s "$baseline_stdout" "$RUN_STDOUT"; then
+      status=PASS
+      diff_path=-
+      ((pass_count++))
+      printf '  %-*s  %-5s  transcribe=%ss\n' "$LABEL_WIDTH" all PASS "$RUN_TSEC"
+    else
+      status=FAIL
+      diff_path="${RUN_STDOUT%.stdout}.diff"
+      ((fail_count++))
+      diff -u "$baseline_stdout" "$RUN_STDOUT" > "$diff_path" || true
+      printf '  %-*s  %-5s  transcribe=%ss  diff=%s\n' "$LABEL_WIDTH" all FAIL "$RUN_TSEC" "$diff_path"
+    fi
+    if ((FAIL_FAST)) && [[ "$status" != PASS ]]; then exit 1; fi
+  fi
+done
+
+printf '\nParity variants: PASS=%d FAIL=%d ERROR=%d\n' "$pass_count" "$fail_count" "$error_count"
+printf 'Results: %s\n' "$OUT"
+
+if ((fail_count > 0 || error_count > 0)); then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Add `tools/asr-env-parity.sh`, a generic command-line harness for testing transcript parity across environment-gated ASR changes.

The harness is backend-agnostic. Everything after `--` is passed directly to the CrispASR CLI, while the harness adds `-f <sample>` for each matching audio file. By default, it tests all `*.wav` files in the `samples/` directory. 

It supports:

* `-e ENV[=VALUE]` for repeatable test variants
* `-E ENV[=VALUE]` for fixed environment settings applied to every run
* `-u ENV` for variables that must be absent from every run
* automatic scrubbing of all `-e` variables before baseline and variant runs
* an `all` variant when more than one test environment variable is provided
* exact stdout parity checking against the baseline
* transcription timing
* saved stdout/stderr and unified diffs for failures

A non-matching transcript is reported as `FAIL`, while a failed CrispASR process is reported as `ERROR`.

## Motivation

This came out of follow-up validation for #424.

Environment-gated optimizations are useful for A/B testing, but manually running a baseline, each individual gate, and their combination across several samples is error-prone. A small generic harness makes that validation reusable across ASR backends instead of adding backend-specific test scripts.

## Validation

### Parakeet

Tested `CRISPASR_PARAKEET_STREAM_THRESHOLD=999` with four repository samples.

Result: `PASS=4 FAIL=0 ERROR=0`

### Nemotron one-shot

Tested the four GPU optimization gates introduced around #424 individually and together:

* `CRISPASR_NEMOTRON_GPU_JOINT`
* `CRISPASR_NEMOTRON_GPU_DIRECT_CONV`
* `CRISPASR_NEMOTRON_GPU_STREAM_CACHE`
* `CRISPASR_NEMOTRON_GPU_PROMPT`

Example:
```
tools/asr-env-parity.sh \
  -n one-shot \
  -o /tmp/nemotron-424-one-shot \
  -u CRISPASR_NEMOTRON_GPU_FASTPATH \
  -u CRISPASR_NEMOTRON_STREAMING \
  -e CRISPASR_NEMOTRON_GPU_JOINT \
  -e CRISPASR_NEMOTRON_GPU_DIRECT_CONV \
  -e CRISPASR_NEMOTRON_GPU_STREAM_CACHE \
  -e CRISPASR_NEMOTRON_GPU_PROMPT \
  -- ./build-vulkan/bin/crispasr \
     --gpu-backend vulkan \
     --lid-backend off \
     -m "$MODEL"

[one-shot] jfk.wav
  baseline                            REF    transcribe=1.19s
  CRISPASR_NEMOTRON_GPU_JOINT         PASS   transcribe=1.14s
  CRISPASR_NEMOTRON_GPU_DIRECT_CONV   PASS   transcribe=1.16s
  CRISPASR_NEMOTRON_GPU_STREAM_CACHE  PASS   transcribe=1.18s
  CRISPASR_NEMOTRON_GPU_PROMPT        PASS   transcribe=0.82s
  all                                 PASS   transcribe=0.73s

[one-shot] ko-369.wav
  baseline                            REF    transcribe=0.51s
  CRISPASR_NEMOTRON_GPU_JOINT         PASS   transcribe=0.51s
  CRISPASR_NEMOTRON_GPU_DIRECT_CONV   PASS   transcribe=0.50s
  CRISPASR_NEMOTRON_GPU_STREAM_CACHE  PASS   transcribe=0.51s
  CRISPASR_NEMOTRON_GPU_PROMPT        PASS   transcribe=0.41s
  all                                 PASS   transcribe=0.38s

[one-shot] multispeaker.wav
  baseline                            REF    transcribe=3.31s
  CRISPASR_NEMOTRON_GPU_JOINT         PASS   transcribe=3.18s
  CRISPASR_NEMOTRON_GPU_DIRECT_CONV   PASS   transcribe=3.28s
  CRISPASR_NEMOTRON_GPU_STREAM_CACHE  PASS   transcribe=3.33s
  CRISPASR_NEMOTRON_GPU_PROMPT        PASS   transcribe=2.07s
  all                                 PASS   transcribe=1.72s

[one-shot] paraformer_zh.wav
  baseline                            REF    transcribe=1.36s
  CRISPASR_NEMOTRON_GPU_JOINT         PASS   transcribe=1.29s
  CRISPASR_NEMOTRON_GPU_DIRECT_CONV   PASS   transcribe=1.32s
  CRISPASR_NEMOTRON_GPU_STREAM_CACHE  PASS   transcribe=1.35s
  CRISPASR_NEMOTRON_GPU_PROMPT        PASS   transcribe=0.91s
  all                                 PASS   transcribe=0.80s

Parity variants: PASS=20 FAIL=0 ERROR=0
Results: /tmp/nemotron-424-one-shot
```

### Nemotron chunked streaming

With `CRISPASR_NEMOTRON_STREAMING=1`:

Result: `PASS=16 FAIL=4 ERROR=0`

The failures were isolated to `CRISPASR_NEMOTRON_GPU_DIRECT_CONV` on `jfk.wav` and `multispeaker.wav`, plus the corresponding `all` runs.

The other individual optimization gates remained transcript-identical to baseline.

This is also a useful example of the harness catching a real numerical parity difference rather than only exercising successful paths.

The `CRISPASR_NEMOTRON_STREAMING=1` tests cover the one-shot chunked streaming path. Persistent `nemotron_stream` sessions still use the existing general streaming path and host-resident caches, as noted in #424. Moving persistent streaming state on-device is another optimization opportunity.

## AI assistance

The harness design and implementation were developed interactively with ChatGPT.
